### PR TITLE
Workaround multiple inheritance bug in SIP 4.18 with vscroll

### DIFF
--- a/build.py
+++ b/build.py
@@ -1033,6 +1033,12 @@ def cmd_sip(options, args):
                     # ...or totally remove them by replacing those lines with ''
                     import re
                     srcTxt = re.sub(r'^#line.*\n', '', srcTxt, flags=re.MULTILINE)
+                if os.path.basename(src) == 'sip_corewxHVScrolledWindow.cpp' or \
+                   os.path.basename(src) == 'sip_corewxVarHVScrollHelper.cpp':
+                    import re
+                    srcTxt = re.sub(r'if \(targetType == sipType_wxVarScrollHelperBase\)'
+                                    '\s+return static_cast<wxVarScrollHelperBase \*>\(sipCpp\);',
+                                    '', srcTxt)
             return srcTxt
         
         # Check each file in tmpdir to see if it is different than the same file


### PR DESCRIPTION
In SIP 4.18, the cast_xyz function generation has been changed, but a bug was
introduced where it attempts to cast a subclass to a multiply inherited
superclass.  This doesn't compile due to ambiguity, so workaround the problem
by deleting the extra casts in the generated code.
