### PR TITLE
Resolved a few minor issues in demos

### DIFF
--- a/demo/AUI_DockingWindowMgr.py
+++ b/demo/AUI_DockingWindowMgr.py
@@ -3,7 +3,11 @@
 import wx
 import wx.grid
 import wx.html
-import wx.aui
+
+try:
+    from agw import aui
+except ImportError: # if it's not there locally, try the wxPython lib.
+    import wx.lib.agw.aui as aui
 
 from wx.lib.six import BytesIO
 
@@ -76,7 +80,7 @@ class PyAUIFrame(wx.Frame):
         wx.Frame.__init__(self, parent, id, title, pos, size, style)
 
         # tell FrameManager to manage this frame
-        self._mgr = wx.aui.AuiManager()
+        self._mgr = aui.AuiManager()
         self._mgr.SetManagedWindow(self)
 
         self._perspectives = []
@@ -141,7 +145,7 @@ class PyAUIFrame(wx.Frame):
 
         self.SetMenuBar(mb)
 
-        self.statusbar = self.CreateStatusBar(2, wx.ST_SIZEGRIP)
+        self.statusbar = self.CreateStatusBar(2, wx.STB_SIZEGRIP)
         self.statusbar.SetStatusWidths([-2, -3])
         self.statusbar.SetStatusText("Ready", 0)
         self.statusbar.SetStatusText("Welcome To wxPython!", 1)
@@ -221,101 +225,101 @@ class PyAUIFrame(wx.Frame):
         tb5.Realize()
 
         # add a bunch of panes
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Name("test1").Caption("Pane Caption").Top().
                           CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Name("test2").Caption("Client Size Reporter").
                           Bottom().Position(1).CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Name("test3").Caption("Client Size Reporter").
                           Bottom().CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Name("test4").Caption("Pane Caption").
                           Left().CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Name("test5").Caption("Pane Caption").
                           Right().CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Name("test6").Caption("Client Size Reporter").
                           Right().Row(1).CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Name("test7").Caption("Client Size Reporter").
                           Left().Layer(1).CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateTreeCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateTreeCtrl(), aui.AuiPaneInfo().
                           Name("test8").Caption("Tree Pane").
                           Left().Layer(1).Position(1).CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Name("test9").Caption("Min Size 200x100").
                           BestSize(wx.Size(200,100)).MinSize(wx.Size(200,100)).
                           Bottom().Layer(1).CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateTextCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateTextCtrl(), aui.AuiPaneInfo().
                           Name("test10").Caption("Text Pane").
                           Bottom().Layer(1).Position(1).CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Name("test11").Caption("Fixed Pane").
                           Bottom().Layer(1).Position(2).Fixed().CloseButton(True).MaximizeButton(True))
 
