### PR TITLE
Update img2img.py

### DIFF
--- a/wx/tools/img2img.py
+++ b/wx/tools/img2img.py
@@ -21,11 +21,7 @@ import  sys
 import  wx
 
 def convert(file, maskClr, outputDir, outputName, outType, outExt):
-    if os.path.splitext(file)[1].lower() == ".ico":
-        icon = wx.Icon(file, wx.BITMAP_TYPE_ICO)
-        img = wx.BitmapFromIcon(icon)
-    else:
-        img = wx.Bitmap(file, wx.BITMAP_TYPE_ANY)
+    img = wx.Bitmap(file, wx.BITMAP_TYPE_ANY)
 
     if not img.IsOk():
         return 0, file + " failed to load!"


### PR DESCRIPTION
Get rid of obsolete call to wx.BitmapFromIcon when converting '.ico' file  ( per http://wxpython.org/Phoenix/docs/html/classic_vs_phoenix.html )