### PR TITLE
Fix extraction for #define's when not an integer or string

### DIFF
--- a/etg/_stc.py
+++ b/etg/_stc.py
@@ -120,6 +120,9 @@ def run():
             return rv;
             """)
 
+    # Correct the type for this define as its value is outside the range of int
+    module.find('wxSTC_MASK_FOLDERS').type = 'unsigned long'
+
     # TODO:  Add the UTF8 PyMethods from classic (see _stc_utf8_methods.py)
     
 

--- a/etg/defs.py
+++ b/etg/defs.py
@@ -47,6 +47,15 @@ def run():
         module.find('wxIntPtr').type =  'long'                #'ssize_t'
         module.find('wxUIntPtr').type = 'unsigned long'       #'size_t'
         
+    # Correct the types for these as their values are outside the range of int
+    module.find('wxUINT32_MAX').type = 'long'
+    module.find('wxINT64_MIN').type = 'long long'
+    module.find('wxINT64_MAX').type = 'long long'
+    module.find('wxUINT64_MAX').type = 'unsigned long long'
+    module.find('wxCANCEL_DEFAULT').type = 'unsigned long'
+    module.find('wxWINDOW_STYLE_MASK').type = 'unsigned long'
+    module.find('wxVSCROLL').type = 'unsigned long'
+
     module.find('wxInt8').pyInt = True
     module.find('wxUint8').pyInt = True
     module.find('wxByte').pyInt = True

--- a/etg/richtextbuffer.py
+++ b/etg/richtextbuffer.py
@@ -394,7 +394,10 @@ def run():
             m.ignore()
     
 
-    
+
+    # Correct the type for this define as it is a float
+    module.find('wxSCRIPT_MUL_FACTOR').type = 'float'
+
     #-----------------------------------------------------------------
     tools.doCommonTweaks(module)
     tools.runGenerators(module)

--- a/etgtools/sip_generator.py
+++ b/etgtools/sip_generator.py
@@ -268,6 +268,8 @@ from .%s import *
         # so tell sip that's what it is.
         if '"' in define.value:
             stream.write('const char* %s;\n' % define.name)
+        elif hasattr(define, 'type'):
+            stream.write('const %s %s;\n' % (define.type, define.name))
         else:
             stream.write('const int %s;\n' % define.name)
         


### PR DESCRIPTION
Some #define values fall outside the range of int, so we need to override the
types.

(GCC6 refuses to compile the resulting generated code, which is how I noticed this.)