### PR TITLE
Fix stc compilation under SIP 4.18

### DIFF
--- a/etg/_stc.py
+++ b/etg/_stc.py
@@ -65,6 +65,7 @@ def run():
     
     c = module.find('wxStyledTextCtrl')
     assert isinstance(c, etgtools.ClassDef)
+    c.bases = ['wxControl']  # wxTextCtrlIface is also a base...
     c.piBases = ['wx.Control', 'wx.TextEntry']
     tools.fixWindowClass(c, False)
     module.addGlobalStr('wxSTCNameStr', c)
@@ -127,6 +128,34 @@ def run():
     # Generate the code for this differently because it needs to be
     # forcibly mashed into an int in the C code
     module.find('wxSTC_MASK_FOLDERS').forcedInt = True
+
+
+    # Make sure that all the methods from wxTextEntry and wxTextCtrl are
+    # included. This is needed because we are pretending that this class only
+    # derives from wxControl but the real C++ class also derives from
+    # wxTextCtrlIface which derives from wxTextEntryBase.
+    import textentry
+    mod = textentry.parseAndTweakModule()
+    klass = mod.find('wxTextEntry')
+    items = [item for item in klass.items if isinstance(item, etgtools.MethodDef) and
+                                             not item.isCtor and
+                                             not item.isDtor and
+                                             not c.findItem(item.name)]
+    c.items.extend(items)
+
+    import textctrl
+    mod = textctrl.parseAndTweakModule()
+    klass = mod.find('wxTextCtrl')
+    items = [item for item in klass.items if isinstance(item, etgtools.MethodDef) and
+                                             not item.isCtor and
+                                             not item.isDtor and
+                                             not c.findItem(item.name)]
+    c.items.extend(items)
+
+    c.find('EmulateKeyPress').ignore()
+    c.find('IsMultiLine').ignore()
+    c.find('IsSingleLine').ignore()
+
 
     # TODO:  Add the UTF8 PyMethods from classic (see _stc_utf8_methods.py)
     

--- a/unittests/test_stc.py
+++ b/unittests/test_stc.py
@@ -222,6 +222,27 @@ class stc_Tests(wtc.WidgetTestCase):
         stc.EVT_STC_INDICATOR_RELEASE
         stc.EVT_STC_AUTOCOMP_CANCELLED
         stc.EVT_STC_AUTOCOMP_CHAR_DELETED
+
+
+    def test_stcHasTextCtrlMethods(self):
+        # Just ensure that the common TextCtrl methods are present. This is
+        # done because the C++ class either derives from wxTextEntryBase
+        # or from wxTextCtrlIface, but these classes are not part of the API
+        # (and thus are not wrapped), so we have to kludge things.
+        # See etg/_stc.py for details.
+
+        t = stc.StyledTextCtrl(self.frame)
+        t.Cut
+        t.CanCut
+        t.DiscardEdits
+        t.GetDefaultStyle
+        t.GetNumberOfLines
+        t.GetStyle
+        t.IsModified
+        t.HitTest
+        t.AppendText
+        t.WriteText
+        t.ChangeValue
         
         
         


### PR DESCRIPTION
The stc code doesn't compile under SIP 4.18.  This appears to be due to changes
in the cast_xyz function generation, but it exposed a problem in the Phoenix
implementation.  The wx interface headers say that wxStyledTextCtrl inherits
from wxTextEntry, but it actually inherits from wxTextCtrlIface.  This now
(probably rightly so) doesn't compile with SIP 4.18.  The solution is to
essentially copy the methods from wxTextEntry and wxTextCtrl, as is done for
wxSearchCtrl and wxRichTextCtrl.