### PR TITLE
Fix throbber test crash on GTK2

### DIFF
--- a/unittests/test_lib_throbber.py
+++ b/unittests/test_lib_throbber.py
@@ -5,9 +5,6 @@ import wx.lib.throbber as th
 
 
 import throbImages
-images = [throbImages.catalog[i].GetBitmap()
-          for i in throbImages.index
-          if i not in ['eclouds', 'logo']]
 
 #---------------------------------------------------------------------------
 
@@ -15,6 +12,9 @@ class lib_throbber_Tests(wtc.WidgetTestCase):
 
     def test_lib_throbber(self):
         pnl = wx.Panel(self.frame)
+        images = [throbImages.catalog[i].GetBitmap()
+                  for i in throbImages.index
+                  if i not in ['eclouds', 'logo']]
         w = th.Throbber(pnl, -1, images, size=(36, 36))
         
     def test_lib_throbber_Events(self):


### PR DESCRIPTION
Move GetBitmap() code into test case so that it is not executed before the
wx.App object is created.