### PR TITLE
Use maxsize instead of maxint

### DIFF
--- a/wx/lib/intctrl.py
+++ b/wx/lib/intctrl.py
@@ -43,7 +43,7 @@ import  wx
 
 #----------------------------------------------------------------------------
 
-from sys import maxint
+from sys import maxsize as maxint
 MAXINT = maxint     # (constants should be in upper case)
 MININT = -maxint-1
 


### PR DESCRIPTION
Python 3 no longer has sys.maxint