### PR TITLE
Fix crash when calling GetHandle() on unrealized window with wxGTK3

### DIFF
--- a/src/window_ex.cpp
+++ b/src/window_ex.cpp
@@ -7,9 +7,19 @@
 #include <gdk/gdkx.h>
 #include <gtk/gtk.h>
 #ifdef __WXGTK3__
-#define GetXWindow(wxwin) (wxwin)->m_wxwindow ? \
-                          GDK_WINDOW_XID(gtk_widget_get_window((wxwin)->m_wxwindow)) :	\
-                          GDK_WINDOW_XID(gtk_widget_get_window((wxwin)->m_widget))
+// Unlike GDK_WINDOW_XWINDOW, GDK_WINDOW_XID can't handle a NULL, so check 1st
+static XID GetXWindow(const wxWindow* wxwin) {
+    if ((wxwin)->m_wxwindow) {
+        if (gtk_widget_get_window((wxwin)->m_wxwindow))
+            return GDK_WINDOW_XID(gtk_widget_get_window((wxwin)->m_wxwindow));
+        return 0;
+    }
+    else {
+        if (gtk_widget_get_window((wxwin)->m_widget))
+            return GDK_WINDOW_XID(gtk_widget_get_window((wxwin)->m_widget));
+        return 0;
+    }
+}
 #else
 #define GetXWindow(wxwin) (wxwin)->m_wxwindow ? \
                           GDK_WINDOW_XWINDOW((wxwin)->m_wxwindow->window) : \


### PR DESCRIPTION
Unlike GDK_WINDOW_XWINDOW(), GDK_WINDOW_XID() seems unable to handle NULLs,
so check for a NULL first.  This is similar to a patch I submitted for Classic:
http://trac.wxwidgets.org/ticket/16765