### PR TITLE
Build patch

### DIFF
--- a/TODO.txt
+++ b/TODO.txt
@@ -1,3 +1,5 @@
+KILL THAT LINE
+
 Phoenix TODO List
 =================
 

--- a/TODO.txt
+++ b/TODO.txt
@@ -1,5 +1,3 @@
-KILL THAT LINE
-
 Phoenix TODO List
 =================
 

--- a/build.py
+++ b/build.py
@@ -466,9 +466,17 @@ def getTool(cmdName, version, MD5, envVar, platformBinary):
     # checked with an MD5 hash.
     if os.environ.get(envVar):
         # Setting a a value in the environment overrides other options
+        print('INFO: Using local "{}".'.format(cmdName))
+        print('      {}={}'.format(envVar, os.environ.get(envVar)))
         return os.environ.get(envVar)
     else:
         if platformBinary:
+            # If doxygen for 32bit is requested print an error and exit.
+            # Because it is not available at the download location.
+            if cmdName is 'doxygen' and PYTHON_ARCH is not '64bit':
+                print('ERROR: This plattform architecture is %s. But %s is available only for 64bit.' % (PYTHON_ARCH, cmdName))
+                print('       Set the enviroment variable %s to use a local build of %s instead' % (envVar, cmdName))
+                sys.exit(1)
             platform = 'linux' if sys.platform.startswith('linux') else sys.platform
             ext = ''
             if platform == 'win32':
@@ -486,7 +494,7 @@ def getTool(cmdName, version, MD5, envVar, platformBinary):
             if m.hexdigest() != md5:
                 print('ERROR: MD5 mismatch, got "%s"' % m.hexdigest())
                 print('       expected          "%s"' % md5)
-                print('       Set %s in the environment to use a local build of %s instead' % (envVar, cmdName))
+                print('       Set the enviroment variable %s to use a local build of %s instead' % (envVar, cmdName))
                 sys.exit(1)
             return cmd
             
@@ -499,7 +507,7 @@ def getTool(cmdName, version, MD5, envVar, platformBinary):
             msg('Data downloaded...')
         except Exception:
             print('ERROR: Unable to download ' + url)
-            print('       Set %s in the environment to use a local build of %s instead' % (envVar, cmdName))
+            print('       Set the enviroment variable %s to use a local build of %s instead' % (envVar, cmdName))
             import traceback
             traceback.print_exc()
             sys.exit(1)

--- a/etgtools/sphinx_generator.py
+++ b/etgtools/sphinx_generator.py
@@ -24,12 +24,9 @@ import textwrap
 import glob
 
 if sys.version_info < (3, ):
-
     from StringIO import StringIO
     string_base = basestring
-
 else:
-    
     from io import StringIO
     string_base = str
     
@@ -1959,7 +1956,7 @@ class XMLDocString(object):
         else:
             raise Exception('Unhandled docstring kind for %s'%xml_item.__class__.__name__)
 
-        if hasattr(xml_item, 'deprecated') and xml_item.deprecated and isinstance(xml_item.deprecated, basestring):
+        if hasattr(xml_item, 'deprecated') and xml_item.deprecated and isinstance(xml_item.deprecated, string_base):
             element = et.Element('deprecated', kind='deprecated')
             element.text = VERSION
             
@@ -2609,7 +2606,7 @@ class XMLDocString(object):
 
         if hasattr(method, 'deprecated') and method.deprecated:
             text = method.deprecated
-            if isinstance(text, basestring):
+            if isinstance(text, string_base):
                 text = '%s %s\n%s%s\n\n'%('      .. deprecated::', VERSION, ' '*9, text.replace('\n', ' '))
                 stream.write(text)
 

--- a/sphinxtools/inheritance.py
+++ b/sphinxtools/inheritance.py
@@ -116,8 +116,8 @@ class InheritanceDiagram(object):
         'shape': 'box',
         'fontsize': 10,
         'height': 0.3,
