### PR TITLE
_msw with Metafile and MetafileDC

### DIFF
--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -789,7 +789,7 @@ def runcmd(cmd, getOutput=False, echoCmd=True, fatal=True):
     if getOutput:
         output = sp.stdout.read()
         if sys.version_info > (3,):
-            output = output.decode('utf-8')  # TODO: is utf-8 okay here?
+            output = output.decode('utf-8', 'ignore')  # TODO: is utf-8 okay here?
         output = output.rstrip()
         
     rval = sp.wait()
@@ -850,6 +850,8 @@ def getVisCVersion():
         return '90'
     if 'Version 16' in text:
         return '100'
+    if 'Version 19' in text:
+        return '140'
     # TODO: Add more tests to get the other versions...
     else:
         return 'FIXME'

--- a/demo/ActiveX_IEHtmlWindow.py
+++ b/demo/ActiveX_IEHtmlWindow.py
@@ -66,7 +66,7 @@ class TestPanel(wx.Panel):
         btnSizer.Add(txt, 0, wx.CENTER|wx.ALL, 2)
 
         self.location = wx.ComboBox(
-                            self, -1, "", style=wx.CB_DROPDOWN|wx.PROCESS_ENTER
+                            self, -1, "", style=wx.CB_DROPDOWN|wx.TE_PROCESS_ENTER
                             )
         
         self.Bind(wx.EVT_COMBOBOX, self.OnLocationSelect, self.location)

--- a/etg/_media.py
+++ b/etg/_media.py
@@ -1,0 +1,76 @@
+#---------------------------------------------------------------------------
+# Name:        etg/_media.py
+# Author:      Dietmar Schwertberger
+#
+# Created:     13-Nov-2015
+# Copyright:   (c) 2015 by Total Control Software
+# License:     wxWindows License
+#---------------------------------------------------------------------------
+
+
+import etgtools
+import etgtools.tweaker_tools as tools
+from etgtools import PyFunctionDef, PyCodeDef, PyPropertyDef
+
+PACKAGE   = "wx" 
+MODULE    = "_media"
+NAME      = "_media"   # Base name of the file to generate to for this script
+DOCSTRING = ""
+
+# The classes and/or the basename of the Doxygen XML files to be processed by
+# this script. 
+ITEMS  = [ ]    
+
+
+
+# The list of other ETG scripts and back-end generator modules that are
+# included as part of this module. These items are in their own etg scripts
+# for easier maintainability, but their class and function definitions are
+# intended to be part of this module, not their own module. This also makes it
+# easier to promote one of these to module status later if desired, simply
+# remove it from this list of Includes, and change the MODULE value in the
+# promoted script to be the same as its NAME.
+
+INCLUDES = [  'mediactrl',
+              #'mediaevent'
+           ]
+
+
+# Separate the list into those that are generated from ETG scripts and the
+# rest. These lists can be used from the build scripts to get a list of
+# sources and/or additional dependencies when building this extension module.
+ETGFILES = ['etg/%s.py' % NAME] + tools.getEtgFiles(INCLUDES)
+DEPENDS = tools.getNonEtgFiles(INCLUDES)
+OTHERDEPS = [ ]
+
+
+#---------------------------------------------------------------------------
+ 
+def run():
+    # Parse the XML file(s) building a collection of Extractor objects
+    module = etgtools.ModuleDef(PACKAGE, MODULE, NAME, DOCSTRING)
+    etgtools.parseDoxyXML(module, ITEMS)
+    module.check4unittest = False
+
+    #-----------------------------------------------------------------
+    # Tweak the parsed meta objects in the module object as needed for
+    # customizing the generated code and docstrings.
+    
+    module.addHeaderCode('#include <wxpy_api.h>')
+    module.addImport('_core')
+    module.addPyCode('import wx', order=10)
+    module.addInclude(INCLUDES)
+ 
+
+    #-----------------------------------------------------------------
+    #-----------------------------------------------------------------
+    tools.doCommonTweaks(module)
+    tools.runGenerators(module)
+    
+    
+
+    
+#---------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    run()

