### PR TITLE
PR45, just a little different.

### DIFF
--- a/build.py
+++ b/build.py
@@ -1023,18 +1023,6 @@ def cmd_sip(options, args):
                     # ...or totally remove them by replacing those lines with ''
                     import re
                     srcTxt = re.sub(r'^#line.*\n', '', srcTxt, flags=re.MULTILINE)
-                # Perform a couple of manual modifications to the generated cpp
-                # to fix C++11 compilation errors.
-                if os.path.basename(src) == 'sip_corecmodule.cpp':
-                    srcTxt = srcTxt.replace('wxCANCEL_DEFAULT},',
-                                            'static_cast<int>(wxCANCEL_DEFAULT)},')
-                    srcTxt = srcTxt.replace('wxVSCROLL},',
-                                            'static_cast<int>(wxVSCROLL)},')
-                    srcTxt = srcTxt.replace('wxWINDOW_STYLE_MASK},',
-                                            'static_cast<int>(wxWINDOW_STYLE_MASK)},')
-                if os.path.basename(src) == 'sip_stccmodule.cpp':
-                    srcTxt = srcTxt.replace('wxSTC_MASK_FOLDERS},',
-                                            'static_cast<int>(wxSTC_MASK_FOLDERS)},')
             return srcTxt
         
         # Check each file in tmpdir to see if it is different than the same file

--- a/etg/_stc.py
+++ b/etg/_stc.py
@@ -123,6 +123,11 @@ def run():
             return rv;
             """)
 
+
+    # Generate the code for this differently because it needs to be
+    # forcibly mashed into an int in the C code
+    module.find('wxSTC_MASK_FOLDERS').forcedInt = True
+
     # TODO:  Add the UTF8 PyMethods from classic (see _stc_utf8_methods.py)
     
 

--- a/etg/defs.py
+++ b/etg/defs.py
@@ -49,6 +49,12 @@ def run():
     module.find('wxINT64_MAX').type = 'long long'
     module.find('wxUINT64_MAX').type = 'unsigned long long'
 
+    # Generate the code for these differently because they need to be
+    # forcibly mashed into an int in the C code
+    module.find('wxCANCEL_DEFAULT').forcedInt = True
+    module.find('wxVSCROLL').forcedInt = True
+    module.find('wxWINDOW_STYLE_MASK').forcedInt = True
+
     module.find('wxInt8').pyInt = True
     module.find('wxUint8').pyInt = True
     module.find('wxByte').pyInt = True

--- a/etgtools/sip_generator.py
+++ b/etgtools/sip_generator.py
@@ -270,6 +270,14 @@ from .%s import *
             stream.write('const char* %s;\n' % define.name)
         elif hasattr(define, 'type'):
             stream.write('const %s %s;\n' % (define.type, define.name))
+        elif getattr(define, 'forcedInt', False):
+            stream.write('%PostInitialisationCode\n')
+            #stream.write('printf("**** %s: %%d\\n", %s);\n' % (define.name, define.name))
+            stream.write(('    PyDict_SetItemString(sipModuleDict, "%s", '
+                          'wxPyInt_FromLong(static_cast<int>(%s)));\n') % 
+                         (define.pyName, define.name))
+            stream.write('%End\n')            
+
         else:
             stream.write('const int %s;\n' % define.name)
         

--- a/unittests/test_defs.py
+++ b/unittests/test_defs.py
@@ -1,0 +1,29 @@
+import imp_unittest, unittest
+import wtc
+import wx
+
+#---------------------------------------------------------------------------
+
+class defs_Tests(wtc.WidgetTestCase):
+
+
+    def test_constants1(self):
+        # These constants are not plain int's
+        self.assertEqual(wx.UINT32_MAX, 2**32-1)
+        self.assertEqual(wx.INT64_MIN, (-9223372036854775807)-1)
+        self.assertEqual(wx.INT64_MAX, 9223372036854775807)
+        self.assertEqual(wx.UINT64_MAX, 0xFFFFFFFFFFFFFFFF)
+        
+    def test_constants2(self):
+        # These constants needed some special tweaking.  Make sure it
+        # was done right.
+        self.assertEqual(wx.VSCROLL, -2147483648)
+        self.assertEqual(wx.CANCEL_DEFAULT, -2147483648)
+        self.assertEqual(wx.WINDOW_STYLE_MASK, -65536)
+
+
+#---------------------------------------------------------------------------
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Starts with PR45 but instead of hacking the generated C++ code after the fact, add the ability to generate the sip code a little differently.  Inject code that explicitly creates the PyObject to be inserted in the module's dictionary and typecasts the value.

Closes #45 and should fix #51 and fix #70.