### PR TITLE
Correct TextCompleterSimple example

### DIFF
--- a/docs/sphinx/rest_substitutions/snippets/python/converted/TextCompleterSimple.1.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/converted/TextCompleterSimple.1.py
@@ -25,5 +25,5 @@
                     
         # Later on...
         text = wx.TextCtrl(parent, wx.ID_ANY, 'My Text')
-        text.AutoComplete(MyTextCompleter)
+        text.AutoComplete(MyTextCompleter())
 


### PR DESCRIPTION
Need to pass instance of MyTextCompleter, not class itself.