-        'fontname': 'Vera Sans, DejaVu Sans, Liberation Sans, '
-                    'Arial, Helvetica, sans',
+        'fontname': '"Vera Sans, DejaVu Sans, Liberation Sans, '
+                    'Arial, Helvetica, sans"',
         'style': '"setlinewidth(0.5)"',
     }
     default_edge_attrs = {
@@ -142,10 +142,10 @@ class InheritanceDiagram(object):
         """
 
         inheritance_graph_attrs = dict(fontsize=9, ratio='auto', size='""', rankdir="TB")
-        inheritance_node_attrs = {"align": "center", 'shape': 'box',
+        inheritance_node_attrs = {'align': 'center', 'shape': 'box',
                                   'fontsize': 10, 'height': 0.3,
-                                  'fontname': 'Vera Sans, DejaVu Sans, Liberation Sans, '
-                                  'Arial, Helvetica, sans', 'style': '"setlinewidth(0.5)"',
+                                  'fontname': '"Vera Sans, DejaVu Sans, Liberation Sans, '
+                                  'Arial, Helvetica, sans"', 'style': '"setlinewidth(0.5)"',
                                   'labelloc': 'c', 'fontcolor': 'grey45'}
 
         inheritance_edge_attrs = {'arrowsize': 0.5, 
@@ -182,13 +182,13 @@ class InheritanceDiagram(object):
 
             if class_summary is None:
                 # Phoenix base classes, assume there is always a link
-                this_node_attrs['URL'] = '"%s.html"'%fullname
+                this_node_attrs['URL'] = '"%s.html"' % fullname
             else:
                 if 'wx.' in fullname:
                     fullname = fullname[3:]
                 
                 if fullname in class_summary:
-                    this_node_attrs['URL'] = '"%s.html"'%fullname
+                    this_node_attrs['URL'] = '"%s.html"' % fullname
                 else:
                     full_page = FormatExternalLink(fullname, inheritance=True)
                     if full_page:
@@ -270,7 +270,6 @@ class InheritanceDiagram(object):
         dot_args.extend(['-Tcmapx', '-o' + mapfile])
 
         try:
-
             p = Popen(dot_args, stdout=PIPE, stdin=PIPE, stderr=PIPE)
 
         except OSError as err:
@@ -278,13 +277,13 @@ class InheritanceDiagram(object):
             if err.errno != ENOENT:   # No such file or directory
                 raise
 
-            print('\nERROR: Graphviz command `dot` cannot be run (needed for Graphviz output), check your ``PATH`` setting')
+            print('\nERROR: Graphviz command `dot` cannot be run (needed for Graphviz output), check \
+                    if `Graphiz` is present on your system and check your ``PATH`` setting')
 
         try:
             # Graphviz may close standard input when an error occurs,
             # resulting in a broken pipe on communicate()
             stdout, stderr = p.communicate(code)
-
         except OSError as err:
 
             # in this case, read the standard output and standard error streams

--- a/sphinxtools/librarydescription.py
+++ b/sphinxtools/librarydescription.py
@@ -2,25 +2,30 @@ import sys
 import os
 import operator
 import re
+from .utilities import IsPython3
 
-if sys.version_info < (3,):
-    import cPickle as pickle
-    from StringIO import StringIO
-else:
+if IsPython3():
     import pickle
     from io import StringIO
+else:
+    import cPickle as pickle
+    from StringIO import StringIO
 
 from inspect import getmro, getclasstree, getdoc, getcomments
 
 from .utilities import MakeSummary, ChopDescription, WriteSphinxOutput
-from .utilities import FindControlImages, FormatExternalLink, IsPython3
+from .utilities import FindControlImages, FormatExternalLink
 from .constants import object_types, MODULE_TO_ICON, DOXY_2_REST, SPHINXROOT
 from . import templates
 
 EPYDOC_PATTERN = re.compile(r'\S+{\S+}', re.DOTALL)
 
-reload(sys)
-sys.setdefaultencoding('utf-8')
+# on Python3 'utf-8' still is the default
+# and an sys.setdefaultencoding doesn't exists there
+# even not using reload() function that moved to the imp module
+if IsPython3() is False:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 
 
 def make_class_tree(tree):

--- a/sphinxtools/modulehunter.py
+++ b/sphinxtools/modulehunter.py
@@ -11,17 +11,17 @@ import types
 import imp
 import traceback
 import pkgutil
+from .utilities import IsPython3
 
-import __builtin__
-
-if sys.version_info < (3,):
-    import cPickle as pickle
-else:
+if IsPython3():
     import pickle
+else:
+    import cPickle as pickle
+    import __builtin__
 
 from buildtools.config import phoenixDir
 
-from inspect import getargspec, ismodule, getdoc, getmodule, getcomments, isfunction
+from inspect import getargspec, getfullargspec, ismodule, getdoc, getmodule, getcomments, isfunction
 from inspect import ismethoddescriptor, getsource, ismemberdescriptor, isgetsetdescriptor
 from inspect import isbuiltin, isclass, getfile, ismethod
 
@@ -30,12 +30,13 @@ from .librarydescription import Method, Property, Attribute
 
 from . import inheritance
 
-from .utilities import IsPython3
 from .constants import object_types, EXCLUDED_ATTRS, MODULE_TO_ICON
 from .constants import CONSTANT_RE
 
-reload(sys)
-sys.setdefaultencoding('utf-8')
+# see my comments in librarydescripton.py for details
+if IsPython3() is False:
+    reload(sys)
+    sys.setdefaultencoding('utf-8')
 
 try:
     import wx
@@ -126,7 +127,10 @@ def analyze_params(obj, signature):
         return signature, param_tuple
 
     try:
-        arginfo = getargspec(obj)
+        if IsPython3() is False:
+            arginfo = getargspec(obj)
+        else:
+            arginfo = getfullargspec(obj)
     except TypeError:
         arginfo = None
 
@@ -295,7 +299,7 @@ def describe_func(obj, parent_class, module_name):
                 code = obj.im_func.func_code
         else:
             if IsPython3():
-                obj.__code__
+                code = obj.__code__
             else:
                 code = obj.func_code
     except AttributeError:

--- a/sphinxtools/utilities.py
+++ b/sphinxtools/utilities.py
@@ -299,7 +299,7 @@ def PythonizeType(ptype, is_param):
 
     else:
         if is_param and '.' in ptype:
-            modules = MODULENAME_REPLACE.values()
+            modules = list(MODULENAME_REPLACE.values())
             modules.sort()
             modules = modules[1:]
             if ptype.split('.')[0] + '.' in modules:


### PR DESCRIPTION
+ build.py and child-scripts now work better with Python3 (but not all cases tested)
+ BUGFIX: using 64bit-doxygen (form the tools-directory on wxPython.org) on a 32bit-linux now create error messages that make more sense
+ BUGFIX: Graphiz: multible font names need to be surrounded by '"'
- wasn't able to test the script with Python2

btw: This is my first PR ever.