### PR TITLE
Rework fix for #define type extraction

### DIFF
--- a/build.py
+++ b/build.py
@@ -1023,6 +1023,18 @@ def cmd_sip(options, args):
                     # ...or totally remove them by replacing those lines with ''
                     import re
                     srcTxt = re.sub(r'^#line.*\n', '', srcTxt, flags=re.MULTILINE)
+                # Perform a couple of manual modifications to the generated cpp
+                # to fix C++11 compilation errors.
+                if os.path.basename(src) == 'sip_corecmodule.cpp':
+                    srcTxt = srcTxt.replace('wxCANCEL_DEFAULT},',
+                                            'static_cast<int>(wxCANCEL_DEFAULT)},')
+                    srcTxt = srcTxt.replace('wxVSCROLL},',
+                                            'static_cast<int>(wxVSCROLL)},')
+                    srcTxt = srcTxt.replace('wxWINDOW_STYLE_MASK},',
+                                            'static_cast<int>(wxWINDOW_STYLE_MASK)},')
+                if os.path.basename(src) == 'sip_stccmodule.cpp':
+                    srcTxt = srcTxt.replace('wxSTC_MASK_FOLDERS},',
+                                            'static_cast<int>(wxSTC_MASK_FOLDERS)},')
             return srcTxt
         
         # Check each file in tmpdir to see if it is different than the same file

--- a/etg/_stc.py
+++ b/etg/_stc.py
@@ -123,9 +123,6 @@ def run():
             return rv;
             """)
 
-    # Correct the type for this define as its value is outside the range of int
-    module.find('wxSTC_MASK_FOLDERS').type = 'unsigned long'
-
     # TODO:  Add the UTF8 PyMethods from classic (see _stc_utf8_methods.py)
     
 

--- a/etg/defs.py
+++ b/etg/defs.py
@@ -48,13 +48,10 @@ def run():
         module.find('wxUIntPtr').type = 'unsigned long'       #'size_t'
         
     # Correct the types for these as their values are outside the range of int
-    module.find('wxUINT32_MAX').type = 'long'
+    module.find('wxUINT32_MAX').type = 'unsigned long'
     module.find('wxINT64_MIN').type = 'long long'
     module.find('wxINT64_MAX').type = 'long long'
     module.find('wxUINT64_MAX').type = 'unsigned long long'
-    module.find('wxCANCEL_DEFAULT').type = 'unsigned long'
-    module.find('wxWINDOW_STYLE_MASK').type = 'unsigned long'
-    module.find('wxVSCROLL').type = 'unsigned long'
 
     module.find('wxInt8').pyInt = True
     module.find('wxUint8').pyInt = True


### PR DESCRIPTION
A user running 32-bit Windows reported a problem with wx.VSCROLL after my
changes in aa0be27.  It is likely some integer conversion is not happening
correctly between C++ and Python.  To resolve this, convert the #defines that
are using standard WX 32-bit values back to int and instead insert casts into
the SIP generated cpp code to resolve the C++11 compilation errors.