--- a/etg/_msw.py
+++ b/etg/_msw.py
@@ -1,0 +1,77 @@
+#---------------------------------------------------------------------------
+# Name:        etg/_msw.py
+# Author:      Dietmar Schwertberger
+#
+# Created:     13-Nov-2015
+# Copyright:   (c) 2015 by Total Control Software
+# License:     wxWindows License
+#---------------------------------------------------------------------------
+
+import etgtools
+import etgtools.tweaker_tools as tools
+from etgtools import PyFunctionDef, PyCodeDef, PyPropertyDef
+
+PACKAGE   = "wx" 
+MODULE    = "_msw"
+NAME      = "_msw"   # Base name of the file to generate to for this script
+DOCSTRING = ""
+
+# The classes and/or the basename of the Doxygen XML files to be processed by
+# this script. 
+ITEMS  = [ ]    
+
+
+
+# The list of other ETG scripts and back-end generator modules that are
+# included as part of this module. These items are in their own etg scripts
+# for easier maintainability, but their class and function definitions are
+# intended to be part of this module, not their own module. This also makes it
+# easier to promote one of these to module status later if desired, simply
+# remove it from this list of Includes, and change the MODULE value in the
+# promoted script to be the same as its NAME.
+
+INCLUDES = [  'dcmetafile',
+              'metafile',
+              #'pyaxbase',
+              #'activex'
+           ]
+
+
+# Separate the list into those that are generated from ETG scripts and the
+# rest. These lists can be used from the build scripts to get a list of
+# sources and/or additional dependencies when building this extension module.
+ETGFILES = ['etg/%s.py' % NAME] + tools.getEtgFiles(INCLUDES)
+DEPENDS = tools.getNonEtgFiles(INCLUDES)
+OTHERDEPS = [ ]
+
+
+#---------------------------------------------------------------------------
+ 
+def run():
+    # Parse the XML file(s) building a collection of Extractor objects
+    module = etgtools.ModuleDef(PACKAGE, MODULE, NAME, DOCSTRING)
+    etgtools.parseDoxyXML(module, ITEMS)
+    module.check4unittest = False
+
+    #-----------------------------------------------------------------
+    # Tweak the parsed meta objects in the module object as needed for
+    # customizing the generated code and docstrings.
+    
+    module.addHeaderCode('#include <wxpy_api.h>')
+    module.addImport('_core')
+    module.addPyCode('import wx', order=10)
+    module.addInclude(INCLUDES)
+ 
+
+    #-----------------------------------------------------------------
+    #-----------------------------------------------------------------
+    tools.doCommonTweaks(module)
+    tools.runGenerators(module)
+    
+    
+
+    
+#---------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    run()

--- a/etg/dcmetafile.py
+++ b/etg/dcmetafile.py
@@ -1,0 +1,49 @@
+#---------------------------------------------------------------------------
+# Name:        etg/dcmetafile.py
+# Author:      Robin Dunn
+#              Dietmar Schwertberger
+#
+# Created:     01-Nov-2015
+# Copyright:   (c) 2015 by Total Control Software
+# License:     wxWindows License
+#---------------------------------------------------------------------------
+
+import etgtools
+import etgtools.tweaker_tools as tools
+
+PACKAGE   = "wx"   
+MODULE    = "_core"
+NAME      = "dcmetafile"   # Base name of the file to generate to for this script
+DOCSTRING = ""
+
+# The classes and/or the basename of the Doxygen XML files to be processed by
+# this script. 
+ITEMS  = [ 'wxMetafileDC' ]
+
+#---------------------------------------------------------------------------
+
+def run():
+    # Parse the XML file(s) building a collection of Extractor objects
+    module = etgtools.ModuleDef(PACKAGE, MODULE, NAME, DOCSTRING)
+    etgtools.parseDoxyXML(module, ITEMS)
+    
+    #-----------------------------------------------------------------
+    # Tweak the parsed meta objects in the module object as needed for
+    # customizing the generated code and docstrings.
+    
+    
+    c = module.find('wxMetafileDC')
+    c.addPrivateCopyCtor()
+    for item in module.findAll("wxMakeMetafilePlaceable"):
+        item.ignore() 
+    
+    
+    #-----------------------------------------------------------------
+    tools.doCommonTweaks(module)
+    tools.runGenerators(module)
+    
+    
+#---------------------------------------------------------------------------
+if __name__ == '__main__':
+    run()
+

--- a/etg/dcmetafile.py
+++ b/etg/dcmetafile.py
@@ -34,9 +34,8 @@ def run():
     
     c = module.find('wxMetafileDC')
     c.addPrivateCopyCtor()
-    for item in module.findAll("wxMakeMetafilePlaceable"):
-        item.ignore() 
-    
+    module.find("wxMakeMetafilePlaceable").ignore()
+
     
     #-----------------------------------------------------------------
     tools.doCommonTweaks(module)

--- a/etg/mediactrl.py
+++ b/etg/mediactrl.py
@@ -8,10 +8,6 @@
 # License:     wxWindows License
 #---------------------------------------------------------------------------
 
-import sys
-sys.path.insert(0, r"C:\Program Files (x86)\Wing IDE 5.1" )
-import wingdbstub
-
 
 import etgtools
 import etgtools.tweaker_tools as tools

