### PR TITLE
Fixes for running on Ubuntu 14.04.2

### DIFF
--- a/build.py
+++ b/build.py
@@ -488,6 +488,13 @@ def getTool(cmdName, version, MD5, envVar, platformBinary):
                 print('       expected          "%s"' % md5)
                 print('       Set %s in the environment to use a local build of %s instead' % (envVar, cmdName))
                 sys.exit(1)
+            try:
+                p = subprocess.Popen([cmd, '--help'], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=os.environ)
+                p.wait()
+            except OSError, e:
+                print('ERROR: Could not execute %s, got "%s"' % (cmd, e))
+                print('       Set %s in the environment to use a local build of %s instead' % (envVar, cmdName))
+                sys.exit(1)
             return cmd
             
         msg('Not found.  Attempting to download...')

--- a/sphinxtools/inheritance.py
+++ b/sphinxtools/inheritance.py
@@ -116,8 +116,8 @@ class InheritanceDiagram(object):
         'shape': 'box',
         'fontsize': 10,
         'height': 0.3,
-        'fontname': 'Vera Sans, DejaVu Sans, Liberation Sans, '
-                    'Arial, Helvetica, sans',
+        'fontname': '"Vera Sans, DejaVu Sans, Liberation Sans, '
+                    'Arial, Helvetica, sans"',
         'style': '"setlinewidth(0.5)"',
     }
     default_edge_attrs = {
@@ -144,8 +144,8 @@ class InheritanceDiagram(object):
         inheritance_graph_attrs = dict(fontsize=9, ratio='auto', size='""', rankdir="TB")
         inheritance_node_attrs = {"align": "center", 'shape': 'box',
                                   'fontsize': 10, 'height': 0.3,
-                                  'fontname': 'Vera Sans, DejaVu Sans, Liberation Sans, '
-                                  'Arial, Helvetica, sans', 'style': '"setlinewidth(0.5)"',
+                                  'fontname': '"Vera Sans, DejaVu Sans, Liberation Sans, '
+                                  'Arial, Helvetica, sans"', 'style': '"setlinewidth(0.5)"',
                                   'labelloc': 'c', 'fontcolor': 'grey45'}
 
         inheritance_edge_attrs = {'arrowsize': 0.5, 


### PR DESCRIPTION
This allows building on Ubuntu 14.04.2 with less headache :)

One commit fixes compatibility with graphviz 2.36.0 (as on Ubuntu 14.04.2) - see [this message](https://groups.google.com/forum/#!topic/wxpython-dev/FdvtlA5Og60) for another user with this problem... Without this patch, `etg` fails with an error message about the `map` file not being present

The other commit checks that the tools downloaded are executable. The downloaded `doxygen-1.8.8-linux` fails to execute on my Ubuntu 14.04.2 x86; this at least tells you about this and how to fix it in advance