### PR TITLE
Fix wacky ints (mainly for Py2.7 / Win64)

### DIFF
--- a/src/wacky_ints.sip
+++ b/src/wacky_ints.sip
@@ -20,7 +20,7 @@
 %MappedType size_t {
 
     %TypeHeaderCode
-    #include <wx/setup.h>
+    #include <wxpy_api.h>
     %End
 
     %ConvertToTypeCode
@@ -32,20 +32,12 @@
         }
 
         // Do the conversion
-        #if wxSIZE_T_IS_ULONG
-            *sipCppPtr = new size_t(PyLong_AsUnsignedLong(sipPy));
-        #else
-            *sipCppPtr = new size_t(PyLong_AsUnsignedLongLong(sipPy));
-        #endif
+        *sipCppPtr = new size_t(wxPyInt_AsSize_t(sipPy));
         return sipGetState(sipTransferObj);
     %End
 
     %ConvertFromTypeCode
-        #if wxSIZE_T_IS_ULONG
-            return PyLong_FromUnsignedLong(*sipCpp);
-        #else
-            return PyLong_FromUnsignedLongLong(*sipCpp);
-        #endif
+        return wxPyInt_FromSize_t(*sipCpp);
     %End
 };
 
@@ -56,6 +48,7 @@
 
     %TypeHeaderCode
     #include <wx/setup.h>
+    #include <wxpy_api.h>
     %End
 
     %ConvertToTypeCode
@@ -68,18 +61,18 @@
 
         // Do the conversion
         #if SIZEOF_LONG >= SIZEOF_VOID_P
-            *sipCppPtr = new wxIntPtr(PyLong_AsLong(sipPy));
+            *sipCppPtr = new wxIntPtr(wxPyInt_AsLong(sipPy));
         #else
-            *sipCppPtr = new wxIntPtr(PyLong_AsLongLong(sipPy));
+            *sipCppPtr = new wxIntPtr(wxPyInt_AsSsize_t(sipPy));
         #endif
         return sipGetState(sipTransferObj);
     %End
 
     %ConvertFromTypeCode
         #if SIZEOF_LONG >= SIZEOF_VOID_P
-            return PyLong_FromLong(*sipCpp);
+            return wxPyInt_FromLong(*sipCpp);
         #else
-            return PyLong_FromLongLong(*sipCpp);
+            return wxPyInt_FromSsize_t(*sipCpp);
         #endif
     %End
 };
@@ -91,6 +84,7 @@
 
     %TypeHeaderCode
     #include <wx/setup.h>
+    #include <wxpy_api.h>
     %End
 
     %ConvertToTypeCode
@@ -103,18 +97,18 @@
 
         // Do the conversion
         #if SIZEOF_LONG >= SIZEOF_VOID_P
-            *sipCppPtr = new wxUIntPtr(PyLong_AsUnsignedLong(sipPy));
+            *sipCppPtr = new wxUIntPtr(wxPyInt_AsUnsignedLong(sipPy));
         #else
-            *sipCppPtr = new wxUIntPtr(PyLong_AsUnsignedLongLong(sipPy));
+            *sipCppPtr = new wxUIntPtr(wxPyInt_AsSize_t(sipPy));
         #endif
         return sipGetState(sipTransferObj);
     %End
 
     %ConvertFromTypeCode
         #if SIZEOF_LONG >= SIZEOF_VOID_P
-            return PyLong_FromUnsignedLong(*sipCpp);
+            return wxPyInt_FromUnsignedLong(*sipCpp);
         #else
-            return PyLong_FromUnsignedLongLong(*sipCpp);
+            return wxPyInt_FromSize_t(*sipCpp);
         #endif
     %End
 };

--- a/src/wxpy_api.h
+++ b/src/wxpy_api.h
@@ -115,16 +115,24 @@ inline PyObject* wxPyMakeBuffer(void* ptr, Py_ssize_t len, bool readOnly=false) 
     #define wxPyInt_Check       PyLong_Check
     #define wxPyInt_AsLong      PyLong_AsLong
     #define wxPyInt_AS_LONG     PyLong_AS_LONG
+    #define wxPyInt_AsSize_t    PyLong_AsSize_t
     #define wxPyInt_AsSsize_t   PyLong_AsSsize_t
+    #define wxPyInt_AsUnsignedLong PyLong_AsUnsignedLong
     #define wxPyInt_FromLong    PyLong_FromLong
+    #define wxPyInt_FromSize_t  PyLong_FromSize_t
+    #define wxPyInt_FromUnsignedLong PyLong_FromUnsignedLong
     #define wxPyNumber_Int      PyNumber_Long
 #else
     #define wxPyInt_Check       PyInt_Check
     #define wxPyInt_AsLong      PyInt_AsLong
     #define wxPyInt_AS_LONG     PyInt_AS_LONG
     #define wxPyInt_AsLong      PyInt_AsLong
+    #define wxPyInt_AsSize_t(x) static_cast<size_t>(PyInt_AsUnsignedLongLongMask(x))
     #define wxPyInt_AsSsize_t   PyInt_AsSsize_t
+    #define wxPyInt_AsUnsignedLong PyInt_AsUnsignedLongMask
     #define wxPyInt_FromLong    PyInt_FromLong
+    #define wxPyInt_FromSize_t  PyInt_FromSize_t
+    #define wxPyInt_FromUnsignedLong PyInt_FromSize_t
     #define wxPyNumber_Int      PyNumber_Int
 #endif
 


### PR DESCRIPTION
The 'wacky ints' tests were failing on Win64.  It seems that the PyLong_XX
functions don't work correctly there on Py 2.7.  The solution was to switch to
the PyInt_XX functions, which will correctly return a PyLong when necessary.