--- a/etg/mediactrl.py
+++ b/etg/mediactrl.py
@@ -1,0 +1,95 @@
+#---------------------------------------------------------------------------
+# Name:        etg/metafile.py
+# Author:      Robin Dunn
+#              Dietmar Schwertberger
+#
+# Created:     24-Nov-2015
+# Copyright:   (c) 2015 by Wide Open Technologies
+# License:     wxWindows License
+#---------------------------------------------------------------------------
+
+import sys
+sys.path.insert(0, r"C:\Program Files (x86)\Wing IDE 5.1" )
+import wingdbstub
+
+
+import etgtools
+import etgtools.tweaker_tools as tools
+
+PACKAGE   = "wx"
+MODULE    = "_media"
+NAME      = "mediactrl"   # Base name of the file to generate to for this script
+DOCSTRING = ""
+
+# The classes and/or the basename of the Doxygen XML files to be processed by
+# this script. 
+ITEMS  = [ 'wxMediaCtrl',
+           'wxMediaEvent']
+
+
+#---------------------------------------------------------------------------
+
+def run():
+    # Parse the XML file(s) building a collection of Extractor objects
+    module = etgtools.ModuleDef(PACKAGE, MODULE, NAME, DOCSTRING)
+    etgtools.parseDoxyXML(module, ITEMS)
+    module.addHeaderCode('#include "wx/mediactrl.h"')
+    #module.addHeaderCode('#include "wx/mediaevent.h"')
+    
+    #-----------------------------------------------------------------
+    # Tweak the parsed meta objects in the module object as needed for
+    # customizing the generated code and docstrings.
+
+    c = module.find('wxMediaCtrl')
+    c.addPrivateCopyCtor()
+
+    # the C++ class has three overloaded Load(...) methods
+    # for now we ignore all than the first one for loading a filename
+    for item in c.findAll("Load"):
+        if not "fileName" in item.argsString:
+            # ignore e.g. the Load with args '(const wxURI &uri)'
+            # keep e.g. '(const wxString &fileName)'
+            item.ignore()
+
+
+    # this is from old SWIG, do we still need it?
+    #%pythoncode { LoadFromURI = LoadURI }
+
+
+    c = module.find('wxMediaEvent')
+    tools.fixEventClass(c)
+
+    c.addPyCode("""\
+                EVT_MEDIA_LOADED = wx.PyEventBinder( wxEVT_MEDIA_LOADED )
+                EVT_MEDIA_STOP = wx.PyEventBinder( wxEVT_MEDIA_STOP )
+                EVT_MEDIA_FINISHED = wx.PyEventBinder( wxEVT_MEDIA_FINISHED )
+                EVT_MEDIA_STATECHANGED = wx.PyEventBinder( wxEVT_MEDIA_STATECHANGED )
+                EVT_MEDIA_PLAY = wx.PyEventBinder( wxEVT_MEDIA_PLAY )
+                EVT_MEDIA_PAUSE = wx.PyEventBinder( wxEVT_MEDIA_PAUSE )
+                """)
+    # do we need such as well?
+    #    # The same as above but with the ability to specify an identifier
+    #    EVT_GRID_CMD_CELL_LEFT_CLICK =     wx.PyEventBinder( wxEVT_GRID_CELL_LEFT_CLICK,    1 )
+
+    
+    # the following is in mediactrl.h:
+    # #define wxMEDIABACKEND_DIRECTSHOW   wxT("wxAMMediaBackend")
+    # not sure whether there would be a better way than just defining these strings here:
+    module.addPyCode("""\
+                MEDIABACKEND_DIRECTSHOW = "wxAMMediaBackend"
+                MEDIABACKEND_MCI        = "wxMCIMediaBackend"
+                MEDIABACKEND_QUICKTIME  = "wxQTMediaBackend"
+                MEDIABACKEND_GSTREAMER  = "wxGStreamerMediaBackend"
+                MEDIABACKEND_REALPLAYER = "wxRealPlayerMediaBackend"
+                MEDIABACKEND_WMP10      = "wxWMP10MediaBackend"
+                """)
+
+    #-----------------------------------------------------------------
+    tools.doCommonTweaks(module)
+    tools.runGenerators(module)
+
+
+#---------------------------------------------------------------------------
+if __name__ == '__main__':
+    run()
+

