### PR TITLE
Fix syntax error on build.py --python parameter evaluation

### DIFF
--- a/build.py
+++ b/build.py
@@ -210,7 +210,7 @@ def setPythonVersion(args):
             else:
                 PYTHON = args[idx+1]
                 del args[idx:idx+2]
-            PYVER = runcmd('"%s" -c "import sys; print(sys.version[:3]"' % PYTHON,
+            PYVER = runcmd('"%s" -c "import sys; print(sys.version[:3])"' % PYTHON,
                            getOutput=True, echoCmd=False)
             PYSHORTVER = PYVER[0] + PYVER[2]
             break


### PR DESCRIPTION
It is missing a parenthesis that causes a syntaxis error when trying to build with other interpreter::

    reingart@s5ultra:~/src/wxPython_Phoenix-trunk$ python build.py --python=/usr/bin/python3
    Command '"/usr/bin/python3" -c "import sys; print(sys.version[:3]"' failed with exit code 1.
      File "<string>", line 1
        import sys; print(sys.version[:3]
                                        ^
    SyntaxError: unexpected EOF while parsing