-        self._mgr.AddPane(SettingsPanel(self, self), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(SettingsPanel(self, self), aui.AuiPaneInfo().
                           Name("settings").Caption("Dock Manager Settings").
                           Dockable(False).Float().Hide().CloseButton(True).MaximizeButton(True))
 
         # create some center panes
 
-        self._mgr.AddPane(self.CreateGrid(), wx.aui.AuiPaneInfo().Name("grid_content").
+        self._mgr.AddPane(self.CreateGrid(), aui.AuiPaneInfo().Name("grid_content").
                           CenterPane().Hide())
 
-        self._mgr.AddPane(self.CreateTreeCtrl(), wx.aui.AuiPaneInfo().Name("tree_content").
+        self._mgr.AddPane(self.CreateTreeCtrl(), aui.AuiPaneInfo().Name("tree_content").
                           CenterPane().Hide())
 
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().Name("sizereport_content").
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().Name("sizereport_content").
                           CenterPane().Hide())
 
-        self._mgr.AddPane(self.CreateTextCtrl(), wx.aui.AuiPaneInfo().Name("text_content").
+        self._mgr.AddPane(self.CreateTextCtrl(), aui.AuiPaneInfo().Name("text_content").
                           CenterPane().Hide())
 
-        self._mgr.AddPane(self.CreateHTMLCtrl(), wx.aui.AuiPaneInfo().Name("html_content").
+        self._mgr.AddPane(self.CreateHTMLCtrl(), aui.AuiPaneInfo().Name("html_content").
                           CenterPane())
 
         # add the toolbars to the manager
 
-        self._mgr.AddPane(tb1, wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(tb1, aui.AuiPaneInfo().
                           Name("tb1").Caption("Big Toolbar").
                           ToolbarPane().Top().
                           LeftDockable(False).RightDockable(False))
 
-        self._mgr.AddPane(tb2, wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(tb2, aui.AuiPaneInfo().
                           Name("tb2").Caption("Toolbar 2").
                           ToolbarPane().Top().Row(1).
                           LeftDockable(False).RightDockable(False))
 
-        self._mgr.AddPane(tb3, wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(tb3, aui.AuiPaneInfo().
                           Name("tb3").Caption("Toolbar 3").
                           ToolbarPane().Top().Row(1).Position(1).
                           LeftDockable(False).RightDockable(False))
 
-        self._mgr.AddPane(tb4, wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(tb4, aui.AuiPaneInfo().
                           Name("tb4").Caption("Sample Bookmark Toolbar").
                           ToolbarPane().Top().Row(2).
                           LeftDockable(False).RightDockable(False))
 
-        self._mgr.AddPane(tb5, wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(tb5, aui.AuiPaneInfo().
                           Name("tbvert").Caption("Sample Vertical Toolbar").
                           ToolbarPane().Left().GripperTop().
                           TopDockable(False).BottomDockable(False))
 
         self._mgr.AddPane(wx.Button(self, -1, "Test Button"),
-                          wx.aui.AuiPaneInfo().Name("tb5").
+                          aui.AuiPaneInfo().Name("tb5").
                           ToolbarPane().Top().Row(2).Position(1).
                           LeftDockable(False).RightDockable(False))
 
@@ -327,7 +331,7 @@ class PyAUIFrame(wx.Frame):
 
         all_panes = self._mgr.GetAllPanes()
 
-        for ii in xrange(len(all_panes)):
+        for ii in range(len(all_panes)):
             if not all_panes[ii].IsToolbar():
                 all_panes[ii].Hide()
 
@@ -339,7 +343,7 @@ class PyAUIFrame(wx.Frame):
 
         perspective_default = self._mgr.SavePerspective()
 
-        for ii in xrange(len(all_panes)):
+        for ii in range(len(all_panes)):
             if not all_panes[ii].IsToolbar():
                 all_panes[ii].Hide()
 
@@ -368,7 +372,7 @@ class PyAUIFrame(wx.Frame):
         self.Bind(wx.EVT_CLOSE, self.OnClose)
 
         # Show How To Use The Closing Panes Event
-        self.Bind(wx.aui.EVT_AUI_PANE_CLOSE, self.OnPaneClose)
+        self.Bind(aui.EVT_AUI_PANE_CLOSE, self.OnPaneClose)
 
         self.Bind(wx.EVT_MENU, self.OnCreateTree, id=ID_CreateTree)
         self.Bind(wx.EVT_MENU, self.OnCreateGrid, id=ID_CreateGrid)
@@ -443,10 +447,10 @@ class PyAUIFrame(wx.Frame):
 
     def OnAbout(self, event):
 
-        msg = "wx.aui Demo\n" + \
+        msg = "aui Demo\n" + \
               "An advanced window management library for wxWidgets\n" + \
               "(c) Copyright 2005-2006, Kirix Corporation"
-        dlg = wx.MessageDialog(self, msg, "About wx.aui Demo",
+        dlg = wx.MessageDialog(self, msg, "About aui Demo",
                                wx.OK | wx.ICON_INFORMATION)
         dlg.ShowModal()
         dlg.Destroy()
@@ -488,13 +492,13 @@ class PyAUIFrame(wx.Frame):
         gradient = 0
 
         if event.GetId() == ID_NoGradient:
-            gradient = wx.aui.AUI_GRADIENT_NONE
+            gradient = aui.AUI_GRADIENT_NONE
         elif event.GetId() == ID_VerticalGradient:
-            gradient = wx.aui.AUI_GRADIENT_VERTICAL
+            gradient = aui.AUI_GRADIENT_VERTICAL
         elif event.GetId() == ID_HorizontalGradient:
-            gradient = wx.aui.AUI_GRADIENT_HORIZONTAL
+            gradient = aui.AUI_GRADIENT_HORIZONTAL
 
-        self._mgr.GetArtProvider().SetMetric(wx.aui.AUI_DOCKART_GRADIENT_TYPE, gradient)
+        self._mgr.GetArtProvider().SetMetric(aui.AUI_DOCKART_GRADIENT_TYPE, gradient)
         self._mgr.Update()
 
 
@@ -505,27 +509,27 @@ class PyAUIFrame(wx.Frame):
 
         if eid in [ ID_TransparentHint, ID_VenetianBlindsHint, ID_RectangleHint, ID_NoHint ]:
             flags = self._mgr.GetFlags()
-            flags &= ~wx.aui.AUI_MGR_TRANSPARENT_HINT
-            flags &= ~wx.aui.AUI_MGR_VENETIAN_BLINDS_HINT
-            flags &= ~wx.aui.AUI_MGR_RECTANGLE_HINT
+            flags &= ~aui.AUI_MGR_TRANSPARENT_HINT
+            flags &= ~aui.AUI_MGR_VENETIAN_BLINDS_HINT
+            flags &= ~aui.AUI_MGR_RECTANGLE_HINT
             self._mgr.SetFlags(flags)
 
         if eid == ID_AllowFloating:
-            flag = wx.aui.AUI_MGR_ALLOW_FLOATING
+            flag = aui.AUI_MGR_ALLOW_FLOATING
         elif eid == ID_TransparentDrag:
-            flag = wx.aui.AUI_MGR_TRANSPARENT_DRAG
+            flag = aui.AUI_MGR_TRANSPARENT_DRAG
         elif eid == ID_HintFade:
-            flag = wx.aui.AUI_MGR_HINT_FADE
+            flag = aui.AUI_MGR_HINT_FADE
         elif eid == ID_NoVenetianFade:
-            flag = wx.aui.AUI_MGR_NO_VENETIAN_BLINDS_FADE
+            flag = aui.AUI_MGR_NO_VENETIAN_BLINDS_FADE
         elif eid == ID_AllowActivePane:
-            flag = wx.aui.AUI_MGR_ALLOW_ACTIVE_PANE
+            flag = aui.AUI_MGR_ALLOW_ACTIVE_PANE
         elif eid == ID_TransparentHint:
-            flag = wx.aui.AUI_MGR_TRANSPARENT_HINT
+            flag = aui.AUI_MGR_TRANSPARENT_HINT
         elif eid == ID_VenetianBlindsHint:
-            flag = wx.aui.AUI_MGR_VENETIAN_BLINDS_HINT
+            flag = aui.AUI_MGR_VENETIAN_BLINDS_HINT
         elif eid == ID_RectangleHint:
-            flag = wx.aui.AUI_MGR_RECTANGLE_HINT
+            flag = aui.AUI_MGR_RECTANGLE_HINT
 
         self._mgr.SetFlags(self._mgr.GetFlags() ^ flag)
 
@@ -536,39 +540,39 @@ class PyAUIFrame(wx.Frame):
         eid = event.GetId()
 
         if eid == ID_NoGradient:
-            event.Check(self._mgr.GetArtProvider().GetMetric(wx.aui.AUI_DOCKART_GRADIENT_TYPE) == wx.aui.AUI_GRADIENT_NONE)
+            event.Check(self._mgr.GetArtProvider().GetMetric(aui.AUI_DOCKART_GRADIENT_TYPE) == aui.AUI_GRADIENT_NONE)
 
         elif eid == ID_VerticalGradient:
-            event.Check(self._mgr.GetArtProvider().GetMetric(wx.aui.AUI_DOCKART_GRADIENT_TYPE) == wx.aui.AUI_GRADIENT_VERTICAL)
+            event.Check(self._mgr.GetArtProvider().GetMetric(aui.AUI_DOCKART_GRADIENT_TYPE) == aui.AUI_GRADIENT_VERTICAL)
 
         elif eid == ID_HorizontalGradient:
-            event.Check(self._mgr.GetArtProvider().GetMetric(wx.aui.AUI_DOCKART_GRADIENT_TYPE) == wx.aui.AUI_GRADIENT_HORIZONTAL)
+            event.Check(self._mgr.GetArtProvider().GetMetric(aui.AUI_DOCKART_GRADIENT_TYPE) == aui.AUI_GRADIENT_HORIZONTAL)
 
         elif eid == ID_AllowFloating:
-            event.Check((flags & wx.aui.AUI_MGR_ALLOW_FLOATING) != 0)
+            event.Check((flags & aui.AUI_MGR_ALLOW_FLOATING) != 0)
 
         elif eid == ID_TransparentDrag:
-            event.Check((flags & wx.aui.AUI_MGR_TRANSPARENT_DRAG) != 0)
+            event.Check((flags & aui.AUI_MGR_TRANSPARENT_DRAG) != 0)
 
         elif eid == ID_TransparentHint:
-            event.Check((flags & wx.aui.AUI_MGR_TRANSPARENT_HINT) != 0)
+            event.Check((flags & aui.AUI_MGR_TRANSPARENT_HINT) != 0)
 
         elif eid == ID_VenetianBlindsHint:
-            event.Check((flags & wx.aui.AUI_MGR_VENETIAN_BLINDS_HINT) != 0)
+            event.Check((flags & aui.AUI_MGR_VENETIAN_BLINDS_HINT) != 0)
 
         elif eid == ID_RectangleHint:
-            event.Check((flags & wx.aui.AUI_MGR_RECTANGLE_HINT) != 0)
+            event.Check((flags & aui.AUI_MGR_RECTANGLE_HINT) != 0)
 
         elif eid == ID_NoHint:
-            event.Check(((wx.aui.AUI_MGR_TRANSPARENT_HINT |
-                          wx.aui.AUI_MGR_VENETIAN_BLINDS_HINT |
-                          wx.aui.AUI_MGR_RECTANGLE_HINT) & flags) == 0)
+            event.Check(((aui.AUI_MGR_TRANSPARENT_HINT |
+                          aui.AUI_MGR_VENETIAN_BLINDS_HINT |
+                          aui.AUI_MGR_RECTANGLE_HINT) & flags) == 0)
 
         elif eid == ID_HintFade:
-            event.Check((flags & wx.aui.AUI_MGR_HINT_FADE) != 0);
+            event.Check((flags & aui.AUI_MGR_HINT_FADE) != 0);
 
         elif eid == ID_NoVenetianFade:
-            event.Check((flags & wx.aui.AUI_MGR_NO_VENETIAN_BLINDS_FADE) != 0);
+            event.Check((flags & aui.AUI_MGR_NO_VENETIAN_BLINDS_FADE) != 0);
 
 
 
@@ -612,7 +616,7 @@ class PyAUIFrame(wx.Frame):
 
 
     def OnCreateTree(self, event):
-        self._mgr.AddPane(self.CreateTreeCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateTreeCtrl(), aui.AuiPaneInfo().
                           Caption("Tree Control").
                           Float().FloatingPosition(self.GetStartPosition()).
                           FloatingSize(wx.Size(150, 300)).CloseButton(True).MaximizeButton(True))
@@ -620,7 +624,7 @@ class PyAUIFrame(wx.Frame):
 
 
     def OnCreateGrid(self, event):
-        self._mgr.AddPane(self.CreateGrid(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateGrid(), aui.AuiPaneInfo().
                           Caption("Grid").
                           Float().FloatingPosition(self.GetStartPosition()).
                           FloatingSize(wx.Size(300, 200)).CloseButton(True).MaximizeButton(True))
@@ -628,7 +632,7 @@ class PyAUIFrame(wx.Frame):
 
 
     def OnCreateHTML(self, event):
-        self._mgr.AddPane(self.CreateHTMLCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateHTMLCtrl(), aui.AuiPaneInfo().
                           Caption("HTML Content").
                           Float().FloatingPosition(self.GetStartPosition()).
                           FloatingSize(wx.Size(300, 200)).CloseButton(True).MaximizeButton(True))
@@ -636,7 +640,7 @@ class PyAUIFrame(wx.Frame):
 
 
     def OnCreateText(self, event):
-        self._mgr.AddPane(self.CreateTextCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateTextCtrl(), aui.AuiPaneInfo().
                           Caption("Text Control").
                           Float().FloatingPosition(self.GetStartPosition()).
                           CloseButton(True).MaximizeButton(True))
@@ -644,7 +648,7 @@ class PyAUIFrame(wx.Frame):
 
 
     def OnCreateSizeReport(self, event):
-        self._mgr.AddPane(self.CreateSizeReportCtrl(), wx.aui.AuiPaneInfo().
+        self._mgr.AddPane(self.CreateSizeReportCtrl(), aui.AuiPaneInfo().
                           Caption("Client Size Reporter").
                           Float().FloatingPosition(self.GetStartPosition()).
                           CloseButton(True).MaximizeButton(True))
@@ -699,7 +703,7 @@ class PyAUIFrame(wx.Frame):
         items.append(tree.AppendItem(root, "Item 4", 0))
         items.append(tree.AppendItem(root, "Item 5", 0))
 
-        for ii in xrange(len(items)):
+        for ii in range(len(items)):
 
             id = items[ii]
             tree.AppendItem(id, "Subitem 1", 1)
@@ -965,9 +969,9 @@ class SettingsPanel(wx.Panel):
         self.SetSizer(cont_sizer)
         self.GetSizer().SetSizeHints(self)
 
-        self._border_size.SetValue(frame.GetDockArt().GetMetric(wx.aui.AUI_DOCKART_PANE_BORDER_SIZE))
-        self._sash_size.SetValue(frame.GetDockArt().GetMetric(wx.aui.AUI_DOCKART_SASH_SIZE))
-        self._caption_size.SetValue(frame.GetDockArt().GetMetric(wx.aui.AUI_DOCKART_CAPTION_SIZE))
+        self._border_size.SetValue(frame.GetDockArt().GetMetric(aui.AUI_DOCKART_PANE_BORDER_SIZE))
+        self._sash_size.SetValue(frame.GetDockArt().GetMetric(aui.AUI_DOCKART_SASH_SIZE))
+        self._caption_size.SetValue(frame.GetDockArt().GetMetric(aui.AUI_DOCKART_CAPTION_SIZE))
 
         self.UpdateColors()
 
@@ -988,9 +992,9 @@ class SettingsPanel(wx.Panel):
 
     def CreateColorBitmap(self, c):
         image = wx.Image(25, 14)
-        
-        for x in xrange(25):
-            for y in xrange(14):
+
+        for x in range(25):
+            for y in range(14):
                 pixcol = c
                 if x == 0 or x == 24 or y == 0 or y == 13:
                     pixcol = wx.BLACK
@@ -1002,54 +1006,54 @@ class SettingsPanel(wx.Panel):
 
     def UpdateColors(self):
 
-        bk = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_BACKGROUND_COLOUR)
+        bk = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_BACKGROUND_COLOUR)
         self._background_color.SetBitmapLabel(self.CreateColorBitmap(bk))
 
-        cap = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_INACTIVE_CAPTION_COLOUR)
+        cap = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_INACTIVE_CAPTION_COLOUR)
         self._inactive_caption_color.SetBitmapLabel(self.CreateColorBitmap(cap))
 
-        capgrad = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_INACTIVE_CAPTION_GRADIENT_COLOUR)
+        capgrad = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_INACTIVE_CAPTION_GRADIENT_COLOUR)
         self._inactive_caption_gradient_color.SetBitmapLabel(self.CreateColorBitmap(capgrad))
 
-        captxt = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_INACTIVE_CAPTION_TEXT_COLOUR)
+        captxt = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_INACTIVE_CAPTION_TEXT_COLOUR)
         self._inactive_caption_text_color.SetBitmapLabel(self.CreateColorBitmap(captxt))
 
-        acap = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_ACTIVE_CAPTION_COLOUR)
+        acap = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_ACTIVE_CAPTION_COLOUR)
         self._active_caption_color.SetBitmapLabel(self.CreateColorBitmap(acap))
 
-        acapgrad = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_ACTIVE_CAPTION_GRADIENT_COLOUR)
+        acapgrad = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_ACTIVE_CAPTION_GRADIENT_COLOUR)
         self._active_caption_gradient_color.SetBitmapLabel(self.CreateColorBitmap(acapgrad))
 