--- a/etg/metafile.py
+++ b/etg/metafile.py
@@ -1,0 +1,49 @@
+#---------------------------------------------------------------------------
+# Name:        etg/metafile.py
+# Author:      Robin Dunn
+#             Dietmar Schwertberger
+#
+# Created:     01-Nov-2015
+# Copyright:   (c) 2015 by Wide Open Technologies
+# License:     wxWindows License
+#---------------------------------------------------------------------------
+
+import etgtools
+import etgtools.tweaker_tools as tools
+
+PACKAGE   = "wx"
+MODULE    = "_core"
+NAME      = "metafile"   # Base name of the file to generate to for this script
+DOCSTRING = ""
+
+# The classes and/or the basename of the Doxygen XML files to be processed by
+# this script. 
+ITEMS  = [ 'wxMetafile',]
+
+
+#---------------------------------------------------------------------------
+
+def run():
+    # Parse the XML file(s) building a collection of Extractor objects
+    module = etgtools.ModuleDef(PACKAGE, MODULE, NAME, DOCSTRING)
+    etgtools.parseDoxyXML(module, ITEMS)
+    
+    #-----------------------------------------------------------------
+    # Tweak the parsed meta objects in the module object as needed for
+    # customizing the generated code and docstrings.
+
+    c = module.find('wxMetafile')
+    c.addPrivateCopyCtor()
+    for item in module.findAll("wxMakeMetafilePlaceable"):
+        print("MAKE METAFILE PLACEABLE ***************************", item)
+        item.ignore() 
+
+    #-----------------------------------------------------------------
+    tools.doCommonTweaks(module)
+    tools.runGenerators(module)
+    
+    
+#---------------------------------------------------------------------------
+if __name__ == '__main__':
+    run()
+

--- a/etg/metafile.py
+++ b/etg/metafile.py
@@ -34,9 +34,7 @@ def run():
 
     c = module.find('wxMetafile')
     c.addPrivateCopyCtor()
-    for item in module.findAll("wxMakeMetafilePlaceable"):
-        print("MAKE METAFILE PLACEABLE ***************************", item)
-        item.ignore() 
+    module.find("wxMakeMetafilePlaceable").ignore()
 
     #-----------------------------------------------------------------
     tools.doCommonTweaks(module)

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -16,6 +16,9 @@ __version__ = wx.__version__.VERSION_STRING
 # package namespace.
 from wx.core import *
 
+if 'wxMSW' in PlatformInfo:
+    from wx._msw import *
+
 
 # Clean up the package namespace
 del core

--- a/unittests/test_dcmetafile.py
+++ b/unittests/test_dcmetafile.py
@@ -1,0 +1,24 @@
+import imp_unittest, unittest
+import wtc
+import wx
+import sys
+import os
+
+fileName = 'metafiletest.emf'
+
+#---------------------------------------------------------------------------
+
+class MetafileDCTests(wtc.WidgetTestCase):
+            
+    def test_MetafileDC1(self):
+        dc = wx.MetafileDC(fileName)
+        dc.DrawLine(0,0, 50,50)
+        del dc
+        
+        os.remove(fileName)
+
+#---------------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wscript
+++ b/wscript
@@ -562,6 +562,15 @@ def build(bld):
     makeExtCopyRule(bld, '_richtext')
 
 
+    if isWindows:
+        etg = loadETG('etg/_msw.py')
+        bld(features = 'c cxx cxxshlib pyext',
+            target   = makeTargetName(bld, '_msw'),
+            source   = getEtgSipCppFiles(etg) + rc,
+            uselib   = 'WX WXPY',
+            )
+        makeExtCopyRule(bld, '_msw')
+
 
     # ** Add code for new modules here
 

--- a/wscript
+++ b/wscript
@@ -134,6 +134,10 @@ def configure(conf):
         _copyEnvGroup(conf.env, '_WX', '_WXRICHTEXT')
         conf.env.LIB_WXRICHTEXT += cfg.makeLibName('richtext')
 
+        _copyEnvGroup(conf.env, '_WX', '_WXMEDIA')
+        conf.env.LIB_WXMEDIA += cfg.makeLibName('media')
+
+
         # ** Add code for new modules here (and below for non-MSW)
 
         # tweak the PYEXT compile and link flags if making a --debug build
@@ -560,6 +564,14 @@ def build(bld):
         uselib   = 'WXHTML WXRICHTEXT WXPY',
         )
     makeExtCopyRule(bld, '_richtext')
+
+    etg = loadETG('etg/_media.py')
+    bld(features = 'c cxx cxxshlib pyext',
+        target   = makeTargetName(bld, '_media'),
+        source   = getEtgSipCppFiles(etg) + rc,
+        uselib   = 'WX WXPY WXMEDIA',
+        )
+    makeExtCopyRule(bld, '_media')
 
 
     if isWindows:

