### PR TITLE
Implement SetExtraControlCreator for wx.FileDialog

### DIFF
--- a/etg/filedlg.py
+++ b/etg/filedlg.py
@@ -35,13 +35,64 @@ def run():
     isinstance(c, etgtools.ClassDef)
     module.addGlobalStr('wxFileDialogNameStr', c)
     module.find('wxFileSelectorDefaultWildcardStr').ignore()
-    
-    
-    # TODO: add this back. We'll need a way to pass it a callable that can be
-    # called from a C ExtraControlCreatorFunction function
-    c.find('SetExtraControlCreator').ignore()
+
     c.find('ExtraControlCreatorFunction').ignore()
 
+    c.find('SetExtraControlCreator').ignore()
+    c.addHeaderCode("""\
+        wxWindow* _callPythonExtraControlCreator(wxWindow* w)
+        {
+            wxPyThreadBlocker blocker;
+            wxWindow* cw = NULL;
+            PyObject* pyw = sipGetPyObject(w, sipType_wxWindow);
+            PyObject* ccf = PyObject_GetAttrString(pyw, "_wxExtraControlCreatorFunction");
+            if (ccf == NULL)
+                PyErr_SetString(PyExc_RuntimeError,
+                                            "extra control creator function disappeared");
+            else {
+                PyObject* pycw = PyObject_CallFunction(ccf, "O", pyw);
+                if (pycw != Py_None) {
+                    if (!sipCanConvertToType(pycw, sipType_wxWindow, SIP_NOT_NONE))
+                        PyErr_Format(PyExc_ValueError,
+                                            "control creator did not return wxWindow: %R", pycw);
+                    else {
+                        int iserr = 0;
+                        cw = (wxWindow*) sipConvertToType(pycw, sipType_wxWindow, NULL,
+                                                            SIP_NOT_NONE, NULL, &iserr);
+                        if (iserr) {
+                            PyErr_Format(PyExc_ValueError,
+                                            "conversion failure for control creator "
+                                            "return value: %R", pycw);
+                            cw = NULL;
+                        }
+                    }
+                }
+            }
+            return cw;
+        }
+        """)
+    c.addCppMethod('bool', 'SetExtraControlCreator', '(PyObject* ccf)',
+        doc="""\
+        Set extra control creator function to be called during dialog creation""",
+        body="""\
+        bool status = true;
+        {
+        wxPyThreadBlocker blocker;
+        PyObject* pySelf = sipGetPyObject(self, sipType_wxWindow);
+        if (pySelf == NULL) {
+            PyErr_SetString(PyExc_ValueError, "expecting wxWindow object");
+            status = false;
+        }
+        else if (!PyCallable_Check(ccf)) {
+            PyErr_SetString(PyExc_ValueError, "expecting function or callable object");
+            status = false;
+        }
+        else if (PyObject_SetAttrString(pySelf, "_wxExtraControlCreatorFunction", ccf) < 0)
+            status = false;
+        self->SetExtraControlCreator(_callPythonExtraControlCreator);
+        }
+        return status;
+        """)
 
     c.find('GetFilenames').ignore()
     c.addCppMethod('wxArrayString*', 'GetFilenames', '()', doc="""\

--- a/etg/filedlg.py
+++ b/etg/filedlg.py
@@ -51,7 +51,7 @@ def run():
                                             "extra control creator function disappeared");
             else {
                 PyObject* pycw = PyObject_CallFunction(ccf, "O", pyw);
-                if (pycw != Py_None) {
+                if (pycw != NULL && pycw != Py_None) {
                     if (!sipCanConvertToType(pycw, sipType_wxWindow, SIP_NOT_NONE))
                         PyErr_Format(PyExc_ValueError,
                                             "control creator did not return wxWindow: %R", pycw);


### PR DESCRIPTION
The Python callable passed to SetExtraControlCreator is saved as an attribute ("_wxExtraControlCreatorFunction") of the wxWindow wrapper.  This greatly simplifies Python object reference counting but does reserve a special attribute name.  The alternative of implementing reference counting in C is more cumbersome but is a possibility if reserving the attribute name is unacceptable.