-        acaptxt = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_ACTIVE_CAPTION_TEXT_COLOUR)
+        acaptxt = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_ACTIVE_CAPTION_TEXT_COLOUR)
         self._active_caption_text_color.SetBitmapLabel(self.CreateColorBitmap(acaptxt))
 
-        sash = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_SASH_COLOUR)
+        sash = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_SASH_COLOUR)
         self._sash_color.SetBitmapLabel(self.CreateColorBitmap(sash))
 
-        border = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_BORDER_COLOUR)
+        border = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_BORDER_COLOUR)
         self._border_color.SetBitmapLabel(self.CreateColorBitmap(border))
 
-        gripper = self._frame.GetDockArt().GetColour(wx.aui.AUI_DOCKART_GRIPPER_COLOUR)
+        gripper = self._frame.GetDockArt().GetColour(aui.AUI_DOCKART_GRIPPER_COLOUR)
         self._gripper_color.SetBitmapLabel(self.CreateColorBitmap(gripper))
 
 
     def OnPaneBorderSize(self, event):
 
-        self._frame.GetDockArt().SetMetric(wx.aui.AUI_DOCKART_PANE_BORDER_SIZE,
+        self._frame.GetDockArt().SetMetric(aui.AUI_DOCKART_PANE_BORDER_SIZE,
                                            event.GetInt())
         self._frame.DoUpdate()
 
 
     def OnSashSize(self, event):
 
-        self._frame.GetDockArt().SetMetric(wx.aui.AUI_DOCKART_SASH_SIZE,
+        self._frame.GetDockArt().SetMetric(aui.AUI_DOCKART_SASH_SIZE,
                                            event.GetInt())
         self._frame.DoUpdate()
 
 
     def OnCaptionSize(self, event):
 
-        self._frame.GetDockArt().SetMetric(wx.aui.AUI_DOCKART_CAPTION_SIZE,
+        self._frame.GetDockArt().SetMetric(aui.AUI_DOCKART_CAPTION_SIZE,
                                            event.GetInt())
         self._frame.DoUpdate()
 
@@ -1065,25 +1069,25 @@ class SettingsPanel(wx.Panel):
 
         var = 0
         if event.GetId() == ID_BackgroundColor:
-            var = wx.aui.AUI_DOCKART_BACKGROUND_COLOUR
+            var = aui.AUI_DOCKART_BACKGROUND_COLOUR
         elif event.GetId() == ID_SashColor:
-            var = wx.aui.AUI_DOCKART_SASH_COLOUR
+            var = aui.AUI_DOCKART_SASH_COLOUR
         elif event.GetId() == ID_InactiveCaptionColor:
-            var = wx.aui.AUI_DOCKART_INACTIVE_CAPTION_COLOUR
+            var = aui.AUI_DOCKART_INACTIVE_CAPTION_COLOUR
         elif event.GetId() == ID_InactiveCaptionGradientColor:
-            var = wx.aui.AUI_DOCKART_INACTIVE_CAPTION_GRADIENT_COLOUR
+            var = aui.AUI_DOCKART_INACTIVE_CAPTION_GRADIENT_COLOUR
         elif event.GetId() == ID_InactiveCaptionTextColor:
-            var = wx.aui.AUI_DOCKART_INACTIVE_CAPTION_TEXT_COLOUR
+            var = aui.AUI_DOCKART_INACTIVE_CAPTION_TEXT_COLOUR
         elif event.GetId() == ID_ActiveCaptionColor:
-            var = wx.aui.AUI_DOCKART_ACTIVE_CAPTION_COLOUR
+            var = aui.AUI_DOCKART_ACTIVE_CAPTION_COLOUR
         elif event.GetId() == ID_ActiveCaptionGradientColor:
-            var = wx.aui.AUI_DOCKART_ACTIVE_CAPTION_GRADIENT_COLOUR
+            var = aui.AUI_DOCKART_ACTIVE_CAPTION_GRADIENT_COLOUR
         elif event.GetId() == ID_ActiveCaptionTextColor:
-            var = wx.aui.AUI_DOCKART_ACTIVE_CAPTION_TEXT_COLOUR
+            var = aui.AUI_DOCKART_ACTIVE_CAPTION_TEXT_COLOUR
         elif event.GetId() == ID_BorderColor:
-            var = wx.aui.AUI_DOCKART_BORDER_COLOUR
+            var = aui.AUI_DOCKART_BORDER_COLOUR
         elif event.GetId() == ID_GripperColor:
-            var = wx.aui.AUI_DOCKART_GRIPPER_COLOUR
+            var = aui.AUI_DOCKART_GRIPPER_COLOUR
         else:
             return
 
@@ -1099,11 +1103,11 @@ class TestPanel(wx.Panel):
     def __init__(self, parent, log):
         self.log = log
         wx.Panel.__init__(self, parent, -1)
-        b = wx.Button(self, -1, "Show the wx.aui Demo Frame", (50,50))
+        b = wx.Button(self, -1, "Show the aui Demo Frame", (50,50))
         self.Bind(wx.EVT_BUTTON, self.OnButton, b)
 
     def OnButton(self, evt):
-        frame = PyAUIFrame(self, wx.ID_ANY, "wx.aui wxPython Demo", size=(750, 590))
+        frame = PyAUIFrame(self, wx.ID_ANY, "aui wxPython Demo", size=(750, 590))
         frame.Show()
 
 #----------------------------------------------------------------------
@@ -1118,17 +1122,17 @@ def runTest(frame, nb, log):
 
 overview = """\
 <html><body>
-<h3>wx.aui, the Advanced User Interface module</h3>
+<h3>aui, the Advanced User Interface module</h3>
 
 <br/><b>Overview</b><br/>
 
-<p>wx.aui is an Advanced User Interface library for the wxWidgets toolkit
+<p>aui is an Advanced User Interface library for the wxWidgets toolkit
 that allows developers to create high-quality, cross-platform user
 interfaces quickly and easily.</p>
 
 <p><b>Features</b></p>
 
-<p>With wx.aui developers can create application frameworks with:</p>
+<p>With aui developers can create application frameworks with:</p>
 
 <ul>
 <li>Native, dockable floating frames</li>

--- a/demo/AUI_MDI.py
+++ b/demo/AUI_MDI.py
@@ -1,14 +1,18 @@
 #!/usr/bin/env python
 
 import wx
-import wx.aui
+try:
+    from agw import aui
+except ImportError: # if it's not there locally, try the wxPython lib.
+    import wx.lib.agw.aui as aui
+
 
 #----------------------------------------------------------------------
 
 
-class ParentFrame(wx.aui.AuiMDIParentFrame):
+class ParentFrame(aui.AuiMDIParentFrame):
     def __init__(self, parent):
-        wx.aui.AuiMDIParentFrame.__init__(self, parent, -1,
+        aui.AuiMDIParentFrame.__init__(self, parent, -1,
                                           title="AuiMDIParentFrame",
                                           size=(640,480),
                                           style=wx.DEFAULT_FRAME_STYLE)
@@ -17,7 +21,7 @@ class ParentFrame(wx.aui.AuiMDIParentFrame):
         self.SetMenuBar(mb)
         self.CreateStatusBar()
         self.Bind(wx.EVT_CLOSE, self.OnDoClose)
-        
+
     def MakeMenuBar(self):
         mb = wx.MenuBar()
         menu = wx.Menu()
@@ -27,7 +31,7 @@ class ParentFrame(wx.aui.AuiMDIParentFrame):
         self.Bind(wx.EVT_MENU, self.OnDoClose, item)
         mb.Append(menu, "&File")
         return mb
-        
+
     def OnNewChild(self, evt):
         self.count += 1
         child = ChildFrame(self, self.count)
@@ -36,25 +40,25 @@ class ParentFrame(wx.aui.AuiMDIParentFrame):
     def OnDoClose(self, evt):
         # Close all ChildFrames first else Python crashes
         for m in self.GetChildren():
-            if isinstance(m, wx.aui.AuiMDIClientWindow):
+            if isinstance(m, aui.AuiMDIClientWindow):
                 for k in m.GetChildren():
                     if isinstance(k, ChildFrame):
-                        k.Close()  
+                        k.Close()
         evt.Skip()
-        
+
 
 #----------------------------------------------------------------------
 
-class ChildFrame(wx.aui.AuiMDIChildFrame):
+class ChildFrame(aui.AuiMDIChildFrame):
     def __init__(self, parent, count):
-        wx.aui.AuiMDIChildFrame.__init__(self, parent, -1,
+        aui.AuiMDIChildFrame.__init__(self, parent, -1,
                                          title="Child: %d" % count)
         mb = parent.MakeMenuBar()
         menu = wx.Menu()
         item = menu.Append(-1, "This is child %d's menu" % count)
         mb.Append(menu, "&Child")
         self.SetMenuBar(mb)
-        
+
         p = wx.Panel(self)
         wx.StaticText(p, -1, "This is child %d" % count, (10,10))
         p.SetBackgroundColour('light blue')
@@ -62,7 +66,7 @@ class ChildFrame(wx.aui.AuiMDIChildFrame):
         sizer = wx.BoxSizer()
         sizer.Add(p, 1, wx.EXPAND)
         self.SetSizer(sizer)
-        
+
         wx.CallAfter(self.Layout)
 
 #----------------------------------------------------------------------
@@ -79,8 +83,8 @@ class TestPanel(wx.Panel):
     def OnButton(self, evt):
         pf = ParentFrame(self)
         pf.Show()
-        
-        
+
+
 
 #----------------------------------------------------------------------
 
@@ -93,11 +97,11 @@ def runTest(frame, nb, log):
 
 
 overview = """<html><body>
-<h2><center>wx.aui.AuiMDI</center></h2>
+<h2><center>aui.AuiMDI</center></h2>
 
-The wx.aui.AuiMDIParentFrame and wx.aui.AuiMDIChildFrame classes
+The aui.AuiMDIParentFrame and aui.AuiMDIChildFrame classes
 implement the same API as wx.MDIParentFrame and wx.MDIChildFrame, but
-implement the multiple document interface with a wx.aui.AuiNotebook.
+implement the multiple document interface with a aui.AuiNotebook.
 
 
 </body></html>

--- a/demo/AUI_Notebook.py
+++ b/demo/AUI_Notebook.py
@@ -1,13 +1,16 @@
 #!/usr/bin/env python
 
 import wx
-import wx.aui
+try:
+    from agw import aui
+except ImportError: # if it's not there locally, try the wxPython lib.
+    import wx.lib.agw.aui as aui
 
 
 text = """\
 Hello!
 
-Welcome to this little demo of draggable tabs using the wx.aui module.
+Welcome to this little demo of draggable tabs using the aui module.
 
 To try it out, drag a tab from the top of the window all the way to the bottom.  After releasing the mouse, the tab will dock at the hinted position.  Then try it again with the remaining tabs in various other positions.  Finally, try dragging a tab to an existing tab ctrl.  You'll soon see that very complex tab layouts may be achieved.
 """
@@ -19,7 +22,7 @@ class TestPanel(wx.Panel):
         self.log = log
         wx.Panel.__init__(self, parent, -1)
 
-        self.nb = wx.aui.AuiNotebook(self)
+        self.nb = aui.AuiNotebook(self)
         page = wx.TextCtrl(self.nb, -1, text, style=wx.TE_MULTILINE)
         self.nb.AddPage(page, "Welcome")
 
@@ -27,12 +30,12 @@ class TestPanel(wx.Panel):
             page = wx.TextCtrl(self.nb, -1, "This is page %d" % num ,
                                style=wx.TE_MULTILINE)
             self.nb.AddPage(page, "Tab Number %d" % num)
-            
+
         sizer = wx.BoxSizer()
         sizer.Add(self.nb, 1, wx.EXPAND)
         self.SetSizer(sizer)
         wx.CallAfter(self.nb.SendSizeEvent)
-        
+
 #----------------------------------------------------------------------
 
 def runTest(frame, nb, log):

--- a/demo/BitmapFromBuffer.py
+++ b/demo/BitmapFromBuffer.py
@@ -34,8 +34,8 @@ class TestPanel(wx.Panel):
         bpp = 3  # bytes per pixel
         bytes = array.array('B', [0] * width*height*bpp)
 
-        for y in xrange(height):
-            for x in xrange(width):
+        for y in range(height):
+            for x in range(width):
                 offset = y*width*bpp + x*bpp
                 r,g,b = self.GetRGB(x, y, bpp)
                 bytes[offset + 0] = r
@@ -49,8 +49,8 @@ class TestPanel(wx.Panel):
         bpp = 4  # bytes per pixel
         bytes = array.array('B', [0] * width*height*bpp)
 
-        for y in xrange(height):
-            for x in xrange(width):
+        for y in range(height):
+            for x in range(width):
                 offset = y*width*bpp + x*bpp
                 r,g,b,a = self.GetRGB(x, y, bpp)
                 bytes[offset + 0] = r
@@ -66,8 +66,8 @@ class TestPanel(wx.Panel):
         bpp = 3  # bytes per pixel
         bytes = array.array('B', [0] * width*height*bpp)
 
-        for y in xrange(height):
-            for x in xrange(width):
+        for y in range(height):
+            for x in range(width):
                 offset = y*width*bpp + x*bpp
                 r,g,b = self.GetRGB(x, y, bpp)
                 bytes[offset + 0] = r

--- a/demo/CheckListCtrlMixin.py
+++ b/demo/CheckListCtrlMixin.py
@@ -46,8 +46,8 @@ class TestPanel(wx.Panel):
         self.list.InsertColumn(1, "Title", wx.LIST_FORMAT_RIGHT)
         self.list.InsertColumn(2, "Genre")
 
-        for key, data in musicdata.iteritems():
-            index = self.list.InsertStringItem(sys.maxint, data[0])
+        for key, data in musicdata.items():
+            index = self.list.InsertStringItem(sys.maxsize, data[0])
             self.list.SetItem(index, 1, data[1])
             self.list.SetItem(index, 2, data[2])
             self.list.SetItemData(index, key)

--- a/demo/DVC_ListCtrl.py
+++ b/demo/DVC_ListCtrl.py
@@ -7,8 +7,8 @@ import wx.dataview as dv
 
 # Reuse the music data in the ListCtrl sample
 import ListCtrl
-musicdata = ListCtrl.musicdata.items()
-musicdata.sort()
+musicdata = sorted(ListCtrl.musicdata.items())
+#musicdata.sort()
 musicdata = [[str(k)] + list(v) for k,v in musicdata]
 
 

--- a/demo/ListCtrl_edit.py
+++ b/demo/ListCtrl_edit.py
@@ -51,7 +51,7 @@ class TestListCtrl(wx.ListCtrl,
 
         items = listctrldata.items()
         for key, data in items:
-            index = self.InsertItem(sys.maxint, data[0])
+            index = self.InsertItem(sys.maxsize, data[0])
             self.SetItem(index, 1, data[1])
             self.SetItem(index, 2, data[2])
             self.SetItemData(index, key)

--- a/demo/RawBitmapAccess.py
+++ b/demo/RawBitmapAccess.py
@@ -107,9 +107,9 @@ class TestPanel(wx.Panel):
         # avoids the iterator/generator magic, but it is not nearly as
         # 'clean' looking ;-)
         #pixels = pixelData.GetPixels()
-        #for y in xrange(DIM):
+        #for y in range(DIM):
         #    pixels.MoveTo(pixelData, 0, y)
-        #    for x in xrange(DIM):
+        #    for x in range(DIM):
         #        pixels.Set(red, green, blue, alpha)
         #        pixels.nextPixel()
 
@@ -118,12 +118,12 @@ class TestPanel(wx.Panel):
         # Next we'll use the pixel accessor to set the border pixels
         # to be fully opaque
         pixels = pixelData.GetPixels()
-        for x in xrange(DIM):
+        for x in range(DIM):
             pixels.MoveTo(pixelData, x, 0)
             pixels.Set(red, green, blue, wx.ALPHA_OPAQUE)
             pixels.MoveTo(pixelData, x, DIM-1)
             pixels.Set(red, green, blue, wx.ALPHA_OPAQUE)
-        for y in xrange(DIM):
+        for y in range(DIM):
             pixels.MoveTo(pixelData, 0, y)
             pixels.Set(red, green, blue, wx.ALPHA_OPAQUE)
             pixels.MoveTo(pixelData, DIM-1, y)

--- a/demo/Toolbook.py
+++ b/demo/Toolbook.py
@@ -19,8 +19,8 @@ def getNextImageID(count):
         imID += 1
         if imID == count:
             imID = 0
-    
-    
+
+
 class TestTB(wx.Toolbook):
     def __init__(self, parent, id, log):
         wx.Toolbook.__init__(self, parent, id, style=
@@ -40,12 +40,12 @@ class TestTB(wx.Toolbook):
             il.Add(bmp)
         self.AssignImageList(il)
         imageIdGenerator = getNextImageID(il.GetImageCount())
-        
+
         # Now make a bunch of panels for the list book
         first = True
         for colour in colourList:
             win = self.makeColorPanel(colour)
-            self.AddPage(win, colour, imageId=imageIdGenerator.next())
+            self.AddPage(win, colour, imageId=next(imageIdGenerator))
             if first:
                 st = wx.StaticText(win.win, -1,
                           "You can put nearly any type of window here,\n"

--- a/demo/Treebook.py
+++ b/demo/Treebook.py
@@ -45,7 +45,7 @@ class TestTB(wx.Treebook):
         first = True
         for colour in colourList:
             win = self.makeColorPanel(colour)
-            self.AddPage(win, colour, imageId=imageIdGenerator.next())
+            self.AddPage(win, colour, imageId=next(imageIdGenerator))
             if first:
                 st = wx.StaticText(win.win, -1,
                           "You can put nearly any type of window here,\n"
@@ -56,7 +56,7 @@ class TestTB(wx.Treebook):
 
             win = self.makeColorPanel(colour)
             st = wx.StaticText(win.win, -1, "this is a sub-page", (10,10))
-            self.AddSubPage(win, 'a sub-page', imageId=imageIdGenerator.next())
+            self.AddSubPage(win, 'a sub-page', imageId=next(imageIdGenerator))
 
         self.Bind(wx.EVT_TREEBOOK_PAGE_CHANGED, self.OnPageChanged)
         self.Bind(wx.EVT_TREEBOOK_PAGE_CHANGING, self.OnPageChanging)

--- a/demo/Validator.py
+++ b/demo/Validator.py
@@ -24,7 +24,7 @@ class MyValidator(wx.Validator):
 
         if self.flag == ALPHA_ONLY:
             for x in val:
-                if x not in string.letters:
+                if x not in string.ascii_letters:
                     return False
 
         elif self.flag == DIGIT_ONLY:
@@ -41,7 +41,7 @@ class MyValidator(wx.Validator):
             event.Skip()
             return
 
-        if self.flag == ALPHA_ONLY and chr(key) in string.letters:
+        if self.flag == ALPHA_ONLY and chr(key) in string.ascii_letters:
             event.Skip()
             return
 

--- a/demo/agw/AUI.py
+++ b/demo/agw/AUI.py
@@ -2670,7 +2670,7 @@ class AuiFrame(wx.Frame):
         # Add the main windows and toolbars, in two separate columns
         # We'll use the item 'id' to store the notebook selection, or -1 if not a page
 
-        for k in xrange(2):
+        for k in range(2):
             if k == 0:
                 items.AddGroup(_("Main Windows"), "mainwindows")
             else:
@@ -2694,7 +2694,7 @@ class AuiFrame(wx.Frame):
         for pane in self._mgr.GetAllPanes():
             nb = pane.window
             if isinstance(nb, aui.AuiNotebook):
-                for j in xrange(nb.GetPageCount()):
+                for j in range(nb.GetPageCount()):
 
                     name = nb.GetPageText(j)
                     win = nb.GetPage(j)

--- a/demo/agw/ButtonPanel.py
+++ b/demo/agw/ButtonPanel.py
@@ -273,8 +273,8 @@ class SettingsPanel(wx.MiniFrame):
 
         image = wx.Image(25, 14)
 
-        for x in xrange(25):
-            for y in xrange(14):
+        for x in range(25):
+            for y in range(14):
                 pixcol = c
                 if x == 0 or x == 24 or y == 0 or y == 13:
                     pixcol = wx.BLACK
@@ -659,7 +659,7 @@ class ButtonPanelDemo(wx.Frame):
 
         self.indices = []
 
-        for count in xrange(8):
+        for count in range(8):
 
             itemImage = random.randint(0, 3)
             hasText = random.randint(0, 1)

--- a/demo/agw/GenericMessageDialog.py
+++ b/demo/agw/GenericMessageDialog.py
@@ -34,7 +34,7 @@ for d in dir(wx):
     if d.startswith('ART_'):
         if not eval('wx.%s'%d).endswith(b'_C'):
             ART_ICONS.append(eval('wx.%s'%d))
-            
+
 
 class GenericMessageDialogDemo(wx.Panel):
 
@@ -43,7 +43,7 @@ class GenericMessageDialogDemo(wx.Panel):
         wx.Panel.__init__(self, parent)
 
         self.log = log
-        
+
         self.mainPanel = wx.Panel(self)
         self.buttonSizer_staticbox = wx.StaticBox(self.mainPanel, -1, "Buttons Styles")
         self.ok = wx.CheckBox(self.mainPanel, -1, "wx.OK")
@@ -65,7 +65,7 @@ class GenericMessageDialogDemo(wx.Panel):
 
         self.useExtended = wx.CheckBox(self.mainPanel, -1, "Add extended message")
         self.customIcons = wx.CheckBox(self.mainPanel, -1, "Use custom icons")
-        
+
         self.showDialog = wx.Button(self.mainPanel, -1, "Show GenericMessageDialog")
 
         self.SetProperties()
@@ -76,7 +76,7 @@ class GenericMessageDialogDemo(wx.Panel):
 
 
     def SetProperties(self):
-        
+
         self.ok.SetValue(1)
         self.dialogStyles.SetSelection(0)
         self.showDialog.SetDefault()
@@ -88,7 +88,7 @@ class GenericMessageDialogDemo(wx.Panel):
         panelSizer = wx.BoxSizer(wx.VERTICAL)
         mainSizer = wx.BoxSizer(wx.HORIZONTAL)
         buttonSizer = wx.StaticBoxSizer(self.buttonSizer_staticbox, wx.VERTICAL)
-        
+
         buttonSizer.Add(self.ok, 0, wx.LEFT|wx.RIGHT|wx.TOP, 5)
         buttonSizer.Add((0, 2), 0, 0, 0)
         buttonSizer.Add(self.yes_no, 0, wx.LEFT|wx.RIGHT, 5)
@@ -113,13 +113,13 @@ class GenericMessageDialogDemo(wx.Panel):
         panelSizer.Add(self.useExtended, 0, wx.ALL, 15)
         panelSizer.Add(self.customIcons, 0, wx.LEFT|wx.RIGHT, 15)
         panelSizer.Add((0, 0), 1, wx.ALL, 10)
-        
+
         self.mainPanel.SetSizer(panelSizer)
 
         frameSizer.Add(self.mainPanel, 1, wx.EXPAND)
         self.SetSizer(frameSizer)
         frameSizer.Layout()
-        
+
 
     def OnCheckBox(self, event):
 
@@ -128,17 +128,17 @@ class GenericMessageDialogDemo(wx.Panel):
         if obj in [self.useExtended, self.customIcons]:
             event.Skip()
             return
-        
+
         widgets = [self.yes, self.yes_no, self.no, self.no_default]
         if not event.IsChecked():
             return
-        
+
         if obj == self.ok:
             for checks in widgets:
                 checks.SetValue(0)
         elif obj in widgets:
             self.ok.SetValue(0)
-            
+
 
     def OnShowDialog(self, event):
 
@@ -164,26 +164,26 @@ class GenericMessageDialogDemo(wx.Panel):
         else:
             extended = ""
             message = _msg
-            
+
         dlg = GMD.GenericMessageDialog(self, message,
                                        "A Nice Message Box",
                                        btnStyle | dlgStyle)
 
         if self.customIcons.GetValue():
-            b1, b2, b3 = [random.randint(0, len(ART_ICONS)-1) for i in xrange(3)]
-            b4, b5 = [random.randint(0, len(ART_ICONS)-1) for i in xrange(2)]
+            b1, b2, b3 = [random.randint(0, len(ART_ICONS)-1) for i in range(3)]
+            b4, b5 = [random.randint(0, len(ART_ICONS)-1) for i in range(2)]
 
             yes    = wx.ArtProvider.GetBitmap(ART_ICONS[b1], wx.ART_OTHER, (16, 16))
             no     = wx.ArtProvider.GetBitmap(ART_ICONS[b2], wx.ART_OTHER, (16, 16))
             cancel = wx.ArtProvider.GetBitmap(ART_ICONS[b3], wx.ART_OTHER, (16, 16))
-            ok     = wx.ArtProvider.GetBitmap(ART_ICONS[b4], wx.ART_OTHER, (16, 16))  
+            ok     = wx.ArtProvider.GetBitmap(ART_ICONS[b4], wx.ART_OTHER, (16, 16))
             help   = wx.ArtProvider.GetBitmap(ART_ICONS[b5], wx.ART_OTHER, (16, 16))
 
             dlg.SetYesNoCancelBitmaps(yes, no, cancel)
             dlg.SetOKBitmap(ok)
             dlg.SetHelpBitmap(help)
 
-        dlg.SetExtendedMessage(extended)        
+        dlg.SetExtendedMessage(extended)
         dlg.SetIcon(images.Mondrian.GetIcon())
         dlg.ShowModal()
         dlg.Destroy()

--- a/demo/agw/HyperTreeList.py
+++ b/demo/agw/HyperTreeList.py
@@ -1407,7 +1407,7 @@ class HyperTreeListDemo(wx.Frame):
         if dlg.ShowModal() == wx.ID_OK:
             data = dlg.GetFontData()
             font = data.GetChosenFont()
-            for i in xrange(0, self.tree.GetMainWindow().GetColumnCount()):
+            for i in range(0, self.tree.GetMainWindow().GetColumnCount()):
                 self.tree.SetColumnFont(i, font)
 
         dlg.Destroy()
@@ -1417,7 +1417,7 @@ class HyperTreeListDemo(wx.Frame):
     def OnColumnColour(self, event):
 
         col1 = event.GetValue()
-        for i in xrange(0, self.tree.GetMainWindow().GetColumnCount()):
+        for i in range(0, self.tree.GetMainWindow().GetColumnCount()):
             self.tree.SetColumnColour(i, col1)
 
         event.Skip()
@@ -1433,7 +1433,7 @@ class HyperTreeListDemo(wx.Frame):
         else:
             alignment = wx.ALIGN_RIGHT
 
-        for i in xrange(1, self.tree.GetMainWindow().GetColumnCount()):
+        for i in range(1, self.tree.GetMainWindow().GetColumnCount()):
             self.tree.SetColumnAlignment(i, alignment)
 
         event.Skip()
@@ -1441,7 +1441,7 @@ class HyperTreeListDemo(wx.Frame):
 
     def OnColumnImages(self, event):
 
-        for i in xrange(self.tree.GetMainWindow().GetColumnCount()):
+        for i in range(self.tree.GetMainWindow().GetColumnCount()):
             randimage = random.randint(1, len(ArtIDs))
             img = (event.IsChecked() and [randimage] or [-1])[0]
             self.tree.SetColumnImage(i, img)
@@ -1473,7 +1473,7 @@ class HyperTreeListDemo(wx.Frame):
         else:
             choice = wx.LIST_AUTOSIZE
 
-        for i in xrange(self.tree.GetMainWindow().GetColumnCount()):
+        for i in range(self.tree.GetMainWindow().GetColumnCount()):
             self.tree.SetColumnWidth(i, choice)
 
         event.Skip()

--- a/demo/agw/RibbonBar.py
+++ b/demo/agw/RibbonBar.py
@@ -827,7 +827,7 @@ class RibbonFrame(wx.Frame):
 
             # Try to find colour in gallery
             item = None
-            for i in xrange(gallery.GetCount()):
+            for i in range(gallery.GetCount()):
                 item = gallery.GetItem(i)
                 if self.GetGalleryColour(gallery, item, None)[0] == clr:
                     break

--- a/demo/agw/ThumbnailCtrl.py
+++ b/demo/agw/ThumbnailCtrl.py
@@ -545,8 +545,9 @@ class ThumbnailCtrlDemo(wx.Frame):
     def OnPopupTen(self, event):
 
         items = self.TC.GetItemCount()
+        self.log.write("Items", items, type(items))
 
-        for ii in xrange(items):
+        for ii in range(items):
             self.TC.SetSelection(ii)
 
         self.log.write("OnGlobalPopupMenu: all thumbs selected\n")

--- a/demo/agw/ToasterBox.py
+++ b/demo/agw/ToasterBox.py
@@ -42,7 +42,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         scrolled.ScrolledPanel.__init__(self, parent)
 
         self.log = log
-        
+
         mainSz = wx.BoxSizer(wx.VERTICAL)
 
         horSz0 = wx.BoxSizer(wx.HORIZONTAL)
@@ -53,14 +53,14 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         rb = wx.RadioBox(self, -1, "ToasterBox Style", wx.DefaultPosition,
                          wx.DefaultSize, sampleList, 2, wx.RA_SPECIFY_COLS)
 
-        horSz0.Add(rb, 1, 0, 5)        
+        horSz0.Add(rb, 1, 0, 5)
         rb.SetToolTip(wx.ToolTip("Choose the ToasterBox style"))
 
         self.radiochoice = rb
-                
+
         horSz1 = wx.BoxSizer(wx.HORIZONTAL)
         mainSz.Add(horSz1, 1, wx.EXPAND | wx.ALL, 5)
-        
+
         statTxt1 = wx.StaticText(self, -1, "Popup position x/y")
         horSz1.Add(statTxt1, 3)
         txtCtrl1 = wx.TextCtrl(self, -1, "500")
@@ -73,7 +73,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
 
         horSz2 = wx.BoxSizer(wx.HORIZONTAL)
         mainSz.Add(horSz2, 1, wx.EXPAND | wx.ALL, 5)
-        
+
         statTxt2 = wx.StaticText(self, -1, "Popup size x/y")
         horSz2.Add(statTxt2, 3)
         txtCtrl2 = wx.TextCtrl(self, -1, "210")
@@ -83,10 +83,10 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
 
         self.sizex = txtCtrl2
         self.sizey = txtCtrl3
-        
+
         horSz3 = wx.BoxSizer(wx.HORIZONTAL)
         mainSz.Add(horSz3, 1, wx.EXPAND | wx.ALL, 5)
-        
+
         statTxt3 = wx.StaticText(self, -1, "Popup linger")
         horSz3.Add(statTxt3, 3)
         txtCtrl4 = wx.TextCtrl(self, -1, "4000")
@@ -108,7 +108,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         self.scrollspeed = txtCtrl4b
 
         horSz3c = wx.BoxSizer(wx.HORIZONTAL)
-        mainSz.Add(horSz3c, 1, wx.EXPAND | wx.ALL, 5)  
+        mainSz.Add(horSz3c, 1, wx.EXPAND | wx.ALL, 5)
         statTxt3c = wx.StaticText(self, -1, "Popup background picture")
         horSz3c.Add(statTxt3c, 3)
         txtCtrl4c = wx.FilePickerCtrl(self, -1, style=wx.FLP_USE_TEXTCTRL|wx.FLP_OPEN)
@@ -120,7 +120,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
                      "written by Andrea Gavana @ 8 September 2005."
         popupText2 = "I don't know what to write in this message. If you like this " \
                      "class, please let me know!."
-        
+
         horSz4 = wx.BoxSizer(wx.HORIZONTAL)
         mainSz.Add(horSz4, 1, wx.EXPAND | wx.ALL, 5)
         statTxt4 = wx.StaticText(self, -1, "Popup text")
@@ -166,7 +166,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         horSz8.Add(self.radiotime, 1, 0, 5)
         self.radioclick = wx.RadioButton(self, -1, "Hide by click")
         horSz8.Add(self.radioclick, 1, 0, 5)
-        
+
         horSz9 = wx.BoxSizer(wx.HORIZONTAL)
         mainSz.Add(horSz9, 1, wx.EXPAND | wx.ALL, 5)
         goButton = wx.Button(self, -1, "Show ToasterBox!")
@@ -182,9 +182,9 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         goButton.Bind(wx.EVT_BUTTON, self.ButtonDown)
         fontbutton.Bind(wx.EVT_BUTTON, self.OnSelectFont)
         rb.Bind(wx.EVT_RADIOBOX, self.OnRadioBox)
-        
+
         self.curFont = self.GetFont()
-        
+
         self.SetAutoLayout(True)
         self.SetSizer(mainSz)
         self.Fit()
@@ -192,21 +192,21 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
 
 
     def SetColours(self, event):
-        
+
         cd = wx.ColourDialog(self)
         cd.ShowModal()
         colBg = cd.GetColourData().GetColour()
         colButton1 = event.GetEventObject()
-        colButton1.SetBackgroundColour(colBg)  
+        colButton1.SetBackgroundColour(colBg)
 
 
     def SetColours2(self, event):
-        
+
         cd = wx.ColourDialog(self)
         cd.ShowModal()
         colFg = cd.GetColourData().GetColour()
         colButton2 = event.GetEventObject()
-        colButton2.SetBackgroundColour(colFg)  
+        colButton2.SetBackgroundColour(colFg)
 
 
     def OnSelectFont(self, event):
@@ -217,9 +217,9 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         data.EnableEffects(True)
         data.SetColour(curClr)
         data.SetInitialFont(curFont)
-        
+
         dlg = wx.FontDialog(self, data)
-        
+
         if dlg.ShowModal() == wx.ID_OK:
             data = dlg.GetFontData()
             font = data.GetChosenFont()
@@ -228,22 +228,22 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
             self.curFont = font
             self.curClr = colour
 
-        dlg.Destroy()        
-    
+        dlg.Destroy()
+
 
     def OnRadioBox(self, event):
 
         mainsizer = self.GetSizer()
-        
+
         if event.GetInt() == 0:
             self.linger.SetValue("4000")
             self.scrollspeed.SetValue("8")
-            
-            for ii in xrange(5, 10):
+
+            for ii in range(5, 10):
                 mainsizer.Show(ii, True)
-                        
+
         else:
-            for ii in xrange(5, 10):
+            for ii in range(5, 10):
                 mainsizer.Show(ii, False)
 
             self.linger.SetValue("10000")
@@ -251,9 +251,9 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
 
         mainsizer.Layout()
         self.Refresh()
-        
+
         event.Skip()
-        
+
 
     def OnCheckCaption(self, event):
 
@@ -268,7 +268,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
 
         self.sizex.Refresh()
         self.sizey.Refresh()
-        
+
 
     def ButtonDown(self, event):
 
@@ -279,7 +279,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
             windowstyle = TB.TB_CAPTION
         else:
             windowstyle = TB.TB_DEFAULT_STYLE
-        
+
         if demochoice == 1:
             tbstyle = TB.TB_COMPLEX
         else:
@@ -289,7 +289,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
             closingstyle = TB.TB_ONCLICK
         else:
             closingstyle = TB.TB_ONTIME
-            
+
         tb = TB.ToasterBox(self, tbstyle, windowstyle, closingstyle,
                            scrollType=TB.TB_SCR_TYPE_FADE
                            )
@@ -304,7 +304,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         posx = int(self.posx.GetValue())
         posy = int(self.posy.GetValue())
         tb.SetPopupPosition((posx, posy))
-        
+
         tb.SetPopupPauseTime(int(self.linger.GetValue()))
         tb.SetPopupScrollSpeed(int(self.scrollspeed.GetValue()))
 
@@ -314,8 +314,8 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
 
         else:
 
-            self.RunComplexDemo(tb)            
-        
+            self.RunComplexDemo(tb)
+
         tb.Play()
 
 
@@ -325,7 +325,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         tb.SetPopupTextColour(self.colButton2.GetBackgroundColour())
         bmp = self.backimage.GetPath()
         dummybmp = wx.NullBitmap
-        
+
         if os.path.isfile(bmp):
             dummybmp = wx.Bitmap(bmp)
 
@@ -342,17 +342,17 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         else:
             if txtshown in [self.popupText1, self.popupText2]:
                 self.counter = 0
-                txtshown = self.popupText2             
-             
+                txtshown = self.popupText2
+
         tb.SetPopupText(txtshown)
         tb.SetPopupTextFont(self.curFont)
-            
+
 
     def RunComplexDemo(self, tb):
 
         # This Is The New Call Style: The Call To GetToasterBoxWindow()
         # Is Mandatory, In Order To Create A Custom Parent On ToasterBox.
-        
+
         tbpanel = tb.GetToasterBoxWindow()
         panel = wx.Panel(tbpanel, -1)
 
@@ -371,7 +371,7 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
         hl = hyperlink.HyperLinkCtrl(panel, -1, "My Home Page",
                                      URL="http://xoomer.alice.it/infinity77/")
 
-        sizer.Add((0,5))        
+        sizer.Add((0,5))
         sizer.Add(horsizer1, 0, wx.EXPAND)
 
         horsizer2 = wx.BoxSizer(wx.HORIZONTAL)
@@ -381,18 +381,18 @@ class ToasterBoxDemo(scrolled.ScrolledPanel):
 
         tk = Ticker(panel)
         tk.SetText("Hello From wxPython!")
-        
+
         horsizer3 = wx.BoxSizer(wx.HORIZONTAL)
         horsizer3.Add((5, 0))
         horsizer3.Add(tk, 1, wx.EXPAND | wx.TOP, 10)
         horsizer3.Add((5,0))
         sizer.Add(horsizer3, 0, wx.EXPAND)
-        
+
         panel.SetSizer(sizer)
         panel.Layout()
-        
+
         tb.AddPanel(panel)
-        
+
 
 #----------------------------------------------------------------------
 


### PR DESCRIPTION
A few minor tweeks to the demos package:

Changed xrange to range in RawBitmapAccess and BitmapFromBuffer : Python 3 does not have an xrange member - all ranges are generators
Addressed iteritems & sys.maxint in ListCtrl_edit and CheckListCtrlMixin: items() replaces iteritems() and sys.maxint does not exist
Modified Treebook and Toolbook to use next(imageIdGenerator) rather than imageIdGenerator.next(): Python3 does not have an automatic .next member
Modified Validator to use string.ascii_letters rather than string.letters: string.letters does not exist in python3.

_Tested with Python 3.5.1 (v3.5.1:37a07cee5969, Dec  6 2015, 01:38:48) [MSC v.1900 32 bit (Intel)] on win32_