--- a/wscript
+++ b/wscript
@@ -68,12 +68,8 @@ def configure(conf):
         # version. We have a chicken-egg problem here. The compiler needs to
         # be selected before the Python stuff can be configured, but we need
         # Python to know what version of the compiler to use.
-        # TODO: Fix this
-        msvc_version = '9.0' #conf.options.msvc_ver
-        if conf.options.python and ('33' in conf.options.python or
-                                    '34' in conf.options.python):
-            msvc_version = '10.0'
-
+        import distutils.msvc9compiler
+        msvc_version = str( distutils.msvc9compiler.get_build_version() )
         conf.env['MSVC_VERSIONS'] = ['msvc ' + msvc_version]
         conf.env['MSVC_TARGETS'] = [conf.options.msvc_arch]
         conf.load('msvc')
@@ -625,7 +621,8 @@ def copyFileToPkg(task):
     from buildtools.config   import opj
     src = task.inputs[0].abspath() 
     tgt = task.outputs[0].abspath() 
-    task.exec_command('touch %s' % tgt)
+    #task.exec_command('touch %s' % tgt)
+    open(tgt, "wb").close() # 'touch'
     tgt = opj(cfg.PKGDIR, os.path.basename(src))
     copy_file(src, tgt, verbose=1)
     return 0

--- a/wx/lib/activex.py
+++ b/wx/lib/activex.py
@@ -90,7 +90,7 @@ class ActiveXCtrl(wx.PyAxBaseWindow):
         # create the control
         atl.AtlAxWinInit()
         hInstance = kernel32.GetModuleHandleA(None)
-        hwnd = user32.CreateWindowExA(0, "AtlAxWin", axID,
+        hwnd = user32.CreateWindowExA(0, b"AtlAxWin", axID.encode("ASCII"),
                                       WS_CHILD | WS_VISIBLE 
                                       | WS_CLIPCHILDREN | WS_CLIPSIBLINGS,
                                       x,y, w,h, parent.GetHandle(), None, 
@@ -112,10 +112,14 @@ class ActiveXCtrl(wx.PyAxBaseWindow):
         self._evt_connections = []
         self.AddEventSink(self)
         
-        # Turn the window handle into a wx.Window and set this object to be that window
-        win = wx.PyAxBaseWindow_FromHWND(parent, hwnd)
-        self.PostCreate(win)
+        wx.Window.__init__(self, parent, wxid, pos, size, style, name)
         
+        # Turn the window handle into a wx.Window and set this object to be that window
+        #win = wx.PyAxBaseWindow_FromHWND(parent, hwnd)
+        self.AssociateHandle(hwnd)
+
+        #self.PostCreate(win)
+
         # Set some wx.Window properties
         if wxid == wx.ID_ANY: 
             wxid = wx.Window.NewControlId()

--- a/wx/lib/activexwrapper.py
+++ b/wx/lib/activexwrapper.py
@@ -90,8 +90,7 @@ def MakeActiveXClass(CoClass, eventClass=None, eventObj=None):
                   }
 
     # make a new class object
-    import new
-    classObj = new.classobj(className, baseClasses, classDict)
+    classObj = type(className, baseClasses, classDict)
     return classObj
 
 
@@ -103,7 +102,7 @@ def axw__init__(self, parent, ID=-1, pos=wx.DefaultPosition, size=wx.DefaultSize
     # init base classes
     pywin.mfc.activex.Control.__init__(self)
     wx.Window.__init__( self, parent, -1, pos, size, style|wx.NO_FULL_REPAINT_ON_RESIZE)
-    self.this.own(False)  # this should be set in wx.Window.__init__ when it calls _setOORInfo, but...
+    #self.this.own(False)  # this should be set in wx.Window.__init__ when it calls _setOORInfo, but...
         
     win32ui.EnableControlContainer()
     self._eventObj = self._eventObj  # move from class to instance
@@ -126,7 +125,7 @@ def axw__init__(self, parent, ID=-1, pos=wx.DefaultPosition, size=wx.DefaultSize
 def axw__getattr__(self, attr):
     try:
         return pywin.mfc.activex.Control.__getattr__(self, attr)
-    except AttributeError:
+    except (AttributeError, win32ui.error):
         try:
             eo = self.__dict__['_eventObj']
             return getattr(eo, attr)


### PR DESCRIPTION
added a MS Windows specific _msw module with Metafile and MetafileDC
added _media module with MediaCtrl (please note that for MediaCtrl events change 5c1f95bc71028e4562f847af56b815b2f13370a9 from wxWidgets is also required)
added support for Visual Studio 2015 (for Python 3.5, the Community Edition supports both 32 and 64 bit)
modified lib.activex for Phoenix