### PR TITLE
[WIP] Additional Refactoring of lib.plot [Part 3: other changes]

### DIFF
--- a/unittests/test_lib_plot.py
+++ b/unittests/test_lib_plot.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import unittest
+import wtc
+import wx
+
+import wx.lib.plot as wxplot
+
+#---------------------------------------------------------------------------
+
+class lib_plot_PlotCanvas_Tests(wtc.WidgetTestCase):
+
+    def test_lib_plot_plotcanvasCtor(self):
+        """ Ctor? """
+        p = wxplot.PlotCanvas(self.frame)
+
+
+class lib_plot_Tests(wtc.WidgetTestCase):
+    def test_lib_plot_tempstyle_contextmanager(self):
+        pass
+
+    def test_lib_plot_tempstyle_decorator(self):
+        pass
+
+#---------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    unittest.main()

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -497,7 +497,7 @@ class PendingDeprecation(object):
         `old_func` is pending deprecation. Please use new_func instead.
 
     """
-    _warn_txt = "`{}` is pending deprecation. Please use {} instead."
+    _warn_txt = "`{}` is pending deprecation. Please use `{}` instead."
 
     def __init__(self, new_func):
         self.new_func = new_func
@@ -706,13 +706,11 @@ class PolyPoints(object):
                                                     # TODO: get rid of the
                                                     # need for copy
 
-        # TODO: I can make this better... move logic to self._log10
         # work on X:
         if self.AbsScale[0]:
-            data[:, 0] = np.abs(data[:, 0])
+            data = self._abs(data, 0)
         if self.LogScale[0]:
-            data = np.compress(data[:, 0] > 0, data, 0)
-            data[:, 0] = np.log10(data[:, 0])
+            data = self._log10(data, 0)
 
         if self.SymLogScale[0]:
             # TODO: implement SymLogScale
@@ -723,10 +721,9 @@ class PolyPoints(object):
 
         # work on Y:
         if self.AbsScale[1]:
-            data[:, 1] = np.abs(data[:, 1])
+            data = self._abs(data, 1)
         if self.LogScale[1]:
-            data = np.compress(data[:, 1] > 0, data, 0)
-            data[:, 1] = np.log10(data[:, 1])
+            data = self._log10(data, 1)
 
         if self.SymLogScale[1]:
             # TODO: implement SymLogScale
@@ -742,6 +739,11 @@ class PolyPoints(object):
         """ Take the Log10 of the data, dropping any negative values """
         data = np.compress(data[:, index] > 0, data, 0)
         data[:, index] = np.log10(data[:, index])
+        return data
+
+    def _abs(self, data, index):
+        """ Take the Abs of the data """
+        data[:, index] = np.abs(data[:, index])
         return data
 
     def boundingBox(self):
@@ -2178,7 +2180,7 @@ class PlotCanvas(wx.Panel):
         frame.Centre(wx.BOTH)
         frame.Show(True)
 
-    @PendingDeprecation("self.LogScale")
+    @PendingDeprecation("self.LogScale property")
     def setLogScale(self, logscale):
         self.LogScale = logscale
 

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -198,36 +198,36 @@ class TempStyle(object):
     Combination Decorator and Context Manager to revert pen or brush changes
     after a method call or block finish.
 
-    **Note: Can only be used on class methods.**
+    :param which: The item to save and revert after execution. Can be
+                  one of ``{'both', 'pen', 'brush'}``.
+    :type which: str
+    :param dc: The DC to get brush/pen info from.
+    :type dc: :class:`wx.DC`
 
-    Parameters:
-    -----------
-    which : {'both', 'pen', 'brush'}
-        The item to save and revert after execution.
-    dc : wx.DC object
-        The DC to pull brush/pen information from.
+    ::
 
-    Usage:
-    ------
-    As a method decorator::
-
+        # Using as a method decorator:
         @TempStyle()                        # same as @TempStyle('both')
         def func(self, dc, a, b, c):        # dc must be 1st arg (beside self)
             # edit pen and brush here
 
-    As a context manager::
-
+        # Or as a context manager:
         with TempStyle('both', dc):
             # do stuff
 
-    Notes:
-    ------
-    As of 2016-06-15, this can only be used as a decorator for **class
-    methods**, not standard functions. There is a plan to try and remove
-    this restriction, but I don't know when that will happen...
+    .. Note::
 
-    Combination Decorator and Context Manager! Also makes Julienne fries!
-    Will not break! Will not... It broke!
+       As of 2016-06-15, this can only be used as a decorator for **class
+       methods**, not standard functions. There is a plan to try and remove
+       this restriction, but I don't know when that will happen...
+
+
+    .. epigraph::
+
+       *Combination Decorator and Context Manager! Also makes Julienne fries!
+       Will not break! Will not... It broke!*
+
+       -- The Genie
     """
     _valid_types = {'both', 'pen', 'brush'}
     _err_str = (

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -190,7 +190,7 @@ except:
     binaries."""
     raise ImportError("NumPy not found.\n" + msg)
 
-# XXX: Comment out this line to disable depreciation warnings
+# XXX: Comment out this line to disable deprecation warnings
 warnings.simplefilter('default')
 
 
@@ -4118,13 +4118,10 @@ Hand = PyEmbeddedImage(
     "FmWQp/JJDXeRh2TXcJa91zAH2uN2mvXFsrIrsjS8rnftWmWfAiLIStuD9m9h9belvzgS/1fP"
     "X7075IwDENteAAAAAElFTkSuQmCC")
 
-#---------------------------------------------------------------------------
-# if running standalone...
-#
-#     ...a sample implementation using the above
-#
 
-
+### -------------------------------------------------------------------------
+### Examples and Demo Frame
+### -------------------------------------------------------------------------
 def _draw1Objects():
     """Sin, Cos, and Points"""
     # 100 points sin function, plotted as green circles
@@ -4158,8 +4155,9 @@ def _draw1Objects():
                           colour='blue',
                           marker='cross',
                           )
+    line2 = PolyLine(pts, drawstyle='steps-post')
 
-    return PlotGraphics([markers1, lines, markers3, markers2],
+    return PlotGraphics([markers1, lines, markers3, markers2, line2],
                         "Graph Title",
                         "X Axis",
                         "Y Axis")

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -542,7 +542,6 @@ class _DisplaySide(object):
     valid_names = ("bottom", "left", "right", "top")
 
     def __init__(self, bottom, left, top, right):
-        # make sure that everything is boolean
         if not all([isinstance(x, bool) for x in [bottom, left, top, right]]):
             raise TypeError("All args must be bools")
         self.bottom = bottom
@@ -608,12 +607,13 @@ class PolyPoints(object):
     """
     Base Class for lines and markers.
 
-    All methods are private.
-
     :param points: The points to plot
     :type points: list of ``(x, y)`` pairs
     :param attr: Additional attributes
     :type attr: dict
+
+    .. warning::
+       All methods are private.
     """
 
     def __init__(self, points, attr):
@@ -905,9 +905,42 @@ class PolyPoints(object):
 
 class PolyLine(PolyPoints):
     """
-    Class to define line type and style
+    Creates PolyLine object
 
-    All methods except ``__init__`` are private.
+    :param points: The points that make up the line
+    :type points: list of ``[x, y]`` values
+    :param **attr: keyword attributes
+
+    ===========================  =============  ====================
+    Keyword and Default          Description    Type
+    ===========================  =============  ====================
+    ``colour='black'``           Line color     :class:`wx.Colour`
+    ``width=1``                  Line width     float
+    ``style=wx.PENSTYLE_SOLID``  Line style     :class:`wx.PenStyle`
+    ``legend=''``                Legend string  str
+    ``drawstyle='line'``         see below      str
+    ===========================  =============  ====================
+
+    ==================  ==================================================
+    Draw style          Description
+    ==================  ==================================================
+    ``'line'``          Draws an straight line between consecutive points
+    ``'steps-pre'``     Draws a line down from point A and then right to
+                        point B
+    ``'steps-post'``    Draws a line right from point A and then down
+                        to point B
+    ``'steps-mid-x'``   Draws a line horizontally to half way between A
+                        and B, then draws a line vertically, then again
+                        horizontally to point B.
+    ``'steps-mid-y'``   Draws a line vertically to half way between A
+                        and B, then draws a line horizonatally, then
+                        again vertically to point B.
+                        *Note: This typically does not look very good*
+    ==================  ==================================================
+
+    .. warning::
+
+       All methods except ``__init__`` are private.
     """
 
     _attributes = {'colour': 'black',
@@ -920,40 +953,6 @@ class PolyLine(PolyPoints):
                    "steps-mid-x", "steps-mid-y")
 
     def __init__(self, points, **attr):
-        """
-        Creates PolyLine object
-
-        :param points: The points that make up the line
-        :type points: list of ``[x, y]`` values
-        :param **attr: keyword attributes
-
-        ===========================  =============  ====================
-        Keyword and Default          Description    Type
-        ===========================  =============  ====================
-        ``colour='black'``           Line color     :class:`wx.Colour`
-        ``width=1``                  Line width     float
-        ``style=wx.PENSTYLE_SOLID``  Line style     :class:`wx.PenStyle`
-        ``legend=''``                Legend string  str
-        ``drawstyle='line'``         see below      str
-        ===========================  =============  ====================
-
-        ==================  ==================================================
-        Draw style          Description
-        ==================  ==================================================
-        ``'line'``          Draws an straight line between consecutive points
-        ``'steps-pre'``     Draws a line down from point A and then right to
-                            point B
-        ``'steps-post'``    Draws a line right from point A and then down
-                            to point B
-        ``'steps-mid-x'``   Draws a line horizontally to half way between A
-                            and B, then draws a line vertically, then again
-                            horizontally to point B.
-        ``'steps-mid-y'``   Draws a line vertically to half way between A
-                            and B, then draws a line horizonatally, then
-                            again vertically to point B.
-                            *Note: This typically does not look very good*
-        ==================  ==================================================
-        """
         PolyPoints.__init__(self, points, attr)
 
     def draw(self, dc, printerScale, coord=None):
@@ -1040,9 +1039,24 @@ class PolyLine(PolyPoints):
 
 class PolySpline(PolyLine):
     """
-    Class to define line type and style.
+    Creates PolySpline object
 
-    All methods except ``__init__`` are private.
+    :param points: The points that make up the spline
+    :type points: list of ``[x, y]`` values
+    :param **attr: keyword attributes
+
+    ===========================  =============  ====================
+    Keyword and Default          Description    Type
+    ===========================  =============  ====================
+    ``colour='black'``           Line color     :class:`wx.Colour`
+    ``width=1``                  Line width     float
+    ``style=wx.PENSTYLE_SOLID``  Line style     :class:`wx.PenStyle`
+    ``legend=''``                Legend string  str
+    ===========================  =============  ====================
+
+    .. warning::
+
+       All methods except ``__init__`` are private.
     """
 
     _attributes = {'colour': 'black',
@@ -1051,21 +1065,6 @@ class PolySpline(PolyLine):
                    'legend': ''}
 
     def __init__(self, points, **attr):
-        """
-        Creates PolyLine object
-
-        :param `points`: sequence (array, tuple or list) of (x,y) points
-                         making up spline
-        :keyword `attr`: keyword attributes, default to:
-
-         ==========================  ================================
-         'colour'= 'black'           wx.Pen Colour any wx.Colour
-         'width'= 1                  Pen width
-         'style'= wx.PENSTYLE_SOLID  wx.Pen style
-         'legend'= ''                Line Legend to display
-         ==========================  ================================
-
-        """
         PolyLine.__init__(self, points, **attr)
 
     def draw(self, dc, printerScale, coord=None):
@@ -1087,9 +1086,40 @@ class PolySpline(PolyLine):
 
 class PolyMarker(PolyPoints):
     """
-    Class to define marker type and style
+    Creates a PolyMarker object.
 
-    All methods except __init__ are private.
+    :param points: The marker coordinates.
+    :type points: list of ``[x, y]`` values
+    :param **attr: keyword attributes
+
+    =================================  =============  ====================
+    Keyword and Default                Description    Type
+    =================================  =============  ====================
+    ``marker='circle'``                see below      str
+    ``size=2``                         Marker size    float
+    ``colour='black'``                 Outline color  :class:`wx.Colour`
+    ``width=1``                        Outline width  float
+    ``style=wx.PENSTYLE_SOLID``        Outline style  :class:`wx.PenStyle`
+    ``fillcolour=colour``              fill color     :class:`wx.Colour`
+    ``fillstyle=wx.BRUSHSTYLE_SOLID``  fill style     :class:`wx.BrushStyle`
+    ``legend=''``                      Legend string  str
+    =================================  =============  ====================
+
+    ===================  ==================================
+    Marker               Description
+    ===================  ==================================
+    ``'circle'``         A circle of diameter ``size``
+    ``'dot'``            A dot. Does not have a size.
+    ``'square'``         A square with side length ``size``
+    ``'triangle'``       An upward-pointed triangle
+    ``'triangle_down'``  A downward-pointed triangle
+    ``'cross'``          An "X" shape
+    ``'plus'``           A "+" shape
+    ===================  ==================================
+
+    .. warning::
+
+       All methods except ``__init__`` are private.
     """
     _attributes = {'colour': 'black',
                    'width': 1,
@@ -1100,34 +1130,7 @@ class PolyMarker(PolyPoints):
                    'legend': ''}
 
     def __init__(self, points, **attr):
-        """
-        Creates PolyMarker object
 
-        :param `points`: sequence (array, tuple or list) of (x,y) points
-        :keyword `attr`: keyword attributes, default to:
-
-         ================================ ================================
-         'colour'= 'black'                wx.Pen Colour any wx.Colour
-         'width'= 1                       Pen width
-         'size'= 2                        Marker size
-         'fillcolour'= same as colour     wx.Brush Colour any wx.Colour
-         'fillstyle'= wx.BRUSHSTYLE_SOLID wx.Brush fill style (use
-                                          wx.BRUSHSTYLE_TRANSPARENT for
-                                          no fill)
-         'style'= wx.FONTFAMILY_SOLID     wx.Pen style
-         'marker'= 'circle'               Marker shape
-         'legend'= ''                     Line Legend to display
-         ================================ ================================
-
-         Marker Shapes:
-         - 'circle'
-         - 'dot'
-         - 'square'
-         - 'triangle'
-         - 'triangle_down'
-         - 'cross'
-         - 'plus'
-        """
 
         PolyPoints.__init__(self, points, attr)
 
@@ -1213,6 +1216,11 @@ class PolyMarker(PolyPoints):
 
 class PolyBarsBase(PolyPoints):
     """
+    Base class for PolyBars and PolyHistogram.
+
+    .. warning::
+
+       All methods are private.
     """
     _attributes = {'edgecolour': 'black',
                    'edgewidth': 2,
@@ -1279,30 +1287,36 @@ class PolyBarsBase(PolyPoints):
 
 class PolyBars(PolyBarsBase):
     """
-    Bar Chart.
+    Creates a PolyBars object.
+
+    :param points: The data to plot.
+    :type points: sequence of ``(center, height)`` points
+    :param **attr: keyword attributes
+
+    =================================  =============  =======================
+    Keyword and Default                Description    Type
+    =================================  =============  =======================
+    ``barwidth=1.0``                   bar width      float or list of floats
+    ``edgecolour='black'``             edge color     :class:`wx.Colour`
+    ``edgewidth=1``                    edge width     float
+    ``edgestyle=wx.PENSTYLE_SOLID``    edge style     :class:`wx.PenStyle`
+    ``fillcolour='red'``               fill color     :class:`wx.Colour`
+    ``fillstyle=wx.BRUSHSTYLE_SOLID``  fill style     :class:`wx.BrushStyle`
+    ``legend=''``                      legend string  str
+    =================================  =============  =======================
+
+    .. important::
+
+       If ``barwidth`` is a list of floats:
+
+       + each bar will have a separate width
+       + ``len(barwidth)`` must equal ``len(points)``.
+
+    .. warning::
+
+       All methods except ``__init__`` are private.
     """
     def __init__(self, points, **attr):
-        """
-        Creates PolyBars object
-
-        :param `points`: sequence (array, tuple or list) of (x, y) points
-                         that define the bar.
-                         x: the centerline of the bar.
-                         y: the value of the bar (from y=0)
-        :keyword `attr`: keyword attributes, default to:
-
-         =================================  ================================
-         'edgecolour' = 'black'             wx.Pen Colour: any wx.Colour
-         'edgewidth' = 1                    wx.Pen width
-         'edgestyle' = wx.PENSTYLE_SOLID    wx.Pen style
-         'legend' = ''                      Line Legend to display
-         'fillcolour' = 'red'               wx.Brush fill color: any wx.Colour
-         'fillstyle' = wx.BRUSHSTYLE_SOLID  The fill style for the rectangle
-         'barwidth' = 1.0                   The bar width. If a list of
-                                            values, len(barwidth) must
-                                            equal len(points).
-         =================================  ================================
-        """
         PolyBarsBase.__init__(self, points, attr)
 
     def calc_rect(self, x, y, w):
@@ -1341,35 +1355,41 @@ class PolyBars(PolyBarsBase):
 
 class PolyHistogram(PolyBarsBase):
     """
-    Histogram
+    Creates a PolyHistogram object.
 
-    Special PolyBarsBase where the bars span the binspec.
+    :param hist: The histogram data.
+    :type hist: sequence of ``y`` values that define the heights of the bars
+    :param binspec: The bin specification.
+    :type binspec: sequence of ``x`` values that define the edges of the bins
+    :param **attr: keyword attributes
 
+    =================================  =============  =======================
+    Keyword and Default                Description    Type
+    =================================  =============  =======================
+    ``edgecolour='black'``             edge color     :class:`wx.Colour`
+    ``edgewidth=3``                    edge width     float
+    ``edgestyle=wx.PENSTYLE_SOLID``    edge style     :class:`wx.PenStyle`
+    ``fillcolour='blue'``              fill color     :class:`wx.Colour`
+    ``fillstyle=wx.BRUSHSTYLE_SOLID``  fill style     :class:`wx.BrushStyle`
+    ``legend=''``                      legend string  str
+    =================================  =============  =======================
 
+    .. tip::
+
+       Use ``np.histogram()`` to easily create your histogram parameters::
+
+         hist_data, binspec = np.histogram(data)
+         hist_plot = PolyHistogram(hist_data, binspec)
+
+    .. important::
+
+       ``len(binspec)`` must equal ``len(hist) + 1``.
+
+    .. warning::
+
+       All methods except ``__init__`` are private.
     """
     def __init__(self, hist, binspec, **attr):
-        """
-        Creates PolyHistogram object
-
-        :param `hist`: sequence (array, tuple or list) of y values
-                       that define the heights of the bars (same as 1st
-                       returned parameter from ``np.histogram(data)``).
-        :param `binspec`: sequence of x values that define the edges of the
-                          bins (same as 2nd returned parameter from
-                          ``np.histogram(data)``).
-                          len(binspec) must equal len(hist) + 1
-        :keyword `attr`: keyword attributes, default to:
-
-         =================================  ================================
-         'edgecolour' = 'black'             wx.Pen Colour: any wx.Colour
-         'edgewidth' = 3                    wx.Pen width
-         'edgestyle' = wx.PENSTYLE_SOLID    wx.Pen style
-         'legend' = ''                      Line Legend to display
-         'fillcolour' = 'blue'              wx.Brush fill color: any wx.Colour
-         'fillstyle' = wx.BRUSHSTYLE_SOLID  The fill style for the rectangle
-         =================================  ================================
-
-        """
         if len(binspec) != len(hist) + 1:
             raise ValueError("Len(binspec) must equal len(hist) + 1")
 
@@ -1412,41 +1432,53 @@ class PolyHistogram(PolyBarsBase):
 
 class BoxPlot(PolyPoints):
     """
-    Class to contain box plots
+    Creates a BoxPlot object.
 
-    This class takes care of calculating the box plots.
+    :param data: Raw data to create a box plot from.
+    :type data: sequence of int or float
+    :param **attr: keyword attributes
 
-    TODO:
-    -----
-    + [x] Separate out each draw into individual methods
-    + [x] Fix the median line extending outside of the box on the right
-    + [x] Allow for multiple box plots side-by-side
-          - It's a hack, but it works.
-    + [ ] change the X axis to some labels.
-    + [x] Add getLegend method
-          - Not Needed since we inherit from PolyPoints
-    + [x] Add getClosestPoint method - links to box plot or outliers
-          - Current method works and hits every point. Is that good enough?
-    + [ ] Add customization
-          - [ ] Pens and Fills for elements
-          - [ ] outlier shapes(?) and sizes
-          - [ ] box width
-    + [ ] Get log-y working
+    =================================  =============  =======================
+    Keyword and Default                Description    Type
+    =================================  =============  =======================
+    ``colour='black'``                 edge color     :class:`wx.Colour`
+    ``width=1``                        edge width     float
+    ``style=wx.PENSTYLE_SOLID``        edge style     :class:`wx.PenStyle`
+    ``legend=''``                      legend string  str
+    =================================  =============  =======================
 
+    .. admonition:: TODO
+
+       + [x] Separate out each draw into individual methods
+       + [x] Fix the median line extending outside of the box on the right
+       + [x] Allow for multiple box plots side-by-side
+
+         - It's a hack, but it works.
+
+       + [ ] change the X axis to some labels.
+       + [x] Add getLegend method
+
+         - Not Needed since we inherit from PolyPoints
+
+       + [x] Add getClosestPoint method - links to box plot or outliers
+
+         - Current method works and hits every point. Is that good enough?
+
+       + [ ] Add customization
+
+         - [ ] Pens and Fills for elements
+         - [ ] outlier shapes(?) and sizes
+         - [ ] box width
+
+       + [ ] Get log-y working
     """
     _attributes = {'colour': 'black',
                    'width': 1,
                    'style': wx.PENSTYLE_SOLID,
                    'legend': '',
-                   'drawstyle': 'line',
-                   'size': 5,
                    }
 
     def __init__(self, points, **attr):
-        """
-        :param data: 1D data to plot.
-
-        """
         # Set various attributes
         self.box_width = 0.5
 
@@ -1740,18 +1772,22 @@ class BoxPlot(PolyPoints):
 
 class PlotGraphics(object):
     """
-    Container to hold PolyXXX objects and graph labels
+    Creates a PlotGraphics object.
 
-    All methods except __init__ are private.
+    :param objects: The Poly objects to plot.
+    :type objects: list of :class:`~wx.lib.plot.PolyPoints` objects
+    :param title: The title shown at the top of the graph.
+    :type title: str
+    :param xLabel: The x-axis label.
+    :type xLabel: str
+    :param yLabel: The y-axis label.
+    :type yLabel: str
+
+    .. warning::
+
+       All methods except ``__init__`` are private.
     """
-
     def __init__(self, objects, title='', xLabel='', yLabel=''):
-        """Creates PlotGraphics object
-        objects - list of PolyXXX objects to make graph
-        title - title shown at top of graph
-        xLabel - label shown on x-axis
-        yLabel - label shown on y-axis
-        """
         if type(objects) not in [list, tuple]:
             raise TypeError("objects argument should be list or tuple")
         self.objects = objects
@@ -1783,6 +1819,14 @@ class PlotGraphics(object):
 
     @PendingDeprecation("self.LogScale property")
     def setLogScale(self, logscale):
+        """
+        Set the log scale boolean value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotGraphics.LogScale` property
+           instead.
+        """
         self.LogScale = logscale
 
     @property
@@ -1815,37 +1859,86 @@ class PlotGraphics(object):
 
     @PendingDeprecation("self.PrinterScale property")
     def setPrinterScale(self, scale):
-        """Thickens up lines and markers only for printing"""
+        """
+        Thickens up lines and markers only for printing
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotGraphics.PrinterScale` property
+           instead.
+        """
         self.PrinterScale = scale
 
     @PendingDeprecation("self.XLabel property")
     def setXLabel(self, xLabel=''):
-        """Set the X axis label on the graph"""
+        """
+        Set the X axis label on the graph
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotGraphics.XLabel` property
+           instead.
+       """
         self.XLabel = xLabel
 
     @PendingDeprecation("self.YLabel property")
     def setYLabel(self, yLabel=''):
-        """Set the Y axis label on the graph"""
+        """
+        Set the Y axis label on the graph
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotGraphics.YLabel` property
+           instead.
+       """
         self.YLabel = yLabel
 
     @PendingDeprecation("self.Title property")
     def setTitle(self, title=''):
-        """Set the title at the top of graph"""
+        """
+        Set the title at the top of graph
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotGraphics.Title` property
+           instead.
+        """
         self.Title = title
 
     @PendingDeprecation("self.XLabel property")
     def getXLabel(self):
-        """Get x axis label string"""
+        """
+        Get X axis label string
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotGraphics.XLabel` property
+           instead.
+        """
         return self.XLabel
 
     @PendingDeprecation("self.YLabel property")
     def getYLabel(self):
-        """Get y axis label string"""
+        """
+        Get Y axis label string
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotGraphics.YLabel` property
+           instead.
+        """
         return self.YLabel
 
     @PendingDeprecation("self.Title property")
     def getTitle(self, title=''):
-        """Get the title at the top of graph"""
+        """
+        Get the title at the top of graph
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotGraphics.Title` property
+           instead.
+        """
         return self.Title
 
     @property
@@ -1977,17 +2070,20 @@ def _set_displayside(value):
 
 class PlotCanvas(wx.Panel):
     """
+    Creates a PlotCanvas object.
+
     Subclass of a wx.Panel which holds two scrollbars and the actual
     plotting canvas (self.canvas). It allows for simple general plotting
     of data with zoom, labels, and automatic axis scaling.
 
+    This is the main window that you will want to import into your
+    application.
+
+    Parameters for ``__init__`` are the same as any :class:`wx.Panel`.
     """
 
     def __init__(self, parent, id=wx.ID_ANY, pos=wx.DefaultPosition,
                  size=wx.DefaultSize, style=0, name="plotCanvas"):
-        """Constructs a panel, which can be a child of a frame or
-        any other non-control window"""
-
         wx.Panel.__init__(self, parent, id, pos, size, style, name)
 
         sizer = wx.FlexGridSizer(2, 2, 0, 0)
@@ -2397,7 +2493,7 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.LogScale property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.LogScale` property instead.
         """
         self.LogScale = logscale
 
@@ -2408,7 +2504,7 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.LogScale property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.LogScale` property instead.
         """
         return self.LogScale
 
@@ -2473,7 +2569,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.FontSizeAxis property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeAxis` property
+           instead.
         """
         self.FontSizeAxis = point
 
@@ -2484,7 +2581,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.FontSizeAxis property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeAxis` property
+           instead.
         """
         return self.FontSizeAxis
 
@@ -2512,7 +2610,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.FontSizeTitle property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeTitle` property
+           instead.
         """
         self.FontSizeTitle = point
 
@@ -2523,7 +2622,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.FontSizeTitle property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeTitle` property
+           instead.
         """
         return self.FontSizeTitle
 
@@ -2551,7 +2651,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.FontSizeLegend property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeLegend' property
+           instead.
         """
         self.FontSizeLegend = point
 
@@ -2561,7 +2662,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.FontSizeLegend property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeLegend' property
+           instead.
         """
         return self.FontSizeLegend
 
@@ -2589,7 +2691,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.ShowScrollbars property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.ShowScrollbars` property
+           instead.
         """
         self.ShowScrollbars = value
 
@@ -2600,7 +2703,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.ShowScrollbars property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.ShowScrollbars` property
+           instead.
         """
         return self.ShowScrollbars
 
@@ -2635,7 +2739,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.UseScientificNotation property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.UseScientificNotation`
+           property instead.
         """
         self.UseScientificNotation = useScientificNotation
 
@@ -2646,7 +2751,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.UseScientificNotation property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.UseScientificNotation`
+           property instead.
         """
         return self.UseScientificNotation
 
@@ -2675,7 +2781,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableAntiAliasing property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableAntiAliasing`
+           property instead.
         """
         self.EnableAntiAliasing = enableAntiAliasing
 
@@ -2686,7 +2793,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableAntiAliasing property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableAntiAliasing`
+           property instead.
         """
         return self.EnableAntiAliasing
 
@@ -2716,7 +2824,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableHiRes property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableHiRes` property
+           instead.
         """
         self.EnableHiRes = enableHiRes
 
@@ -2727,7 +2836,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableHiRes property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableHiRes` property
+           instead.
         """
         return self._hiResEnabled
 
@@ -2757,7 +2867,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableDrag property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableDrag` property
+           instead.
         """
         self.EnableDrag = value
 
@@ -2768,7 +2879,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableDrag property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableDrag` property
+           instead.
         """
         return self.EnableDrag
 
@@ -2811,7 +2923,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableZoom property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableZoom` property
+           instead.
         """
         self.EnableZoom = value
 
@@ -2822,7 +2935,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableZoom property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableZoom` property
+           instead.
         """
         return self.EnableZoom
 
@@ -2865,7 +2979,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableGrid property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableGrid` property
+           instead.
         """
         self.EnableGrid = value
 
@@ -2876,7 +2991,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableGrid property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableGrid` property
+           instead.
         """
         return self.EnableGrid
 
@@ -2918,7 +3034,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableCenterLines property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableCenterLines`
+           property instead.
         """
         self.EnableCenterLines = value
 
@@ -2929,7 +3046,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableCenterLines property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableCenterLines`
+           property instead.
         """
         return self.EnableCenterLines
 
@@ -2965,7 +3083,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableDiagonals property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableDiagonals`
+           property instead.
         """
         self.EnableDiagonals = value
 
@@ -2976,7 +3095,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableDiagonals property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableDiagonals`
+           property instead.
         """
         return self.EnableDiagonals
 
@@ -3017,7 +3137,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableLegend property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableLegend`
+           property instead.
         """
         self.EnableLegend = value
 
@@ -3028,7 +3149,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableLegend property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableLegend`
+           property instead.
         """
         return self.EnableLegend
 
@@ -3060,7 +3182,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableTitle property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableTitle` property
+           instead.
         """
         self.EnableTitle = value
 
@@ -3071,7 +3194,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnableTitle property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableTitle` property
+           instead.
         """
         return self.EnableTitle
 
@@ -3101,7 +3225,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnablePointLabel property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnablePointLabel`
+           property instead.
         """
         self.EnablePointLabel = value
 
@@ -3112,7 +3237,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnablePointLabel property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnablePointLabel`
+           property instead.
         """
         return self.EnablePointLabel
 
@@ -3298,7 +3424,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnablePointLabel property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnablePointLabel`
+           property instead.
         """
         self.PointLabelFunc = func
 
@@ -3309,7 +3436,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.EnablePointLabel property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.EnablePointLabel`
+           property instead.
         """
         return self.PointLabelFunc
 
@@ -3386,7 +3514,7 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.XSpec property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.XSpec` property instead.
         """
         self.XSpec = spectype
 
@@ -3397,7 +3525,7 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.YSpec property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.YSpec` property instead.
         """
         self.YSpec = spectype
 
@@ -3408,7 +3536,7 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.XSpec property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.XSpec` property instead.
         """
         return self.XSpec
 
@@ -3419,7 +3547,7 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the self.YSpec property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.YSpec` property instead.
         """
         return self.YSpec
 

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -923,38 +923,50 @@ class PolyLine(PolyPoints):
         """
         Creates PolyLine object
 
-        :param `points`: sequence (array, tuple or list) of (x,y) points
-                         making up line
-        :keyword `attr`: keyword attributes, default to:
+        :param points: The points that make up the line
+        :type points: list of ``[x, y]`` values
+        :param **attr: keyword attributes
 
-         ==========================  ================================
-         'colour'= 'black'           wx.Pen Colour any wx.Colour
-         'width'= 1                  Pen width
-         'style'= wx.PENSTYLE_SOLID  wx.Pen style
-         'legend'= ''                Line Legend to display
-         'drawstyle'= 'line'         How points are joined.
-         ==========================  ================================
+        ===========================  =============  ====================
+        Keyword and Default          Description    Type
+        ===========================  =============  ====================
+        ``colour='black'``           Line color     :class:`wx.Colour`
+        ``width=1``                  Line width     float
+        ``style=wx.PENSTYLE_SOLID``  Line style     :class:`wx.PenStyle`
+        ``legend=''``                Legend string  str
+        ``drawstyle='line'``         see below      str
+        ===========================  =============  ====================
 
-        Valid 'drawstyle' values are:
-
-            'line'          Draws an straight line between consecutive points
-            'steps-pre'     Draws a line down from point A and then right to
+        ==================  ==================================================
+        Draw style          Description
+        ==================  ==================================================
+        ``'line'``          Draws an straight line between consecutive points
+        ``'steps-pre'``     Draws a line down from point A and then right to
                             point B
-            'steps-post'    Draws a line right from point A and then down
+        ``'steps-post'``    Draws a line right from point A and then down
                             to point B
-            'steps-mid-x'   Draws a line right to half way between A and B,
-                            then draws a line vertically, then again right
-                            to point B.
-            'steps-mid-y'   Draws a line vertically to half way between A
+        ``'steps-mid-x'``   Draws a line horizontally to half way between A
+                            and B, then draws a line vertically, then again
+                            horizontally to point B.
+        ``'steps-mid-y'``   Draws a line vertically to half way between A
                             and B, then draws a line horizonatally, then
                             again vertically to point B.
                             *Note: This typically does not look very good*
-
+        ==================  ==================================================
         """
         PolyPoints.__init__(self, points, attr)
 
     def draw(self, dc, printerScale, coord=None):
-        """ Draw the lines """
+        """
+        Draw the lines.
+
+        :param dc: The DC to draw on.
+        :type dc: :class:`wx.DC`
+        :param printerScale:
+        :type printerScale: float
+        :param coord: The legend coordinate?
+        :type coord: ???
+        """
         colour = self.attributes['colour']
         width = self.attributes['width'] * printerScale * self._pointSize[0]
         style = self.attributes['style']
@@ -968,18 +980,34 @@ class PolyLine(PolyPoints):
         if coord is None:
             if len(self.scaled):  # bugfix for Mac OS X
                 for c1, c2 in zip(self.scaled, self.scaled[1:]):
-                    self.path(dc, c1, c2, drawstyle)
+                    self._path(dc, c1, c2, drawstyle)
         else:
             dc.DrawLines(coord)  # draw legend line
 
     def getSymExtent(self, printerScale):
-        """Width and Height of Marker"""
+        """
+        Get the Width and Height of the symbol.
+
+        :param printerScale:
+        :type printerScale: float
+        """
         h = self.attributes['width'] * printerScale * self._pointSize[0]
         w = 5 * h
         return (w, h)
 
-    def path(self, dc, coord1, coord2, drawstyle):
-        """ calculates the path from coord1 to coord 2 along X and Y """
+    def _path(self, dc, coord1, coord2, drawstyle):
+        """
+        Calculates the path from coord1 to coord 2 along X and Y
+
+        :param dc: The DC to draw on.
+        :type dc: :class:`wx.DC`
+        :param coord1: The first coordinate in the coord pair
+        :type coord1: list, length 2: ``[x, y]``
+        :param coord2: The second coordinate in the coord pair
+        :type coord2: list, length 2: ``[x, y]``
+        :param drawstyle: The type of connector to use
+        :type drawstyle: str
+        """
         if drawstyle == 'line':
             # Straight line between points.
             line = [coord1, coord2]

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -1812,6 +1812,25 @@ class PlotGraphics(object):
         return self.objects[item]
 
 
+def scale_and_shift_point(x, y, scale=1, shift=0):
+    """
+    Creates a scaled and shifted 2x1 numpy array of [x, y] values.
+
+    :param float `x`:        The x value of the unscaled, unshifted point
+    :param float `y`:        The y valye of the unscaled, unshifted point
+    :param np.array `scale`: The scale factor to use ``[x_sacle, y_scale]``
+    :param np.array `shift`: The offset to apply ``[x_shift, y_shift]``.
+                             Must be in scaled units
+
+    :returns np.array: a numpy array of 2 elements
+
+    .. note::
+       :math:`new = (scale * old) + shift`
+    """
+    point = scale * np.array([x, y]) + shift
+    return point
+
+
 #-------------------------------------------------------------------------
 # Main window that you will want to import into your application.
 
@@ -3624,13 +3643,13 @@ class PlotCanvas(wx.Panel):
         if self._xSpec != 'none':
             if self.EnableGrid[0]:
                 for x, _ in xticks:
-                    pt = scale * np.array([x, p1[1]]) + shift
+                    pt = scale_and_shift_point(x, p1[1], scale, shift)
                     dc.DrawLine(pt[0], pt[1], pt[0], pt[1] - height)
 
         if self._ySpec != 'none':
             if self.EnableGrid[1]:
                 for y, label in yticks:
-                    pt = scale * np.array([p1[0], y]) + shift
+                    pt = scale_and_shift_point(p1[0], y, scale, shift)
                     dc.DrawLine(pt[0], pt[1], pt[0] + width, pt[1])
 
     @TempStyle('pen')
@@ -3640,7 +3659,6 @@ class PlotCanvas(wx.Panel):
         #       - done via negative ticklength values?
         #           + works but the axes values cut off the ticks.
         # increases thickness for printing only
-        # TODO: changes to XSpec and YSpec api.
         pen = self.TickPen
         penWidth = self.printerScale * pen.GetWidth()
         pen.SetWidth(penWidth)
@@ -3655,13 +3673,13 @@ class PlotCanvas(wx.Panel):
             if ticks.bottom:
                 lines = []
                 for x, label in xticks:
-                    pt = scale * np.array([x, p1[1]]) + shift
+                    pt = scale_and_shift_point(x, p1[1], scale, shift)
                     lines.append((pt[0], pt[1], pt[0], pt[1] - xTickLength))
                 dc.DrawLineList(lines)
             if ticks.top:
                 lines = []
                 for x, label in xticks:
-                    pt = scale * np.array([x, p2[1]]) + shift
+                    pt = scale_and_shift_point(x, p2[1], scale, shift)
                     lines.appned((pt[0], pt[1], pt[0], pt[1] + xTickLength))
                 dc.DrawLineList(lines)
 
@@ -3669,13 +3687,13 @@ class PlotCanvas(wx.Panel):
             if ticks.left:
                 lines = []
                 for y, label in yticks:
-                    pt = scale * np.array([p1[0], y]) + shift
+                    pt = scale_and_shift_point(p1[0], y, scale, shift)
                     lines.append((pt[0], pt[1], pt[0] + yTickLength, pt[1]))
                 dc.DrawLineList(lines)
             if ticks.right:
                 lines = []
                 for y, label in yticks:
-                    pt = scale * np.array([p2[0], y]) + shift
+                    pt = scale_and_shift_point(p2[0], y, scale, shift)
                     lines.append((pt[0], pt[1], pt[0] - yTickLength, pt[1]))
                 dc.DrawLineList(lines)
 
@@ -3737,25 +3755,25 @@ class PlotCanvas(wx.Panel):
         if self.XSpec != 'none':
             if axes.bottom:
                 lower, upper = p1[0], p2[0]
-                a1 = scale * np.array([lower, p1[1]]) + shift
-                a2 = scale * np.array([upper, p1[1]]) + shift
+                a1 = scale_and_shift_point(lower, p1[1], scale, shift)
+                a2 = scale_and_shift_point(upper, p1[1], scale, shift)
                 dc.DrawLine(a1[0], a1[1], a2[0], a2[1])
             if axes.top:
                 lower, upper = p1[0], p2[0]
-                a1 = scale * np.array([lower, p2[1]]) + shift
-                a2 = scale * np.array([upper, p2[1]]) + shift
+                a1 = scale_and_shift_point(lower, p2[1], scale, shift)
+                a2 = scale_and_shift_point(upper, p2[1], scale, shift)
                 dc.DrawLine(a1[0], a1[1], a2[0], a2[1])
 
         if self.YSpec != 'none':
             if axes.left:
                 lower, upper = p1[1], p2[1]
-                a1 = scale * np.array([p1[0], lower]) + shift
-                a2 = scale * np.array([p1[0], upper]) + shift
+                a1 = scale_and_shift_point(p1[0], lower, scale, shift)
+                a2 = scale_and_shift_point(p1[0], upper, scale, shift)
                 dc.DrawLine(a1[0], a1[1], a2[0], a2[1])
             if axes.right:
                 lower, upper = p1[1], p2[1]
-                a1 = scale * np.array([p2[0], lower]) + shift
-                a2 = scale * np.array([p2[0], upper]) + shift
+                a1 = scale_and_shift_point(p2[0], lower, scale, shift)
+                a2 = scale_and_shift_point(p2[0], upper, scale, shift)
                 dc.DrawLine(a1[0], a1[1], a2[0], a2[1])
 
     @TempStyle('pen')
@@ -3770,7 +3788,7 @@ class PlotCanvas(wx.Panel):
                 coords = []
                 for x, label in xticks:
                     w = dc.GetTextExtent(label)[0]
-                    pt = scale * np.array([x, p1[1]]) + shift
+                    pt = scale_and_shift_point(x, p1[1], scale, shift)
                     coords.append(
                         (pt[0] - w/2, pt[1] + 2 * self._pointSize[1])
                     )
@@ -3781,7 +3799,7 @@ class PlotCanvas(wx.Panel):
                 coords = []
                 for x, label in xticks:
                     w, h = dc.GetTextExtent(label)
-                    pt = scale * np.array([x, p2[1]]) + shift
+                    pt = scale_and_shift_point(x, p2[1], scale, shift)
                     coords.append(
                         (pt[0] - w/2, pt[1] - 2 * self._pointSize[1] - h)
                     )
@@ -3794,7 +3812,7 @@ class PlotCanvas(wx.Panel):
                 coords = []
                 for y, label in yticks:
                     w = dc.GetTextExtent(label)[0]
-                    pt = scale * np.array([p1[0], y]) + shift
+                    pt = scale_and_shift_point(p1[0], y, scale, shift)
                     coords.append(
                         (pt[0] - w - 3 * self._pointSize[0], pt[1] - 0.5 * h)
                     )
@@ -3806,7 +3824,7 @@ class PlotCanvas(wx.Panel):
                 coords = []
                 for y, label in yticks:
                     w = dc.GetTextExtent(label)[0]
-                    pt = scale * np.array([p2[0], y]) + shift
+                    pt = scale_and_shift_point(p2[0], y, scale, shift)
                     coords.append(
                         (pt[0] + 3 * self._pointSize[0], pt[1] - 0.5 * h)
                     )

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -126,23 +126,21 @@ improvement though. Lines are much faster than markers, especially
 filled markers.  Stay away from circles and triangles unless you
 only have a few thousand points.
 
-+-----------------------------------+
-| Times for 25,000 points           |
-+===================================+
-| Line                    | 0.078 s |
-+-------------------------+---------+
-| Markers                           |
-+-------------------------+---------+
-| Square                  | 0.22 s  |
-+-------------------------+---------+
-| dot                     | 0.10    |
-+-------------------------+---------+
-| circle                  | 0.87    |
-+-------------------------+---------+
-| cross, plus             | 0.28    |
-+-------------------------+---------+
-| triangle, triangle_down | 0.90    |
-+-------------------------+---------+
++--------------------------------------------+
+| Times for 25,000 points                    |
++============================================+
+| Line                             | 0.078 s |
++----------------------------------+---------+
+| Markers: Square                  | 0.22 s  |
++----------------------------------+---------+
+| Markers: dot                     | 0.10    |
++----------------------------------+---------+
+| Markers: circle                  | 0.87    |
++----------------------------------+---------+
+| Markers: cross, plus             | 0.28    |
++----------------------------------+---------+
+| Markers: triangle, triangle_down | 0.90    |
++----------------------------------+---------+
 
 Thanks to Chris Barker for getting this version working on Linux.
 
@@ -1243,6 +1241,8 @@ class PolyHistogram(PolyBarsBase):
     Histogram
 
     Special PolyBarsBase where the bars span the binspec.
+
+
     """
     def __init__(self, hist, binspec, **attr):
         """
@@ -3653,23 +3653,31 @@ class PlotCanvas(wx.Panel):
         ticks = self.EnableTicks
         if self.XSpec != 'none':        # I don't like this :-/
             if ticks.bottom:
+                lines = []
                 for x, label in xticks:
                     pt = scale * np.array([x, p1[1]]) + shift
-                    dc.DrawLine(pt[0], pt[1], pt[0], pt[1] - xTickLength)
+                    lines.append((pt[0], pt[1], pt[0], pt[1] - xTickLength))
+                dc.DrawLineList(lines)
             if ticks.top:
+                lines = []
                 for x, label in xticks:
                     pt = scale * np.array([x, p2[1]]) + shift
-                    dc.DrawLine(pt[0], pt[1], pt[0], pt[1] + xTickLength)
+                    lines.appned((pt[0], pt[1], pt[0], pt[1] + xTickLength))
+                dc.DrawLineList(lines)
 
         if self.YSpec != 'none':
             if ticks.left:
+                lines = []
                 for y, label in yticks:
                     pt = scale * np.array([p1[0], y]) + shift
-                    dc.DrawLine(pt[0], pt[1], pt[0] + yTickLength, pt[1])
+                    lines.append((pt[0], pt[1], pt[0] + yTickLength, pt[1]))
+                dc.DrawLineList(lines)
             if ticks.right:
+                lines = []
                 for y, label in yticks:
                     pt = scale * np.array([p2[0], y]) + shift
-                    dc.DrawLine(pt[0], pt[1], pt[0] - yTickLength, pt[1])
+                    lines.append((pt[0], pt[1], pt[0] - yTickLength, pt[1]))
+                dc.DrawLineList(lines)
 
     @TempStyle('pen')
     def _drawCenterLines(self, dc, p1, p2, scale, shift):
@@ -3754,41 +3762,55 @@ class PlotCanvas(wx.Panel):
     def _drawAxesValues(self, dc, p1, p2, scale, shift, xticks, yticks):
         """ Draws the axes values """
         # TODO: More code duplication? Same as _drawGrid and _drawTicks?
-        # TODO: replace dc.DrawText with dc.DrawTextList?
         # TODO: update the bounding boxes when adding right and top values
         axes = self.EnableAxesValues
         if self.XSpec != 'none':
             if axes.bottom:
+                labels = [tick[1] for tick in xticks]
+                coords = []
                 for x, label in xticks:
                     w = dc.GetTextExtent(label)[0]
                     pt = scale * np.array([x, p1[1]]) + shift
-                    dc.DrawText(label,
-                                pt[0] - w/2,
-                                pt[1] + 2 * self._pointSize[1])
+                    coords.append(
+                        (pt[0] - w/2, pt[1] + 2 * self._pointSize[1])
+                    )
+                dc.DrawTextList(labels, coords)
+
             if axes.top:
+                labels = [tick[1] for tick in xticks]
+                coords = []
                 for x, label in xticks:
                     w, h = dc.GetTextExtent(label)
                     pt = scale * np.array([x, p2[1]]) + shift
-                    dc.DrawText(label,
-                                pt[0] - w/2,
-                                pt[1] - 2 * self._pointSize[1] - h)
+                    coords.append(
+                        (pt[0] - w/2, pt[1] - 2 * self._pointSize[1] - h)
+                    )
+                dc.DrawTextList(labels, coords)
+
         if self.YSpec != 'none':
             if axes.left:
                 h = dc.GetCharHeight()
+                labels = [tick[1] for tick in yticks]
+                coords = []
                 for y, label in yticks:
                     w = dc.GetTextExtent(label)[0]
                     pt = scale * np.array([p1[0], y]) + shift
-                    dc.DrawText(label,
-                                pt[0] - w - 3 * self._pointSize[0],
-                                pt[1] - 0.5 * h)
+                    coords.append(
+                        (pt[0] - w - 3 * self._pointSize[0], pt[1] - 0.5 * h)
+                    )
+                dc.DrawTextList(labels, coords)
+
             if axes.right:
                 h = dc.GetCharHeight()
+                labels = [tick[1] for tick in yticks]
+                coords = []
                 for y, label in yticks:
                     w = dc.GetTextExtent(label)[0]
                     pt = scale * np.array([p2[0], y]) + shift
-                    dc.DrawText(label,
-                                pt[0] + 3 * self._pointSize[0],
-                                pt[1] - 0.5 * h)
+                    coords.append(
+                        (pt[0] + 3 * self._pointSize[0], pt[1] - 0.5 * h)
+                    )
+                dc.DrawTextList(labels, coords)
 
     @TempStyle('pen')
     def _drawPlotAreaItems(self, dc, p1, p2, scale, shift, xticks, yticks):

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -324,26 +324,23 @@ class SavePen(object):
     Decorator which saves the dc Pen before calling a function and sets the
     pen back after the funcion, even if the function raises an exception.
 
-    The DC to paint on **must** be the first argument of the function.
+    The DC to paint on **must** be the first argument of the decorated
+    function.
 
-    Usage:
-    -------
     ::
 
         @SavePen
         def func(dc, a, b, c):
             # edit pen here
 
-    is the same as::
-
+        # is the same as:
         def func(dc, a, b, c):
             prevPen = dc.GetPen()
             # edit pen here
             dc.SetPen(prevPen)
 
-    See Also:
-    ---------
-    SaveBrush : Decorator to save a wx.Brush before calling a function.
+    .. seealso::
+       :func:`~wx.lib.plot.SaveBrush`
 
     """
     def __init__(self, func):
@@ -371,10 +368,11 @@ class SavePen(object):
 
 class SavedPen(object):
     """
-    Context Manager for saving the previous wx.Pen and resetting it after.
+    Context Manager for saving the previous :class:`wx.Pen` and resetting
+    it after.
 
-    Usage:
-    ------
+    :param dc: The DC to get pen information from.
+    :type dc: :class:`wx.DC`
 
     ::
 
@@ -404,24 +402,20 @@ class SaveBrush(object):
 
     The DC to paint on **must** be the first argument of the function.
 
-    Usage:
-    -------
     ::
 
         @SaveBrush
         def func(dc, a, b, c):
             # edit Brush here
 
-    is the same as::
-
+        # is the same as:
         def func(dc, a, b, c):
             prevBrush = dc.GetBrush()
             # edit Brush here
             dc.SetBrush(prevBrush)
 
-    See Also:
-    ---------
-    SavePen : Decorator to save a wx.Pen before calling a function.
+    .. seealso::
+        :func:`~wx.lib.plot.SavePen`
 
     """
     def __init__(self, func):
@@ -449,10 +443,11 @@ class SaveBrush(object):
 
 class SavedBrush(object):
     """
-    Context Manager for saving the previous wx.Pen and resetting it after.
+    Context Manager for saving the previous :class:`wx.Pen` and resetting
+    it after.
 
-    Usage:
-    ------
+    :param dc: The DC to get brush info from.
+    :type dc: :class:`wx.DC`
 
     ::
 
@@ -481,8 +476,8 @@ class PendingDeprecation(object):
     Decorator which warns the developer about methods that are
     pending deprecation.
 
-    Usage:
-    ------
+    :param new_func: The new class, method, or function that should be used.
+    :type new_func: str
 
     ::
 
@@ -490,9 +485,8 @@ class PendingDeprecation(object):
         def old_func():
             pass
 
-    prints the warning::
-
-        `old_func` is pending deprecation. Please use new_func instead.
+        # prints the warning:
+        # `old_func` is pending deprecation. Please use `new_func` instead.
 
     """
     _warn_txt = "`{}` is pending deprecation. Please use `{}` instead."
@@ -532,11 +526,14 @@ class _DisplaySide(object):
     - it contains type checking, only allowing boolean values
     - it contains name checking, only allowing valid_names as attributes
 
-    Parameters:
-    -----------
-    bottom, left, top, right : bool
-        Boolean values for a given side's display value.
-
+    :param bottom: Display the bottom side?
+    :type bottom: bool
+    :param left: Display the left side?
+    :type left: bool
+    :param top: Display the top side?
+    :type top: bool
+    :param right: Display the right side?
+    :type right: bool
     """
     # TODO: Do I want to replace with __slots__?
     #       Not much memory gain because this class is only called a small
@@ -612,6 +609,11 @@ class PolyPoints(object):
     Base Class for lines and markers.
 
     All methods are private.
+
+    :param points: The points to plot
+    :type points: list of ``(x, y)`` pairs
+    :param attr: Additional attributes
+    :type attr: dict
     """
 
     def __init__(self, points, attr):
@@ -633,15 +635,19 @@ class PolyPoints(object):
 
     @property
     def LogScale(self):
+        """
+        A tuple of ``(x_axis_is_log10, y_axis_is_log10)`` booleans. If a value
+        is ``True``, then that axis is plotted on a logarithmic base 10 scale.
+
+        :getter: Returns the current value of LogScale
+        :setter: Sets the value of LogScale
+        :type: tuple of bool, length 2
+        :raises ValueError: when setting an invalid value
+        """
         return self._logscale
 
     @LogScale.setter
     def LogScale(self, logscale):
-        """
-        Set to change the axes to plot Log10(values)
-
-        Value must be a tuple of booleans (x_axis_bool, y_axis_bool)
-        """
         if not isinstance(logscale, tuple) or len(logscale) != 2:
             raise ValueError("`logscale` must be a 2-tuple of bools")
         self._logscale = logscale
@@ -657,25 +663,90 @@ class PolyPoints(object):
 
     @property
     def SymLogScale(self):
+        """
+        .. warning::
+
+           Not yet implemented.
+
+        A tuple of ``(x_axis_is_SymLog10, y_axis_is_SymLog10)`` booleans.
+        If a value is ``True``, then that axis is plotted on a symmetric
+        logarithmic base 10 scale.
+
+        A Symmetric Log10 scale means that values can be positive and
+        negative. Any values less than
+        :attr:`~wx.lig.plot.PolyPoints.SymLogThresh` will be plotted on
+        a linear scale to avoid the plot going to infinity near 0.
+
+        :getter: Returns the current value of SymLogScale
+        :setter: Sets the value of SymLogScale
+        :type: tuple of bool, length 2
+        :raises ValueError: when setting an invalid value
+
+        .. notes::
+
+           This is a simplified example of how SymLog works::
+
+             if x >= thresh:
+                 x = Log10(x)
+             elif x =< thresh:
+                 x = -Log10(Abs(x))
+             else:
+                 x = x
+
+        .. seealso::
+
+           + :attr:`~wx.lib.plot.PolyPoints.SymLogThresh`
+           + See http://matplotlib.org/examples/pylab_examples/symlog_demo.html
+             for an example.
+        """
         return self._symlogscale
 
     # TODO: Implement symmetric log scale
     @SymLogScale.setter
-    def SymLogScale(self, symlogscale):
+    def SymLogScale(self, symlogscale, thresh):
+        raise NotImplementedError("Symmetric Log Scale not yet implemented")
+
+        if not isinstance(symlogscale, tuple) or len(symlogscale) != 2:
+            raise ValueError("`symlogscale` must be a 2-tuple of bools")
+        self._symlogscale = symlogscale
+
+    @property
+    def SymLogThresh(self):
         """
-        # Not implemented yet
+        .. warning::
 
+           Not yet implemented.
 
-        Set to change the axes to a symmetric log10 scale.
+        A tuple of ``(x_thresh, y_thresh)`` floats that define where the plot
+        changes to linear scale when using a symmetric log scale.
 
-        Value must be a 2-tuple of booleans (x_axis_bool, y_axis_bool)
+        :getter: Returns the current value of SymLogThresh
+        :setter: Sets the value of SymLogThresh
+        :type: tuple of float, length 2
+        :raises ValueError: when setting an invalid value
 
-        A Symmetric Log scale uses the following properties:
-        if x > 0:
-            x = Log10(x)
-        elif x < 0:
-            x = -Log10(Abs(x))
+        .. notes::
+
+           This is a simplified example of how SymLog works::
+
+             if x >= thresh:
+                 x = Log10(x)
+             elif x =< thresh:
+                 x = -Log10(Abs(x))
+             else:
+                 x = x
+
+        .. seealso::
+
+           + :attr:`~wx.lib.plot.PolyPoints.SymLogScale`
+           + See http://matplotlib.org/examples/pylab_examples/symlog_demo.html
+             for an example.
         """
+        return self._symlogscale
+
+    # TODO: Implement symmetric log scale threshold
+    @SymLogThresh.setter
+    def SymLogThresh(self, symlogscale, thresh):
         raise NotImplementedError("Symmetric Log Scale not yet implemented")
 
         if not isinstance(symlogscale, tuple) or len(symlogscale) != 2:
@@ -684,22 +755,39 @@ class PolyPoints(object):
 
     @property
     def AbsScale(self):
+        """
+        A tuple of ``(x_axis_is_abs, y_axis_is_abs)`` booleans. If a value
+        is ``True``, then that axis is plotted on an absolute value scale.
+
+        :getter: Returns the current value of AbsScale
+        :setter: Sets the value of AbsScale
+        :type: tuple of bool, length 2
+        :raises ValueError: when setting an invalid value
+        """
         return self._absScale
 
     @AbsScale.setter
     def AbsScale(self, absscale):
-        """
-        Set to change the axes to plot Abs(values)
 
-        Value must be a tuple of booleans (x_axis_bool, y_axis_bool)
-        """
         if not isinstance(absscale, tuple) and len(absscale) == 2:
             raise ValueError("`absscale` must be a 2-tuple of bools")
         self._absScale = absscale
 
     @property
     def points(self):
-        """Returns the points, adjusting for log scale if LogScale is set"""
+        """
+        Get or set the plotted points.
+
+        :getter: Returns the current value of points, adjusting for the
+                 various scale options such as Log, Abs, or SymLog.
+        :setter: Sets the value of points.
+        :type: list of `(x, y)` pairs
+
+        .. Note::
+
+           Only set unscaled points - do not perform the log, abs, or symlog
+           adjustments yourself.
+        """
         data = np.array(self._points, copy=True)    # need the copy
                                                     # TODO: get rid of the
                                                     # need for copy
@@ -751,15 +839,8 @@ class PolyPoints(object):
 
             ((minX, minY), (maxX, maxY))
 
-        Parameters:
-        -----------
-        None
-
-        Returns:
-        --------
-        minXY, maxXY : numpy arrays of length 2
-            The minimum and maximum X and Y values.
-
+        :returns: boundingbox
+        :rtype: numpy array of ``[[minX, minY], [maxX, maxY]]``
         """
         if len(self.points) == 0:
             # no curves to draw
@@ -775,18 +856,12 @@ class PolyPoints(object):
         """
         Scales and shifts the data for plotting.
 
-        Parameters:
-        -----------
-        scale : tuple of floats
-            The (x_scale, y_scale) tuple to scale the data by
-
-        shift : tuple of floats
-            The (x_shift, y_shift) tuple to shift the data by.
-
-        Returns:
-        --------
-        None
-
+        :param scale: The values to scale the data by.
+        :type scale: tuple of floats: ``(x_scale, y_scale)``
+        :param shift: The value to shift the data by. This should be in scaled
+                      units
+        :type shift: tuple of floats: ``(x_shift, y_shift)``
+        :returns: None
         """
         if len(self.points) == 0:
             # no curves to draw

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -1162,7 +1162,7 @@ class PolyMarker(PolyPoints):
         return (s, s)
 
     def _drawmarkers(self, dc, coords, marker, size=1):
-        f = eval('self._' + marker)     # XXX: look into changing this
+        f = getattr(self, "_{}".format(marker))
         f(dc, coords, size)
 
     def _circle(self, dc, coords, size=1):
@@ -1925,7 +1925,8 @@ def scale_and_shift_point(x, y, scale=1, shift=0):
     :param np.array `shift`: The offset to apply ``[x_shift, y_shift]``.
                              Must be in scaled units
 
-    :returns np.array: a numpy array of 2 elements
+    :returns: a numpy array of 2 elements
+    :rtype: np.array
 
     .. note::
        :math:`new = (scale * old) + shift`

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -85,7 +85,7 @@
 #   - Added demos for PolyBars and PolyHistogram
 #   - updated plotNN menu items status-bar text to be descriptive.
 #   - increased default size of demo
-#   - updated XSpec and YSpec to accept a list or tuple of (min, max) values.
+#   - updated xSpec and ySpec to accept a list or tuple of (min, max) values.
 #
 # Jun 14, 2016 (Start)  Douglas Thor (doug.thor@gmail.com)
 #   -
@@ -634,25 +634,25 @@ class PolyPoints(object):
             self.attributes[name] = value
 
     @property
-    def LogScale(self):
+    def logScale(self):
         """
         A tuple of ``(x_axis_is_log10, y_axis_is_log10)`` booleans. If a value
         is ``True``, then that axis is plotted on a logarithmic base 10 scale.
 
-        :getter: Returns the current value of LogScale
-        :setter: Sets the value of LogScale
+        :getter: Returns the current value of logScale
+        :setter: Sets the value of logScale
         :type: tuple of bool, length 2
         :raises ValueError: when setting an invalid value
         """
         return self._logscale
 
-    @LogScale.setter
-    def LogScale(self, logscale):
+    @logScale.setter
+    def logScale(self, logscale):
         if not isinstance(logscale, tuple) or len(logscale) != 2:
             raise ValueError("`logscale` must be a 2-tuple of bools")
         self._logscale = logscale
 
-    @PendingDeprecation("self.LogScale property")
+    @PendingDeprecation("self.logScale property")
     def setLogScale(self, logscale):
         """
         Set to change the axes to plot Log10(values)
@@ -662,7 +662,7 @@ class PolyPoints(object):
         self._logscale = logscale
 
     @property
-    def SymLogScale(self):
+    def symLogScale(self):
         """
         .. warning::
 
@@ -674,11 +674,11 @@ class PolyPoints(object):
 
         A Symmetric Log10 scale means that values can be positive and
         negative. Any values less than
-        :attr:`~wx.lig.plot.PolyPoints.SymLogThresh` will be plotted on
+        :attr:`~wx.lig.plot.PolyPoints.symLogThresh` will be plotted on
         a linear scale to avoid the plot going to infinity near 0.
 
-        :getter: Returns the current value of SymLogScale
-        :setter: Sets the value of SymLogScale
+        :getter: Returns the current value of symLogScale
+        :setter: Sets the value of symLogScale
         :type: tuple of bool, length 2
         :raises ValueError: when setting an invalid value
 
@@ -695,15 +695,15 @@ class PolyPoints(object):
 
         .. seealso::
 
-           + :attr:`~wx.lib.plot.PolyPoints.SymLogThresh`
+           + :attr:`~wx.lib.plot.PolyPoints.symLogThresh`
            + See http://matplotlib.org/examples/pylab_examples/symlog_demo.html
              for an example.
         """
         return self._symlogscale
 
     # TODO: Implement symmetric log scale
-    @SymLogScale.setter
-    def SymLogScale(self, symlogscale, thresh):
+    @symLogScale.setter
+    def symLogScale(self, symlogscale, thresh):
         raise NotImplementedError("Symmetric Log Scale not yet implemented")
 
         if not isinstance(symlogscale, tuple) or len(symlogscale) != 2:
@@ -711,7 +711,7 @@ class PolyPoints(object):
         self._symlogscale = symlogscale
 
     @property
-    def SymLogThresh(self):
+    def symLogThresh(self):
         """
         .. warning::
 
@@ -720,8 +720,8 @@ class PolyPoints(object):
         A tuple of ``(x_thresh, y_thresh)`` floats that define where the plot
         changes to linear scale when using a symmetric log scale.
 
-        :getter: Returns the current value of SymLogThresh
-        :setter: Sets the value of SymLogThresh
+        :getter: Returns the current value of symLogThresh
+        :setter: Sets the value of symLogThresh
         :type: tuple of float, length 2
         :raises ValueError: when setting an invalid value
 
@@ -738,15 +738,15 @@ class PolyPoints(object):
 
         .. seealso::
 
-           + :attr:`~wx.lib.plot.PolyPoints.SymLogScale`
+           + :attr:`~wx.lib.plot.PolyPoints.symLogScale`
            + See http://matplotlib.org/examples/pylab_examples/symlog_demo.html
              for an example.
         """
         return self._symlogscale
 
     # TODO: Implement symmetric log scale threshold
-    @SymLogThresh.setter
-    def SymLogThresh(self, symlogscale, thresh):
+    @symLogThresh.setter
+    def symLogThresh(self, symlogscale, thresh):
         raise NotImplementedError("Symmetric Log Scale not yet implemented")
 
         if not isinstance(symlogscale, tuple) or len(symlogscale) != 2:
@@ -754,20 +754,20 @@ class PolyPoints(object):
         self._symlogscale = symlogscale
 
     @property
-    def AbsScale(self):
+    def absScale(self):
         """
         A tuple of ``(x_axis_is_abs, y_axis_is_abs)`` booleans. If a value
         is ``True``, then that axis is plotted on an absolute value scale.
 
-        :getter: Returns the current value of AbsScale
-        :setter: Sets the value of AbsScale
+        :getter: Returns the current value of absScale
+        :setter: Sets the value of absScale
         :type: tuple of bool, length 2
         :raises ValueError: when setting an invalid value
         """
         return self._absScale
 
-    @AbsScale.setter
-    def AbsScale(self, absscale):
+    @absScale.setter
+    def absScale(self, absscale):
 
         if not isinstance(absscale, tuple) and len(absscale) == 2:
             raise ValueError("`absscale` must be a 2-tuple of bools")
@@ -793,26 +793,26 @@ class PolyPoints(object):
                                                     # need for copy
 
         # work on X:
-        if self.AbsScale[0]:
+        if self.absScale[0]:
             data = self._abs(data, 0)
-        if self.LogScale[0]:
+        if self.logScale[0]:
             data = self._log10(data, 0)
 
-        if self.SymLogScale[0]:
-            # TODO: implement SymLogScale
-            # Should SymLogScale override AbsScale? My vote is no.
-            # Should SymLogScale override LogScale? My vote is yes.
-            #   - SymLogScale could be a parameter passed to LogScale...
+        if self.symLogScale[0]:
+            # TODO: implement symLogScale
+            # Should symLogScale override absScale? My vote is no.
+            # Should symLogScale override logScale? My vote is yes.
+            #   - symLogScale could be a parameter passed to logScale...
             pass
 
         # work on Y:
-        if self.AbsScale[1]:
+        if self.absScale[1]:
             data = self._abs(data, 1)
-        if self.LogScale[1]:
+        if self.logScale[1]:
             data = self._log10(data, 1)
 
-        if self.SymLogScale[1]:
-            # TODO: implement SymLogScale
+        if self.symLogScale[1]:
+            # TODO: implement symLogScale
             pass
 
         return data
@@ -1791,59 +1791,59 @@ class PlotGraphics(object):
         if type(objects) not in [list, tuple]:
             raise TypeError("objects argument should be list or tuple")
         self.objects = objects
-        self.title = title
-        self.xLabel = xLabel
-        self.yLabel = yLabel
+        self._title = title
+        self._xLabel = xLabel
+        self._yLabel = yLabel
         self._pointSize = (1.0, 1.0)
 
     @property
-    def LogScale(self):
+    def logScale(self):
         # TODO: convert to try..except statement
 #        try:
-#        return [obj.LogScale for obj in self.objects]
+#        return [obj.logScale for obj in self.objects]
 #        except:     # what error would be returned?
 #            return
         if len(self.objects) == 0:
             return
-        return [obj.LogScale for obj in self.objects]
+        return [obj.logScale for obj in self.objects]
 
-    @LogScale.setter
-    def LogScale(self, logscale):
+    @logScale.setter
+    def logScale(self, logscale):
         # XXX: error checking done by PolyPoints class
 #        if not isinstance(logscale, tuple) and len(logscale) != 2:
 #            raise TypeError("logscale must be a 2-tuple of bools")
         if len(self.objects) == 0:
             return
         for obj in self.objects:
-            obj.LogScale = logscale
+            obj.logScale = logscale
 
-    @PendingDeprecation("self.LogScale property")
+    @PendingDeprecation("self.logScale property")
     def setLogScale(self, logscale):
         """
         Set the log scale boolean value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.LogScale` property
+           Use the :attr:`~wx.lib.plot.PlotGraphics.logScale` property
            instead.
         """
-        self.LogScale = logscale
+        self.logScale = logscale
 
     @property
-    def AbsScale(self):
+    def absScale(self):
         if len(self.objects) == 0:
             return
-        return [obj.AbsScale for obj in self.objects]
+        return [obj.absScale for obj in self.objects]
 
-    @AbsScale.setter
-    def AbsScale(self, absscale):
+    @absScale.setter
+    def absScale(self, absscale):
         # XXX: error checking done by PolyPoints class
 #        if not isinstance(absscale, tuple) and len(absscale) != 2:
 #            raise TypeError("absscale must be a 2-tuple of bools")
         if len(self.objects) == 0:
             return
         for obj in self.objects:
-            obj.AbsScale = absscale
+            obj.absScale = absscale
 
     def boundingBox(self):
         p1, p2 = self.objects[0].boundingBox()
@@ -1857,125 +1857,125 @@ class PlotGraphics(object):
         for o in self.objects:
             o.scaleAndShift(scale, shift)
 
-    @PendingDeprecation("self.PrinterScale property")
+    @PendingDeprecation("self.printerScale property")
     def setPrinterScale(self, scale):
         """
         Thickens up lines and markers only for printing
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.PrinterScale` property
+           Use the :attr:`~wx.lib.plot.PlotGraphics.printerScale` property
            instead.
         """
-        self.PrinterScale = scale
+        self.printerScale = scale
 
-    @PendingDeprecation("self.XLabel property")
+    @PendingDeprecation("self.xLabel property")
     def setXLabel(self, xLabel=''):
         """
         Set the X axis label on the graph
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.XLabel` property
+           Use the :attr:`~wx.lib.plot.PlotGraphics.xLabel` property
            instead.
        """
-        self.XLabel = xLabel
+        self.xLabel = xLabel
 
-    @PendingDeprecation("self.YLabel property")
+    @PendingDeprecation("self.yLabel property")
     def setYLabel(self, yLabel=''):
         """
         Set the Y axis label on the graph
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.YLabel` property
+           Use the :attr:`~wx.lib.plot.PlotGraphics.yLabel` property
            instead.
        """
-        self.YLabel = yLabel
+        self.yLabel = yLabel
 
-    @PendingDeprecation("self.Title property")
+    @PendingDeprecation("self.title property")
     def setTitle(self, title=''):
         """
         Set the title at the top of graph
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.Title` property
+           Use the :attr:`~wx.lib.plot.PlotGraphics.title` property
            instead.
         """
-        self.Title = title
+        self.title = title
 
-    @PendingDeprecation("self.XLabel property")
+    @PendingDeprecation("self.xLabel property")
     def getXLabel(self):
         """
         Get X axis label string
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.XLabel` property
+           Use the :attr:`~wx.lib.plot.PlotGraphics.xLabel` property
            instead.
         """
-        return self.XLabel
+        return self.xLabel
 
-    @PendingDeprecation("self.YLabel property")
+    @PendingDeprecation("self.yLabel property")
     def getYLabel(self):
         """
         Get Y axis label string
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.YLabel` property
+           Use the :attr:`~wx.lib.plot.PlotGraphics.yLabel` property
            instead.
         """
-        return self.YLabel
+        return self.yLabel
 
-    @PendingDeprecation("self.Title property")
+    @PendingDeprecation("self.title property")
     def getTitle(self, title=''):
         """
         Get the title at the top of graph
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.Title` property
+           Use the :attr:`~wx.lib.plot.PlotGraphics.title` property
            instead.
         """
-        return self.Title
+        return self.title
 
     @property
-    def PrinterScale(self):
+    def printerScale(self):
         return self._printerScale
 
-    @PrinterScale.setter
-    def PrinterScale(self, scale):
+    @printerScale.setter
+    def printerScale(self, scale):
         """Thickens up lines and markers only for printing"""
         self._printerScale = scale
 
     @property
-    def XLabel(self):
+    def xLabel(self):
         """Get the X axis label on the graph"""
-        return self.xLabel
+        return self._xLabel
 
-    @XLabel.setter
-    def XLabel(self, text):
-        self.xLabel = text
+    @xLabel.setter
+    def xLabel(self, text):
+        self._xLabel = text
 
     @property
-    def YLabel(self):
+    def yLabel(self):
         """Get the Y axis label on the graph"""
-        return self.yLabel
+        return self._yLabel
 
-    @YLabel.setter
-    def YLabel(self, text):
-        self.yLabel = text
+    @yLabel.setter
+    def yLabel(self, text):
+        self._yLabel = text
 
     @property
-    def Title(self):
+    def title(self):
         """Get the title at the top of graph"""
-        return self.title
+        return self._title
 
-    @Title.setter
-    def Title(self, text):
-        self.title = text
+    @title.setter
+    def title(self, text):
+        self._title = text
 
     def draw(self, dc):
         for o in self.objects:
@@ -2235,7 +2235,7 @@ class PlotCanvas(wx.Panel):
 
     ### Pen Properties
     @property
-    def GridPen(self):
+    def gridPen(self):
         """
         The :class:`wx.Pen` used to draw the grid lines on the plot.
 
@@ -2248,14 +2248,14 @@ class PlotCanvas(wx.Panel):
         """
         return self._gridPen
 
-    @GridPen.setter
-    def GridPen(self, pen):
+    @gridPen.setter
+    def gridPen(self, pen):
         if not isinstance(pen, wx.Pen):
             raise TypeError("pen must be an instance of wx.Pen")
         self._gridPen = pen
 
     @property
-    def DiagonalPen(self):
+    def diagonalPen(self):
         """
         The :class:`wx.Pen` used to draw the diagonal lines on the plot.
 
@@ -2268,14 +2268,14 @@ class PlotCanvas(wx.Panel):
         """
         return self._diagonalPen
 
-    @DiagonalPen.setter
-    def DiagonalPen(self, pen):
+    @diagonalPen.setter
+    def diagonalPen(self, pen):
         if not isinstance(pen, wx.Pen):
             raise TypeError("pen must be an instance of wx.Pen")
         self._diagonalPen = pen
 
     @property
-    def CenterLinePen(self):
+    def centerLinePen(self):
         """
         The :class:`wx.Pen` used to draw the center lines on the plot.
 
@@ -2288,14 +2288,14 @@ class PlotCanvas(wx.Panel):
         """
         return self._centerLinePen
 
-    @CenterLinePen.setter
-    def CenterLinePen(self, pen):
+    @centerLinePen.setter
+    def centerLinePen(self, pen):
         if not isinstance(pen, wx.Pen):
             raise TypeError("pen must be an instance of wx.Pen")
         self._centerLinePen = pen
 
     @property
-    def AxesPen(self):
+    def axesPen(self):
         """
         The :class:`wx.Pen` used to draw the axes lines on the plot.
 
@@ -2308,14 +2308,14 @@ class PlotCanvas(wx.Panel):
         """
         return self._axesPen
 
-    @AxesPen.setter
-    def AxesPen(self, pen):
+    @axesPen.setter
+    def axesPen(self, pen):
         if not isinstance(pen, wx.Pen):
             raise TypeError("pen must be an instance of wx.Pen")
         self._axesPen = pen
 
     @property
-    def TickPen(self):
+    def tickPen(self):
         """
         The :class:`wx.Pen` used to draw the tick marks on the plot.
 
@@ -2327,14 +2327,14 @@ class PlotCanvas(wx.Panel):
         """
         return self._tickPen
 
-    @TickPen.setter
-    def TickPen(self, pen):
+    @tickPen.setter
+    def tickPen(self, pen):
         if not isinstance(pen, wx.Pen):
             raise TypeError("pen must be an instance of wx.Pen")
         self._tickPen = pen
 
     @property
-    def TickLength(self):
+    def tickLength(self):
         """
         The length of the tick marks on an axis.
 
@@ -2345,8 +2345,8 @@ class PlotCanvas(wx.Panel):
         """
         return self._tickLength
 
-    @TickLength.setter
-    def TickLength(self, length):
+    @tickLength.setter
+    def tickLength(self, length):
         if not isinstance(length, (int, float)):
             raise TypeError("`length` must be an integer or float")
         self._tickWidth = length
@@ -2486,175 +2486,175 @@ class PlotCanvas(wx.Panel):
         frame.Centre(wx.BOTH)
         frame.Show(True)
 
-    @PendingDeprecation("self.LogScale property")
+    @PendingDeprecation("self.logScale property")
     def setLogScale(self, logscale):
         """
         Set the log scale boolean value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.LogScale` property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.logScale` property instead.
         """
-        self.LogScale = logscale
+        self.logScale = logscale
 
-    @PendingDeprecation("self.LogScale property")
+    @PendingDeprecation("self.logScale property")
     def getLogScale(self):
         """
         Set the log scale boolean value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.LogScale` property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.logScale` property instead.
         """
-        return self.LogScale
+        return self.logScale
 
     @property
-    def LogScale(self):
+    def logScale(self):
         """
-        The LogScale value as a 2-tuple of bools:
+        The logScale value as a 2-tuple of bools:
         ``(x_axis_is_log_scale, y_axis_is_log_scale)``.
 
-        :getter: Returns the value of LogScale.
-        :setter: Sets the value of LogScale.
+        :getter: Returns the value of logScale.
+        :setter: Sets the value of logScale.
         :type:   tuple of bools, length 2
         :raise:  `TypeError` when setting an invalid value.
         """
         return self._logscale
 
-    @LogScale.setter
-    def LogScale(self, logscale):
+    @logScale.setter
+    def logScale(self, logscale):
         if type(logscale) != tuple:
             raise TypeError(
                 'logscale must be a tuple of bools, e.g. (False, False)'
             )
         if self.last_draw is not None:
             graphics, xAxis, yAxis = self.last_draw
-            graphics.LogScale = logscale
+            graphics.logScale = logscale
             self.last_draw = (graphics, None, None)
-        self.XSpec = 'min'
-        self.YSpec = 'min'
+        self.xSpec = 'min'
+        self.ySpec = 'min'
         self._logscale = logscale
 
     @property
-    def AbsScale(self):
+    def absScale(self):
         """
-        The AbsScale value as a 2-tuple of bools:
+        The absScale value as a 2-tuple of bools:
         ``(x_axis_is_abs_scale, y_axis_is_abs_scale)``.
 
-        :getter: Returns the value of AbsScale.
-        :setter: Sets the value of AbsScale.
+        :getter: Returns the value of absScale.
+        :setter: Sets the value of absScale.
         :type:   tuple of bools, length 2
         :raise:  `TypeError` when setting an invalid value.
         """
         return self._absScale
 
-    @AbsScale.setter
-    def AbsScale(self, absscale):
+    @absScale.setter
+    def absScale(self, absscale):
         if not isinstance(absscale, tuple):
             raise TypeError(
                 "absscale must be tuple of bools, e.g. (False, False)"
             )
         if self.last_draw is not None:
             graphics, xAxis, yAxis = self.last_draw
-            graphics.AbsScale = absscale
+            graphics.absScale = absscale
             self.last_draw = (graphics, None, None)
-        self.XSpec = 'min'
-        self.YSpec = 'min'
+        self.xSpec = 'min'
+        self.ySpec = 'min'
         self._absScale = absscale
 
-    @PendingDeprecation("self.FontSizeAxis property")
+    @PendingDeprecation("self.fontSizeAxis property")
     def SetFontSizeAxis(self, point=10):
         """
         Set the tick and axis label font size (default is 10 point)
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeAxis` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeAxis` property
            instead.
         """
-        self.FontSizeAxis = point
+        self.fontSizeAxis = point
 
-    @PendingDeprecation("self.FontSizeAxis property")
+    @PendingDeprecation("self.fontSizeAxis property")
     def GetFontSizeAxis(self):
         """
         Get current tick and axis label font size in points
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeAxis` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeAxis` property
            instead.
         """
-        return self.FontSizeAxis
+        return self.fontSizeAxis
 
     @property
-    def FontSizeAxis(self):
+    def fontSizeAxis(self):
         """
         The current tick and axis label font size in points.
 
         Default is 10pt font.
 
-        :getter: Returns the value of FontSizeAxis.
-        :setter: Sets the value of FontSizeAxis.
+        :getter: Returns the value of fontSizeAxis.
+        :setter: Sets the value of fontSizeAxis.
         :type:   int or float
         """
         return self._fontSizeAxis
 
-    @FontSizeAxis.setter
-    def FontSizeAxis(self, value):
+    @fontSizeAxis.setter
+    def fontSizeAxis(self, value):
         self._fontSizeAxis = value
 
-    @PendingDeprecation("self.FontSizeTitle property")
+    @PendingDeprecation("self.fontSizeTitle property")
     def SetFontSizeTitle(self, point=15):
         """
         Set Title font size (default is 15 point)
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeTitle` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeTitle` property
            instead.
         """
-        self.FontSizeTitle = point
+        self.fontSizeTitle = point
 
-    @PendingDeprecation("self.FontSizeTitle property")
+    @PendingDeprecation("self.fontSizeTitle property")
     def GetFontSizeTitle(self):
         """
         Get Title font size (default is 15 point)
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeTitle` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeTitle` property
            instead.
         """
-        return self.FontSizeTitle
+        return self.fontSizeTitle
 
     @property
-    def FontSizeTitle(self):
+    def fontSizeTitle(self):
         """
         The current Title font size in points.
 
         Default is 15pt font.
 
-        :getter: Returns the value of FontSizeAxis.
-        :setter: Sets the value of FontSizeAxis.
+        :getter: Returns the value of fontSizeTitle.
+        :setter: Sets the value of fontSizeTitle.
         :type:   int or float
         """
         return self._fontSizeTitle
 
-    @FontSizeTitle.setter
-    def FontSizeTitle(self, pointsize):
+    @fontSizeTitle.setter
+    def fontSizeTitle(self, pointsize):
         self._fontSizeTitle = pointsize
 
-    @PendingDeprecation("self.FontSizeLegend property")
+    @PendingDeprecation("self.fontSizeLegend property")
     def SetFontSizeLegend(self, point=7):
         """
         Set legend font size (default is 7 point)
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeLegend' property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeLegend' property
            instead.
         """
-        self.FontSizeLegend = point
+        self.fontSizeLegend = point
 
     def GetFontSizeLegend(self):
         """
@@ -2662,360 +2662,360 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.FontSizeLegend' property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeLegend' property
            instead.
         """
-        return self.FontSizeLegend
+        return self.fontSizeLegend
 
     @property
-    def FontSizeLegend(self):
+    def fontSizeLegend(self):
         """
         The current Legned font size in points.
 
         Default is 7pt font.
 
-        :getter: Returns the value of FontSizeLegend.
-        :setter: Sets the value of FontSizeLegend.
+        :getter: Returns the value of fontSizeLegend.
+        :setter: Sets the value of fontSizeLegend.
         :type:   int or float
         """
         return self._fontSizeLegend
 
-    @FontSizeLegend.setter
-    def FontSizeLegend(self, point):
+    @fontSizeLegend.setter
+    def fontSizeLegend(self, point):
         self._fontSizeLegend = point
 
-    @PendingDeprecation("self.ShowScrollbars property")
+    @PendingDeprecation("self.showScrollbars property")
     def SetShowScrollbars(self, value):
         """
-        Set the ShowScrollbars value.
+        Set the showScrollbars value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.ShowScrollbars` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.showScrollbars` property
            instead.
         """
-        self.ShowScrollbars = value
+        self.showScrollbars = value
 
-    @PendingDeprecation("self.ShowScrollbars property")
+    @PendingDeprecation("self.showScrollbars property")
     def GetShowScrollbars(self):
         """
-        Get the ShowScrollbars value.
+        Get the showScrollbars value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.ShowScrollbars` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.showScrollbars` property
            instead.
         """
-        return self.ShowScrollbars
+        return self.showScrollbars
 
     @property
-    def ShowScrollbars(self):
+    def showScrollbars(self):
         """
-        The current ShowScrollbars value.
+        The current showScrollbars value.
 
-        :getter: Returns the value of ShowScrollbars.
-        :setter: Sets the value of ShowScrollbars.
+        :getter: Returns the value of showScrollbars.
+        :setter: Sets the value of showScrollbars.
         :type:   bool
         :raises: `TypeError` if setting a non-boolean value.
         """
         # XXX: should have sb_hor.IsShown() as well.
         return self.sb_vert.IsShown()
 
-    @ShowScrollbars.setter
-    def ShowScrollbars(self, value):
+    @showScrollbars.setter
+    def showScrollbars(self, value):
         if not isinstance(value, bool):
             raise TypeError("Value should be True or False")
-        if value == self.ShowScrollbars:
+        if value == self.showScrollbars:
             # no change, so don't do anything
             return
         self.sb_vert.Show(value)
         self.sb_hor.Show(value)
         wx.CallAfter(self.Layout)
 
-    @PendingDeprecation("self.UseScientificNotation property")
+    @PendingDeprecation("self.useScientificNotation property")
     def SetUseScientificNotation(self, useScientificNotation):
         """
-        Set the UseScientificNotation value.
+        Set the useScientificNotation value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.UseScientificNotation`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.useScientificNotation`
            property instead.
         """
-        self.UseScientificNotation = useScientificNotation
+        self.useScientificNotation = useScientificNotation
 
-    @PendingDeprecation("self.UseScientificNotation property")
+    @PendingDeprecation("self.useScientificNotation property")
     def GetUseScientificNotation(self):
         """
-        Get the UseScientificNotation value.
+        Get the useScientificNotation value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.UseScientificNotation`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.useScientificNotation`
            property instead.
         """
-        return self.UseScientificNotation
+        return self.useScientificNotation
 
     @property
-    def UseScientificNotation(self):
+    def useScientificNotation(self):
         """
-        The current UseScientificNotation value.
+        The current useScientificNotation value.
 
-        :getter: Returns the value of UseScientificNotation.
-        :setter: Sets the value of UseScientificNotation.
+        :getter: Returns the value of useScientificNotation.
+        :setter: Sets the value of useScientificNotation.
         :type:   bool
         :raises: `TypeError` if setting a non-boolean value.
         """
         return self._useScientificNotation
 
-    @UseScientificNotation.setter
-    def UseScientificNotation(self, value):
+    @useScientificNotation.setter
+    def useScientificNotation(self, value):
         if not isinstance(value, bool):
             raise TypeError("Value should be True or False")
         self._useScientificNotation = value
 
-    @PendingDeprecation("self.EnableAntiAliasing property")
+    @PendingDeprecation("self.enableAntiAliasing property")
     def SetEnableAntiAliasing(self, enableAntiAliasing):
         """
-        Set the EnableAntiAliasing value.
+        Set the enableAntiAliasing value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableAntiAliasing`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableAntiAliasing`
            property instead.
         """
-        self.EnableAntiAliasing = enableAntiAliasing
+        self.enableAntiAliasing = enableAntiAliasing
 
-    @PendingDeprecation("self.EnableAntiAliasing property")
+    @PendingDeprecation("self.enableAntiAliasing property")
     def GetEnableAntiAliasing(self):
         """
-        Get the EnableAntiAliasing value.
+        Get the enableAntiAliasing value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableAntiAliasing`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableAntiAliasing`
            property instead.
         """
-        return self.EnableAntiAliasing
+        return self.enableAntiAliasing
 
     @property
-    def EnableAntiAliasing(self):
+    def enableAntiAliasing(self):
         """
-        The current EnableAntiAliasing value.
+        The current enableAntiAliasing value.
 
-        :getter: Returns the value of EnableAntiAliasing.
-        :setter: Sets the value of EnableAntiAliasing.
+        :getter: Returns the value of enableAntiAliasing.
+        :setter: Sets the value of enableAntiAliasing.
         :type:   bool
         :raises: `TypeError` if setting a non-boolean value.
         """
         return self._antiAliasingEnabled
 
-    @EnableAntiAliasing.setter
-    def EnableAntiAliasing(self, value):
+    @enableAntiAliasing.setter
+    def enableAntiAliasing(self, value):
         if not isinstance(value, bool):
             raise TypeError("Value should be True or False")
         self._antiAliasingEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.EnableHiRes property")
+    @PendingDeprecation("self.enableHiRes property")
     def SetEnableHiRes(self, enableHiRes):
         """
-        Set the EnableHiRes value.
+        Set the enableHiRes value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableHiRes` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableHiRes` property
            instead.
         """
-        self.EnableHiRes = enableHiRes
+        self.enableHiRes = enableHiRes
 
-    @PendingDeprecation("self.EnableHiRes property")
+    @PendingDeprecation("self.enableHiRes property")
     def GetEnableHiRes(self):
         """
-        Get the EnableHiRes value.
+        Get the enableHiRes value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableHiRes` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableHiRes` property
            instead.
         """
         return self._hiResEnabled
 
     @property
-    def EnableHiRes(self):
+    def enableHiRes(self):
         """
-        The current EnableHiRes value.
+        The current enableHiRes value.
 
-        :getter: Returns the value of EnableHiRes.
-        :setter: Sets the value of EnableHiRes.
+        :getter: Returns the value of enableHiRes.
+        :setter: Sets the value of enableHiRes.
         :type:   bool
         :raises: `TypeError` if setting a non-boolean value.
         """
         return self._hiResEnabled
 
-    @EnableHiRes.setter
-    def EnableHiRes(self, value):
+    @enableHiRes.setter
+    def enableHiRes(self, value):
         if not isinstance(value, bool):
             raise TypeError("Value should be True or False")
         self._hiResEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.EnableDrag property")
+    @PendingDeprecation("self.enableDrag property")
     def SetEnableDrag(self, value):
         """
-        Set the EnableDrag value.
+        Set the enableDrag value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableDrag` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableDrag` property
            instead.
         """
-        self.EnableDrag = value
+        self.enableDrag = value
 
-    @PendingDeprecation("self.EnableDrag property")
+    @PendingDeprecation("self.enableDrag property")
     def GetEnableDrag(self):
         """
-        Get the EnableDrag value.
+        Get the enableDrag value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableDrag` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableDrag` property
            instead.
         """
-        return self.EnableDrag
+        return self.enableDrag
 
     @property
-    def EnableDrag(self):
+    def enableDrag(self):
         """
-        The current EnableDrag value.
+        The current enableDrag value.
 
-        :getter: Returns the value of EnableDrag.
-        :setter: Sets the value of EnableDrag.
+        :getter: Returns the value of enableDrag.
+        :setter: Sets the value of enableDrag.
         :type:   bool
         :raises: `TypeError` if setting a non-boolean value.
 
         .. note::
            This is mutually exclusive with
-           :attr:`~wx.lib.plot.PlotCanvas.EnableZoom`. Setting one will
+           :attr:`~wx.lib.plot.PlotCanvas.enableZoom`. Setting one will
            disable the other.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.EnableZoom`
+           :attr:`~wx.lib.plot.PlotCanvas.enableZoom`
         """
         return self._dragEnabled
 
-    @EnableDrag.setter
-    def EnableDrag(self, value):
+    @enableDrag.setter
+    def enableDrag(self, value):
         if not isinstance(value, bool):
             raise TypeError("Value must be a bool.")
         if value:
-            if self.EnableZoom:
-                self.EnableZoom = False
+            if self.enableZoom:
+                self.enableZoom = False
             self.SetCursor(self.HandCursor)
         else:
             self.SetCursor(wx.CROSS_CURSOR)
         self._dragEnabled = value
 
-    @PendingDeprecation("self.EnableZoom property")
+    @PendingDeprecation("self.enableZoom property")
     def SetEnableZoom(self, value):
         """
-        Set the EnableZoom value.
+        Set the enableZoom value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableZoom` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableZoom` property
            instead.
         """
-        self.EnableZoom = value
+        self.enableZoom = value
 
-    @PendingDeprecation("self.EnableZoom property")
+    @PendingDeprecation("self.enableZoom property")
     def GetEnableZoom(self):
         """
-        Get the EnableZoom value.
+        Get the enableZoom value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableZoom` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableZoom` property
            instead.
         """
-        return self.EnableZoom
+        return self.enableZoom
 
     @property
-    def EnableZoom(self):
+    def enableZoom(self):
         """
-        The current EnableZoom value.
+        The current enableZoom value.
 
-        :getter: Returns the value of EnableZoom.
-        :setter: Sets the value of EnableZoom.
+        :getter: Returns the value of enableZoom.
+        :setter: Sets the value of enableZoom.
         :type:   bool
         :raises: `TypeError` if setting a non-boolean value.
 
         .. note::
            This is mutually exclusive with
-           :attr:`~wx.lib.plot.PlotCanvas.EnableDrag`. Setting one will
+           :attr:`~wx.lib.plot.PlotCanvas.enableDrag`. Setting one will
            disable the other.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.EnableDrag`
+           :attr:`~wx.lib.plot.PlotCanvas.enableDrag`
         """
         return self._zoomEnabled
 
-    @EnableZoom.setter
-    def EnableZoom(self, value):
+    @enableZoom.setter
+    def enableZoom(self, value):
         if not isinstance(value, bool):
             raise TypeError("Value must be a bool.")
         if value:
-            if self.EnableDrag:
-                self.EnableDrag = False
+            if self.enableDrag:
+                self.enableDrag = False
             self.SetCursor(self.MagCursor)
         else:
             self.SetCursor(wx.CROSS_CURSOR)
         self._zoomEnabled = value
 
-    @PendingDeprecation("self.EnableGrid property")
+    @PendingDeprecation("self.enableGrid property")
     def SetEnableGrid(self, value):
         """
-        Set the EnableGrid value.
+        Set the enableGrid value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableGrid` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableGrid` property
            instead.
         """
-        self.EnableGrid = value
+        self.enableGrid = value
 
-    @PendingDeprecation("self.EnableGrid property")
+    @PendingDeprecation("self.enableGrid property")
     def GetEnableGrid(self):
         """
-        Get the EnableGrid value.
+        Get the enableGrid value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableGrid` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableGrid` property
            instead.
         """
-        return self.EnableGrid
+        return self.enableGrid
 
     @property
-    def EnableGrid(self):
+    def enableGrid(self):
         """
-        The current EnableGrid value.
+        The current enableGrid value.
 
-        :getter: Returns the value of EnableGrid.
-        :setter: Sets the value of EnableGrid.
+        :getter: Returns the value of enableGrid.
+        :setter: Sets the value of enableGrid.
         :type:   bool or 2-tuple of bools
         :raises: `TypeError` if setting an invalid value.
 
         If set to a single boolean value, then both X and y grids will be
-        enabled (``EnableGrid = True``) or disabled (``EnableGrid = False``).
+        enabled (``enableGrid = True``) or disabled (``enableGrid = False``).
 
         If a 2-tuple of bools, the 1st value is the X (vertical) grid and
         the 2nd value is the Y (horizontal) grid.
         """
         return self._gridEnabled
 
-    @EnableGrid.setter
-    def EnableGrid(self, value):
+    @enableGrid.setter
+    def enableGrid(self, value):
         if isinstance(value, bool):
             value = (value, value)
         elif isinstance(value, tuple) and len(value) == 2:
@@ -3027,37 +3027,37 @@ class PlotCanvas(wx.Panel):
         self._gridEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.EnableCenterLines property")
+    @PendingDeprecation("self.enableCenterLines property")
     def SetEnableCenterLines(self, value):
         """
-        Set the EnableCenterLines value.
+        Set the enableCenterLines value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableCenterLines`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableCenterLines`
            property instead.
         """
-        self.EnableCenterLines = value
+        self.enableCenterLines = value
 
-    @PendingDeprecation("self.EnableCenterLines property")
+    @PendingDeprecation("self.enableCenterLines property")
     def GetEnableCenterLines(self):
         """
-        Get the EnableCenterLines value.
+        Get the enableCenterLines value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableCenterLines`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableCenterLines`
            property instead.
         """
-        return self.EnableCenterLines
+        return self.enableCenterLines
 
     @property
-    def EnableCenterLines(self):
+    def enableCenterLines(self):
         """
-        The current EnableCenterLines value.
+        The current enableCenterLines value.
 
-        :getter: Returns the value of EnableCenterLines.
-        :setter: Sets the value of EnableCenterLines.
+        :getter: Returns the value of enableCenterLines.
+        :setter: Sets the value of enableCenterLines.
         :type:   bool or str
         :raises: `TypeError` if setting an invalid value.
 
@@ -3068,45 +3068,45 @@ class PlotCanvas(wx.Panel):
         """
         return self._centerLinesEnabled
 
-    @EnableCenterLines.setter
-    def EnableCenterLines(self, value):
+    @enableCenterLines.setter
+    def enableCenterLines(self, value):
         if value not in [True, False, 'Horizontal', 'Vertical']:
             raise TypeError(
                 "Value should be True, False, 'Horizontal' or 'Vertical'")
         self._centerLinesEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.EnableDiagonals property")
+    @PendingDeprecation("self.enableDiagonals property")
     def SetEnableDiagonals(self, value):
         """
-        Set the EnableDiagonals value.
+        Set the enableDiagonals value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableDiagonals`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableDiagonals`
            property instead.
         """
-        self.EnableDiagonals = value
+        self.enableDiagonals = value
 
-    @PendingDeprecation("self.EnableDiagonals property")
+    @PendingDeprecation("self.enableDiagonals property")
     def GetEnableDiagonals(self):
         """
-        Get the EnableDiagonals value.
+        Get the enableDiagonals value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableDiagonals`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableDiagonals`
            property instead.
         """
-        return self.EnableDiagonals
+        return self.enableDiagonals
 
     @property
-    def EnableDiagonals(self):
+    def enableDiagonals(self):
         """
-        The current EnableDiagonals value.
+        The current enableDiagonals value.
 
-        :getter: Returns the value of EnableDiagonals.
-        :setter: Sets the value of EnableDiagonals.
+        :getter: Returns the value of enableDiagonals.
+        :setter: Sets the value of enableDiagonals.
         :type:   bool or str
         :raises: `TypeError` if setting an invalid value.
 
@@ -3118,8 +3118,8 @@ class PlotCanvas(wx.Panel):
         """
         return self._diagonalsEnabled
 
-    @EnableDiagonals.setter
-    def EnableDiagonals(self, value):
+    @enableDiagonals.setter
+    def enableDiagonals(self, value):
         # TODO: Rename Bottomleft-TopRight, Bottomright-Topleft
         if value not in [True, False,
                          'Bottomleft-Topright', 'Bottomright-Topleft']:
@@ -3130,44 +3130,44 @@ class PlotCanvas(wx.Panel):
         self._diagonalsEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.EnableLegend property")
+    @PendingDeprecation("self.enableLegend property")
     def SetEnableLegend(self, value):
         """
-        Set the EnableLegend value.
+        Set the enableLegend value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableLegend`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableLegend`
            property instead.
         """
-        self.EnableLegend = value
+        self.enableLegend = value
 
-    @PendingDeprecation("self.EnableLegend property")
+    @PendingDeprecation("self.enableLegend property")
     def GetEnableLegend(self):
         """
-        Get the EnableLegend value.
+        Get the enableLegend value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableLegend`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableLegend`
            property instead.
         """
-        return self.EnableLegend
+        return self.enableLegend
 
     @property
-    def EnableLegend(self):
+    def enableLegend(self):
         """
-        The current EnableLegend value.
+        The current enableLegend value.
 
-        :getter: Returns the value of EnableLegend.
-        :setter: Sets the value of EnableLegend.
+        :getter: Returns the value of enableLegend.
+        :setter: Sets the value of enableLegend.
         :type:   bool
         :raises: `TypeError` if setting a non-boolean value.
         """
         return self._legendEnabled
 
-    @EnableLegend.setter
-    def EnableLegend(self, value):
+    @enableLegend.setter
+    def enableLegend(self, value):
         """Set True to enable legend."""
         # XXX: why not `if not isinstance(value, bool):`?
         if value not in [True, False]:
@@ -3175,87 +3175,87 @@ class PlotCanvas(wx.Panel):
         self._legendEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.EnableTitle property")
+    @PendingDeprecation("self.enableTitle property")
     def SetEnableTitle(self, value):
         """
-        Set the EnableTitle value.
+        Set the enableTitle value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableTitle` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableTitle` property
            instead.
         """
-        self.EnableTitle = value
+        self.enableTitle = value
 
-    @PendingDeprecation("self.EnableTitle property")
+    @PendingDeprecation("self.enableTitle property")
     def GetEnableTitle(self):
         """
-        Get the EnableTitle value.
+        Get the enableTitle value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnableTitle` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enableTitle` property
            instead.
         """
-        return self.EnableTitle
+        return self.enableTitle
 
     @property
-    def EnableTitle(self):
+    def enableTitle(self):
         """
-        The current EnableTitle value.
+        The current enableTitle value.
 
-        :getter: Returns the value of EnableTitle.
-        :setter: Sets the value of EnableTitle.
+        :getter: Returns the value of enableTitle.
+        :setter: Sets the value of enableTitle.
         :type:   bool
         :raises: `TypeError` if setting a non-boolean value.
         """
         return self._titleEnabled
 
-    @EnableTitle.setter
-    def EnableTitle(self, value):
+    @enableTitle.setter
+    def enableTitle(self, value):
         if not isinstance(value, bool):
             raise TypeError("Value must be a bool.")
         self._titleEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.EnablePointLabel property")
+    @PendingDeprecation("self.enablePointLabel property")
     def SetEnablePointLabel(self, value):
         """
-        Set the EnablePointLabel value.
+        Set the enablePointLabel value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnablePointLabel`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enablePointLabel`
            property instead.
         """
-        self.EnablePointLabel = value
+        self.enablePointLabel = value
 
-    @PendingDeprecation("self.EnablePointLabel property")
+    @PendingDeprecation("self.enablePointLabel property")
     def GetEnablePointLabel(self):
         """
-        Set the EnablePointLabel value.
+        Set the enablePointLabel value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnablePointLabel`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enablePointLabel`
            property instead.
         """
-        return self.EnablePointLabel
+        return self.enablePointLabel
 
     @property
-    def EnablePointLabel(self):
+    def enablePointLabel(self):
         """
-        The current EnablePointLabel value.
+        The current enablePointLabel value.
 
-        :getter: Returns the value of EnablePointLabel.
-        :setter: Sets the value of EnablePointLabel.
+        :getter: Returns the value of enablePointLabel.
+        :setter: Sets the value of enablePointLabel.
         :type:   bool
         :raises: `TypeError` if setting a non-boolean value.
         """
         return self._pointLabelEnabled
 
-    @EnablePointLabel.setter
-    def EnablePointLabel(self, value):
+    @enablePointLabel.setter
+    def enablePointLabel(self, value):
         if not isinstance(value, bool):
             raise TypeError("Value must be a bool.")
         self._pointLabelEnabled = value
@@ -3263,12 +3263,12 @@ class PlotCanvas(wx.Panel):
         self.last_PointLabel = None
 
     @property
-    def EnableAxes(self):
+    def enableAxes(self):
         """
-        The current EnableAxes value.
+        The current enableAxes value.
 
-        :getter: Returns the value of EnableAxes.
-        :setter: Sets the value of EnableAxes.
+        :getter: Returns the value of enableAxes.
+        :setter: Sets the value of enableAxes.
         :type:   bool, 2-tuple of bool, or 4-tuple of bool
         :raises: `TypeError` if setting an invalid value.
         :raises: `ValueError` if the tuple has incorrect length.
@@ -3283,18 +3283,18 @@ class PlotCanvas(wx.Panel):
         """
         return self._axesEnabled
 
-    @EnableAxes.setter
-    def EnableAxes(self, value):
+    @enableAxes.setter
+    def enableAxes(self, value):
         self._axesEnabled = _set_displayside(value)
         self.Redraw()
 
     @property
-    def EnableAxesValues(self):
+    def enableAxesValues(self):
         """
-        The current EnableAxesValues value.
+        The current enableAxesValues value.
 
-        :getter: Returns the value of EnableAxesValues.
-        :setter: Sets the value of EnableAxesValues.
+        :getter: Returns the value of enableAxesValues.
+        :setter: Sets the value of enableAxesValues.
         :type:   bool, 2-tuple of bool, or 4-tuple of bool
         :raises: `TypeError` if setting an invalid value.
         :raises: `ValueError` if the tuple has incorrect length.
@@ -3309,18 +3309,18 @@ class PlotCanvas(wx.Panel):
         """
         return self._axesValuesEnabled
 
-    @EnableAxesValues.setter
-    def EnableAxesValues(self, value):
+    @enableAxesValues.setter
+    def enableAxesValues(self, value):
         self._axesValuesEnabled = _set_displayside(value)
         self.Redraw()
 
     @property
-    def EnableTicks(self):
+    def enableTicks(self):
         """
-        The current EnableTicks value.
+        The current enableTicks value.
 
-        :getter: Returns the value of EnableTicks.
-        :setter: Sets the value of EnableTicks.
+        :getter: Returns the value of enableTicks.
+        :setter: Sets the value of enableTicks.
         :type:   bool, 2-tuple of bool, or 4-tuple of bool
         :raises: `TypeError` if setting an invalid value.
         :raises: `ValueError` if the tuple has incorrect length.
@@ -3335,119 +3335,119 @@ class PlotCanvas(wx.Panel):
         """
         return self._ticksEnabled
 
-    @EnableTicks.setter
-    def EnableTicks(self, value):
+    @enableTicks.setter
+    def enableTicks(self, value):
         self._ticksEnabled = _set_displayside(value)
         self.Redraw()
 
     @property
-    def EnablePlotTitle(self):
+    def enablePlotTitle(self):
         """
-        The current EnablePlotTitle value.
+        The current enablePlotTitle value.
 
-        :getter: Returns the value of EnablePlotTitle.
-        :setter: Sets the value of EnablePlotTitle.
+        :getter: Returns the value of enablePlotTitle.
+        :setter: Sets the value of enablePlotTitle.
         :type:   bool
         :raises: `TypeError` if setting an invalid value.
         """
         return self._titleEnabled
 
-    @EnablePlotTitle.setter
-    def EnablePlotTitle(self, value):
+    @enablePlotTitle.setter
+    def enablePlotTitle(self, value):
         if not isinstance(value, bool):
             raise TypeError("`value` must be boolean True or False")
         self._titleEnabled = value
         self.Redraw()
 
     @property
-    def EnableXAxisLabel(self):
+    def enableXAxisLabel(self):
         """
-        The current EnableXAxisLabel value.
+        The current enableXAxisLabel value.
 
-        :getter: Returns the value of EnableXAxisLabel.
-        :setter: Sets the value of EnableXAxisLabel.
+        :getter: Returns the value of enableXAxisLabel.
+        :setter: Sets the value of enableXAxisLabel.
         :type:   bool
         :raises: `TypeError` if setting an invalid value.
         """
         return self._xAxisLabelEnabled
 
-    @EnableXAxisLabel.setter
-    def EnableXAxisLabel(self, value):
+    @enableXAxisLabel.setter
+    def enableXAxisLabel(self, value):
         if not isinstance(value, bool):
             raise TypeError("`value` must be boolean True or False")
         self._xAxisLabelEnabled = value
         self.Redraw()
 
     @property
-    def EnableYAxisLabel(self):
+    def enableYAxisLabel(self):
         """
-        The current EnableYAxisLabel value.
+        The current enableYAxisLabel value.
 
-        :getter: Returns the value of EnableYAxisLabel.
-        :setter: Sets the value of EnableYAxisLabel.
+        :getter: Returns the value of enableYAxisLabel.
+        :setter: Sets the value of enableYAxisLabel.
         :type:   bool
         :raises: `TypeError` if setting an invalid value.
         """
         return self._yAxisLabelEnabled
 
-    @EnableYAxisLabel.setter
-    def EnableYAxisLabel(self, value):
+    @enableYAxisLabel.setter
+    def enableYAxisLabel(self, value):
         if not isinstance(value, bool):
             raise TypeError("`value` must be boolean True or False")
         self._yAxisLabelEnabled = value
         self.Redraw()
 
-    # TODO: this conflicts with EnableXAxisLabel and EnableYAxisLabel
+    # TODO: this conflicts with enableXAxisLabel and enableYAxisLabel
     @property
-    def EnableAxesLabels(self):
+    def enableAxesLabels(self):
         """
-        The current EnableAxesLabels value.
+        The current enableAxesLabels value.
 
-        :getter: Returns the value of EnableAxesLabels.
-        :setter: Sets the value of EnableAxesLabels.
+        :getter: Returns the value of enableAxesLabels.
+        :setter: Sets the value of enableAxesLabels.
         :type:   bool
         :raises: `TypeError` if setting an invalid value.
         """
         return self._axesLabelsEnabled
 
-    @EnableAxesLabels.setter
-    def EnableAxesLabels(self, value):
+    @enableAxesLabels.setter
+    def enableAxesLabels(self, value):
         if not isinstance(value, bool):
             raise TypeError("`value` must be boolean True or False")
         self._axesLabelsEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.PointLabelFunc property")
+    @PendingDeprecation("self.pointLabelFunc property")
     def SetPointLabelFunc(self, func):
         """
-        Set the EnablePointLabel value.
+        Set the enablePointLabel value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnablePointLabel`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enablePointLabel`
            property instead.
         """
-        self.PointLabelFunc = func
+        self.pointLabelFunc = func
 
-    @PendingDeprecation("self.PointLabelFunc property")
+    @PendingDeprecation("self.pointLabelFunc property")
     def GetPointLabelFunc(self):
         """
-        Get the EnablePointLabel value.
+        Get the enablePointLabel value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.EnablePointLabel`
+           Use the :attr:`~wx.lib.plot.PlotCanvas.enablePointLabel`
            property instead.
         """
-        return self.PointLabelFunc
+        return self.pointLabelFunc
 
     @property
-    def PointLabelFunc(self):
+    def pointLabelFunc(self):
         """
-        The current PointLabelFunc value.
+        The current pointLabelFunc value.
 
-        :getter: Returns the value of PointLabelFunc.
-        :setter: Sets the value of PointLabelFunc.
+        :getter: Returns the value of pointLabelFunc.
+        :setter: Sets the value of pointLabelFunc.
         :type:   function
 
         TODO: More information is needed.
@@ -3455,8 +3455,8 @@ class PlotCanvas(wx.Panel):
         """
         return self._pointLabelFunc
 
-    @PointLabelFunc.setter
-    def PointLabelFunc(self, func):
+    @pointLabelFunc.setter
+    def pointLabelFunc(self, func):
         self._pointLabelFunc = func
 
     def Reset(self):
@@ -3484,9 +3484,9 @@ class PlotCanvas(wx.Panel):
     def GetXY(self, event):
         """Wrapper around _getXY, which handles log scales"""
         x, y = self._getXY(event)
-        if self.LogScale[0]:
+        if self.logScale[0]:
             x = np.power(10, x)
-        if self.LogScale[1]:
+        if self.logScale[1]:
             y = np.power(10, y)
         return x, y
 
@@ -3507,59 +3507,59 @@ class PlotCanvas(wx.Panel):
         x, y = (screenPos - self._pointShift) / self._pointScale
         return x, y
 
-    @PendingDeprecation("self.XSpec property")
+    @PendingDeprecation("self.xSpec property")
     def SetXSpec(self, spectype='auto'):
         """
-        Set the XSpec value.
+        Set the xSpec value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.XSpec` property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.xSpec` property instead.
         """
-        self.XSpec = spectype
+        self.xSpec = spectype
 
-    @PendingDeprecation("self.YSpec property")
+    @PendingDeprecation("self.ySpec property")
     def SetYSpec(self, spectype='auto'):
         """
-        Set the YSpec value.
+        Set the ySpec value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.YSpec` property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.ySpec` property instead.
         """
-        self.YSpec = spectype
+        self.ySpec = spectype
 
-    @PendingDeprecation("self.XSpec property")
+    @PendingDeprecation("self.xSpec property")
     def GetXSpec(self):
         """
-        Get the XSpec value.
+        Get the xSpec value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.XSpec` property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.xSpec` property instead.
         """
-        return self.XSpec
+        return self.xSpec
 
-    @PendingDeprecation("self.YSpec property")
+    @PendingDeprecation("self.ySpec property")
     def GetYSpec(self):
         """
-        Get the YSpec value.
+        Get the ySpec value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.YSpec` property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.ySpec` property instead.
         """
-        return self.YSpec
+        return self.ySpec
 
     @property
-    def XSpec(self):
+    def xSpec(self):
         """
         Defines the X axis type.
 
         Default is 'auto'.
 
-        :getter: Returns the value of XSpec.
-        :setter: Sets the value of XSpec.
+        :getter: Returns the value of xSpec.
+        :setter: Sets the value of xSpec.
         :type:   str, int, or length-2 sequence of floats
         :raises: `TypeError` if setting an invalid value.
 
@@ -3573,29 +3573,29 @@ class PlotCanvas(wx.Panel):
         + list or tuple: a list of (min, max) values. Must be length 2.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.YSpec`
+           :attr:`~wx.lib.plot.PlotCanvas.ySpec`
         """
         return self._xSpec
 
-    @XSpec.setter
-    def XSpec(self, value):
+    @xSpec.setter
+    def xSpec(self, value):
         ok_values = ('none', 'min', 'auto')
         if value not in ok_values and not isinstance(value, (int, float)):
             if not isinstance(value, (list, tuple)) and len(value != 2):
-                err_str = ("XSpec must be 'none', 'min', 'auto', "
+                err_str = ("xSpec must be 'none', 'min', 'auto', "
                            "a number, or sequence of numbers (length 2)")
                 raise TypeError(err_str)
         self._xSpec = value
 
     @property
-    def YSpec(self):
+    def ySpec(self):
         """
         Defines the Y axis type.
 
         Default is 'auto'.
 
-        :getter: Returns the value of XSpec.
-        :setter: Sets the value of XSpec.
+        :getter: Returns the value of xSpec.
+        :setter: Sets the value of xSpec.
         :type:   str, int, or length-2 sequence of floats
         :raises: `TypeError` if setting an invalid value.
 
@@ -3609,43 +3609,43 @@ class PlotCanvas(wx.Panel):
         + list or tuple: a list of (min, max) values. Must be length 2.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.XSpec`
+           :attr:`~wx.lib.plot.PlotCanvas.xSpec`
         """
         return self._ySpec
 
-    @YSpec.setter
-    def YSpec(self, value):
+    @ySpec.setter
+    def ySpec(self, value):
         ok_values = ('none', 'min', 'auto')
         if value not in ok_values and not isinstance(value, (int, float)):
             if not isinstance(value, (list, tuple)) and len(value != 2):
-                err_str = ("YSpec must be 'none', 'min', 'auto', "
+                err_str = ("ySpec must be 'none', 'min', 'auto', "
                            "a number, or sequence of numbers (length 2)")
                 raise TypeError(err_str)
         self._ySpec = value
 
-    @PendingDeprecation("self.XMaxRange property")
+    @PendingDeprecation("self.xMaxRange property")
     def GetXMaxRange(self):
         """
-        Get the XMaxRange value.
+        Get the xMaxRange value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.XMaxRange` property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.xMaxRange` property instead.
         """
-        return self.XMaxRange
+        return self.xMaxRange
 
     @property
-    def XMaxRange(self):
+    def xMaxRange(self):
         """
         The plots' maximum X range as a tuple of ``(min, max)``.
 
-        :getter: Returns the value of XMaxRange.
+        :getter: Returns the value of xMaxRange.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.YMaxRange`
+           :attr:`~wx.lib.plot.PlotCanvas.yMaxRange`
         """
         xAxis = self._getXMaxRange()
-        if self.LogScale[0]:
+        if self.logScale[0]:
             xAxis = np.power(10, xAxis)
         return xAxis
 
@@ -3656,29 +3656,29 @@ class PlotCanvas(wx.Panel):
         xAxis = self._axisInterval(self._xSpec, p1[0], p2[0])  # in user units
         return xAxis
 
-    @PendingDeprecation("self.YMaxRange property")
+    @PendingDeprecation("self.yMaxRange property")
     def GetYMaxRange(self):
         """
-        Get the YMaxRange value.
+        Get the yMaxRange value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.YMaxRange` property instead.
+           Use the :attr:`~wx.lib.plot.PlotCanvas.yMaxRange` property instead.
         """
-        return self.YMaxRange
+        return self.yMaxRange
 
     @property
-    def YMaxRange(self):
+    def yMaxRange(self):
         """
         The plots' maximum Y range as a tuple of ``(min, max)``.
 
-        :getter: Returns the value of YMaxRange.
+        :getter: Returns the value of yMaxRange.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.XMaxRange`
+           :attr:`~wx.lib.plot.PlotCanvas.xMaxRange`
         """
         yAxis = self._getYMaxRange()
-        if self.LogScale[1]:
+        if self.logScale[1]:
             yAxis = np.power(10, yAxis)
         return yAxis
 
@@ -3689,31 +3689,31 @@ class PlotCanvas(wx.Panel):
         yAxis = self._axisInterval(self._ySpec, p1[1], p2[1])
         return yAxis
 
-    @PendingDeprecation("self.XCurrentRange property")
+    @PendingDeprecation("self.xCurrentRange property")
     def GetXCurrentRange(self):
         """
-        Get the XCurrentRange value.
+        Get the xCurrentRange value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.XCurrentRange` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.xCurrentRange` property
            instead.
         """
-        return self.XCurrentRange
+        return self.xCurrentRange
 
     @property
-    def XCurrentRange(self):
+    def xCurrentRange(self):
         """
         The plots' X range of the currently displayed portion as
         a tuple of ``(min, max)``
 
-        :getter: Returns the value of XCurrentRange.
+        :getter: Returns the value of xCurrentRange.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.YCurrentRange`
+           :attr:`~wx.lib.plot.PlotCanvas.yCurrentRange`
         """
         xAxis = self._getXCurrentRange()
-        if self.LogScale[0]:
+        if self.logScale[0]:
             xAxis = np.power(10, xAxis)
         return xAxis
 
@@ -3722,31 +3722,31 @@ class PlotCanvas(wx.Panel):
         portion of graph"""
         return self.last_draw[1]
 
-    @PendingDeprecation("self.YCurrentRange property")
+    @PendingDeprecation("self.yCurrentRange property")
     def GetYCurrentRange(self):
         """
-        Get the YCurrentRange value.
+        Get the yCurrentRange value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.YCurrentRange` property
+           Use the :attr:`~wx.lib.plot.PlotCanvas.yCurrentRange` property
            instead.
         """
-        return self.YCurrentRange
+        return self.yCurrentRange
 
     @property
-    def YCurrentRange(self):
+    def yCurrentRange(self):
         """
         The plots' Y range of the currently displayed portion as
         a tuple of ``(min, max)``
 
-        :getter: Returns the value of YCurrentRange.
+        :getter: Returns the value of yCurrentRange.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.XCurrentRange`
+           :attr:`~wx.lib.plot.PlotCanvas.xCurrentRange`
         """
         yAxis = self._getYCurrentRange()
-        if self.LogScale[1]:
+        if self.logScale[1]:
             yAxis = np.power(10, yAxis)
         return yAxis
 
@@ -3758,7 +3758,7 @@ class PlotCanvas(wx.Panel):
     def Draw(self, graphics, xAxis=None, yAxis=None, dc=None):
         """Wrapper around _Draw, which handles log axes"""
 
-        graphics.LogScale = self.LogScale
+        graphics.logScale = self.logScale
 
         # check Axis is either tuple or none
         err_txt = "xAxis should be None or (minX, maxX). Got type `{}`."
@@ -3773,12 +3773,12 @@ class PlotCanvas(wx.Panel):
         if xAxis is not None:
             if xAxis[0] == xAxis[1]:
                 return
-            if self.LogScale[0]:
+            if self.logScale[0]:
                 xAxis = np.log10(xAxis)
         if yAxis is not None:
             if yAxis[0] == yAxis[1]:
                 return
-            if self.LogScale[1]:
+            if self.logScale[1]:
                 yAxis = np.log10(yAxis)
         self._Draw(graphics, xAxis, yAxis, dc)
 
@@ -3882,7 +3882,7 @@ class PlotCanvas(wx.Panel):
         else:
             yticks = None
         if yticks:
-            if self.LogScale[1]:
+            if self.logScale[1]:
                 yTextExtent = dc.GetTextExtent('-2e-2')
             else:
                 yTextExtentBottom = dc.GetTextExtent(yticks[0][1])
@@ -3940,7 +3940,7 @@ class PlotCanvas(wx.Panel):
 
         graphics.scaleAndShift(scale, shift)
         # thicken up lines and markers if printing
-        graphics.PrinterScale = self.printerScale
+        graphics.printerScale = self.printerScale
 
         # set clipping area so drawing does not occur outside axis box
         ptx, pty, rectWidth, rectHeight = self._point2ClientCoord(p1, p2)
@@ -4302,13 +4302,13 @@ class PlotCanvas(wx.Panel):
         """Draws Title and labels and returns width and height for each"""
         # TextExtents for Title and Axis Labels
         dc.SetFont(self._getFont(self._fontSizeTitle))
-        if self.EnablePlotTitle:
-            title = graphics.Title
+        if self.enablePlotTitle:
+            title = graphics.title
             titleWH = dc.GetTextExtent(title)
         else:
             titleWH = (0, 0)
         dc.SetFont(self._getFont(self._fontSizeAxis))
-        xLabel, yLabel = graphics.XLabel, graphics.YLabel
+        xLabel, yLabel = graphics.xLabel, graphics.yLabel
         xLabelWH = dc.GetTextExtent(xLabel)
         yLabelWH = dc.GetTextExtent(yLabel)
         return titleWH, xLabelWH, yLabelWH
@@ -4436,7 +4436,7 @@ class PlotCanvas(wx.Panel):
         :type yticks: list of length-2 lists
         """
         # increases thickness for printing only
-        pen = self.GridPen
+        pen = self.gridPen
         penWidth = self.printerScale * pen.GetWidth()
         pen.SetWidth(penWidth)
         dc.SetPen(pen)
@@ -4444,13 +4444,13 @@ class PlotCanvas(wx.Panel):
         x, y, width, height = self._point2ClientCoord(p1, p2)
 
         if self._xSpec != 'none':
-            if self.EnableGrid[0]:
+            if self.enableGrid[0]:
                 for x, _ in xticks:
                     pt = scale_and_shift_point(x, p1[1], scale, shift)
                     dc.DrawLine(pt[0], pt[1], pt[0], pt[1] - height)
 
         if self._ySpec != 'none':
-            if self.EnableGrid[1]:
+            if self.enableGrid[1]:
                 for y, label in yticks:
                     pt = scale_and_shift_point(p1[0], y, scale, shift)
                     dc.DrawLine(pt[0], pt[1], pt[0] + width, pt[1])
@@ -4484,7 +4484,7 @@ class PlotCanvas(wx.Panel):
         #       - done via negative ticklength values?
         #           + works but the axes values cut off the ticks.
         # increases thickness for printing only
-        pen = self.TickPen
+        pen = self.tickPen
         penWidth = self.printerScale * pen.GetWidth()
         pen.SetWidth(penWidth)
         dc.SetPen(pen)
@@ -4493,8 +4493,8 @@ class PlotCanvas(wx.Panel):
         yTickLength = 3 * self.printerScale * self._tickLength[1]
         xTickLength = 3 * self.printerScale * self._tickLength[0]
 
-        ticks = self.EnableTicks
-        if self.XSpec != 'none':        # I don't like this :-/
+        ticks = self.enableTicks
+        if self.xSpec != 'none':        # I don't like this :-/
             if ticks.bottom:
                 lines = []
                 for x, label in xticks:
@@ -4508,7 +4508,7 @@ class PlotCanvas(wx.Panel):
                     lines.appned((pt[0], pt[1], pt[0], pt[1] + xTickLength))
                 dc.DrawLineList(lines)
 
-        if self.YSpec != 'none':
+        if self.ySpec != 'none':
             if ticks.left:
                 lines = []
                 for y, label in yticks:
@@ -4544,7 +4544,7 @@ class PlotCanvas(wx.Panel):
         :type shift: :class:`np.array`, length 2
         """
         # increases thickness for printing only
-        pen = self.CenterLinePen
+        pen = self.centerLinePen
         penWidth = self.printerScale * pen.GetWidth()
         pen.SetWidth(penWidth)
         dc.SetPen(pen)
@@ -4588,7 +4588,7 @@ class PlotCanvas(wx.Panel):
                       DC coords. Must be in plot units, not DC units.
         :type shift: :class:`np.array`, length 2
         """
-        pen = self.DiagonalPen
+        pen = self.diagonalPen
         penWidth = self.printerScale * pen.GetWidth()
         pen.SetWidth(penWidth)
         dc.SetPen(pen)
@@ -4627,13 +4627,13 @@ class PlotCanvas(wx.Panel):
         :type shift: :class:`np.array`, length 2
         """
         # increases thickness for printing only
-        pen = self.AxesPen
+        pen = self.axesPen
         penWidth = self.printerScale * pen.GetWidth()
         pen.SetWidth(penWidth)
         dc.SetPen(pen)
 
-        axes = self.EnableAxes
-        if self.XSpec != 'none':
+        axes = self.enableAxes
+        if self.xSpec != 'none':
             if axes.bottom:
                 lower, upper = p1[0], p2[0]
                 a1 = scale_and_shift_point(lower, p1[1], scale, shift)
@@ -4645,7 +4645,7 @@ class PlotCanvas(wx.Panel):
                 a2 = scale_and_shift_point(upper, p2[1], scale, shift)
                 dc.DrawLine(a1[0], a1[1], a2[0], a2[1])
 
-        if self.YSpec != 'none':
+        if self.ySpec != 'none':
             if axes.left:
                 lower, upper = p1[1], p2[1]
                 a1 = scale_and_shift_point(p1[0], lower, scale, shift)
@@ -4685,8 +4685,8 @@ class PlotCanvas(wx.Panel):
         """
         # TODO: More code duplication? Same as _drawGrid and _drawTicks?
         # TODO: update the bounding boxes when adding right and top values
-        axes = self.EnableAxesValues
-        if self.XSpec != 'none':
+        axes = self.enableAxesValues
+        if self.xSpec != 'none':
             if axes.bottom:
                 labels = [tick[1] for tick in xticks]
                 coords = []
@@ -4709,7 +4709,7 @@ class PlotCanvas(wx.Panel):
                     )
                 dc.DrawTextList(labels, coords)
 
-        if self.YSpec != 'none':
+        if self.ySpec != 'none':
             if axes.left:
                 h = dc.GetCharHeight()
                 labels = [tick[1] for tick in yticks]
@@ -4789,7 +4789,7 @@ class PlotCanvas(wx.Panel):
             + (self.plotbox_size[0] - lhsW - rhsW) / 2. - titleWH[0] / 2.,
             self.plotbox_origin[1] - self.plotbox_size[1]
         )
-        dc.DrawText(graphics.Title, titlePos[0], titlePos[1])
+        dc.DrawText(graphics.title, titlePos[0], titlePos[1])
 
     def _drawAxesLabels(self, dc, graphics, lhsW, rhsW, bottomH, topH,
                         xLabelWH, yLabelWH):
@@ -4803,15 +4803,15 @@ class PlotCanvas(wx.Panel):
             + (self.plotbox_size[0] - lhsW - rhsW) / 2. - xLabelWH[0] / 2.,
             self.plotbox_origin[1] - xLabelWH[1]
         )
-        dc.DrawText(graphics.XLabel, xLabelPos[0], xLabelPos[1])
+        dc.DrawText(graphics.xLabel, xLabelPos[0], xLabelPos[1])
         yLabelPos = (
             self.plotbox_origin[0] - 3 * self._pointSize[0],
             self.plotbox_origin[1] - bottomH
             - (self.plotbox_size[1] - bottomH - topH) / 2. + yLabelWH[0] / 2.
         )
-        if graphics.YLabel:  # bug fix for Linux
+        if graphics.yLabel:  # bug fix for Linux
             dc.DrawRotatedText(
-                graphics.YLabel, yLabelPos[0], yLabelPos[1], 90)
+                graphics.yLabel, yLabelPos[0], yLabelPos[1], 90)
 
     @TempStyle('pen')
     def _drawPlotAreaLabels(self, dc, graphics, lhsW, rhsW, titleWH,
@@ -4916,7 +4916,7 @@ class PlotCanvas(wx.Panel):
             self._sb_ignore = False
             return
 
-        if not self.ShowScrollbars:
+        if not self.showScrollbars:
             return
 
         self._adjustingSB = True
@@ -5597,7 +5597,7 @@ class TestFrame(wx.Frame):
         self.client = PlotCanvas(self)
         # define the function for drawing pointLabels
 #        self.client.SetPointLabelFunc(self.DrawPointLabel)
-        self.client.PointLabelFunc = self.DrawPointLabel
+        self.client.pointLabelFunc = self.DrawPointLabel
         # Create mouse event for showing cursor coords in status bar
         self.client.canvas.Bind(wx.EVT_LEFT_DOWN, self.OnMouseLeftDown)
         # Show closest point when enabled
@@ -5643,7 +5643,7 @@ class TestFrame(wx.Frame):
 
     def OnMotion(self, event):
         # show closest point (when enbled)
-        if self.client.EnablePointLabel:
+        if self.client.enablePointLabel:
             # make up dict with info for the pointLabel
             # I've decided to mark the closest point on the closest curve
             dlst = self.client.GetClosestPoint(
@@ -5691,10 +5691,10 @@ class TestFrame(wx.Frame):
                                     wx.FONTSTYLE_NORMAL,
                                     wx.FONTWEIGHT_NORMAL)
                             )
-        self.client.FontSizeAxis = 20
-        self.client.FontSizeLegend = 12
-        self.client.XSpec = 'min'
-        self.client.YSpec = 'none'
+        self.client.fontSizeAxis = 20
+        self.client.fontSizeLegend = 12
+        self.client.xSpec = 'min'
+        self.client.ySpec = 'none'
         self.client.Draw(_draw3Objects())
 
     def OnPlotDraw4(self, event):
@@ -5721,8 +5721,8 @@ class TestFrame(wx.Frame):
         self.resetDefaults()
         # self.client.SetEnableLegend(True)   #turn on Legend
         # self.client.SetEnableGrid(True)     #turn on Grid
-        self.client.XSpec = 'none'
-        self.client.YSpec = 'auto'
+        self.client.xSpec = 'none'
+        self.client.ySpec = 'auto'
         self.client.Draw(_draw6Objects(), xAxis=(0, 7))
 
     def OnPlotDraw7(self, event):
@@ -5730,7 +5730,7 @@ class TestFrame(wx.Frame):
         self.resetDefaults()
         self.plot_options_menu.Check(271, True)
         self.plot_options_menu.Check(272, True)
-        self.client.LogScale = (True, True)
+        self.client.logScale = (True, True)
         self.client.Draw(_draw7Objects())
 
     def OnPlotDraw8(self, event):
@@ -5760,7 +5760,7 @@ class TestFrame(wx.Frame):
             self.client.Draw(graphics, (1, 3.05), (0, 1))
 
     def OnEnableZoom(self, event):
-        self.client.EnableZoom = event.IsChecked()
+        self.client.enableZoom = event.IsChecked()
         if self.mainmenu.IsChecked(217):
             self.mainmenu.Check(217, False)
 
@@ -5768,155 +5768,155 @@ class TestFrame(wx.Frame):
 
     def _checkOtherGridMenuItems(self):
         """ check or uncheck the submenu items """
-        self.gridSubMenu.Check(2151, self.client.EnableGrid[0])
-        self.gridSubMenu.Check(2152, self.client.EnableGrid[1])
-        self.gridSubMenu.Check(2153, all(self.client.EnableGrid))
+        self.gridSubMenu.Check(2151, self.client.enableGrid[0])
+        self.gridSubMenu.Check(2152, self.client.enableGrid[1])
+        self.gridSubMenu.Check(2153, all(self.client.enableGrid))
 
     def OnEnableGridX(self, event):
-        old = self.client.EnableGrid
-        self.client.EnableGrid = (event.IsChecked(), old[1])
+        old = self.client.enableGrid
+        self.client.enableGrid = (event.IsChecked(), old[1])
         self._checkOtherGridMenuItems()
 
     def OnEnableGridY(self, event):
-        old = self.client.EnableGrid
-        self.client.EnableGrid = (old[0], event.IsChecked())
+        old = self.client.enableGrid
+        self.client.enableGrid = (old[0], event.IsChecked())
         self._checkOtherGridMenuItems()
 
     def OnEnableGridAll(self, event):
-        self.client.EnableGrid = event.IsChecked()
+        self.client.enableGrid = event.IsChecked()
         self._checkOtherGridMenuItems()
         self.gridSubMenu.Check(2151, event.IsChecked())
         self.gridSubMenu.Check(2152, event.IsChecked())
 
     def OnEnableDrag(self, event):
-        self.client.EnableDrag = event.IsChecked()
+        self.client.enableDrag = event.IsChecked()
         if self.mainmenu.IsChecked(214):
             self.mainmenu.Check(214, False)
 
     def OnEnableLegend(self, event):
-        self.client.EnableLegend = event.IsChecked()
+        self.client.enableLegend = event.IsChecked()
 
     def OnEnablePointLabel(self, event):
-        self.client.EnablePointLabel = event.IsChecked()
+        self.client.enablePointLabel = event.IsChecked()
 
     def OnEnableAntiAliasing(self, event):
-        self.client.EnableAntiAliasing = event.IsChecked()
+        self.client.enableAntiAliasing = event.IsChecked()
 
     def OnEnableHiRes(self, event):
-        self.client.EnableHiRes = event.IsChecked()
+        self.client.enableHiRes = event.IsChecked()
 
     ### Axes Events ###
 
     def _checkOtherAxesMenuItems(self):
         """ check or uncheck the submenu items """
-        self.axesSubMenu.Check(2401, self.client.EnableAxes[0])
-        self.axesSubMenu.Check(2402, self.client.EnableAxes[1])
-        self.axesSubMenu.Check(2403, self.client.EnableAxes[2])
-        self.axesSubMenu.Check(2404, self.client.EnableAxes[3])
-        self.axesSubMenu.Check(2405, all(self.client.EnableAxes[:2]))
-        self.axesSubMenu.Check(2406, all(self.client.EnableAxes))
+        self.axesSubMenu.Check(2401, self.client.enableAxes[0])
+        self.axesSubMenu.Check(2402, self.client.enableAxes[1])
+        self.axesSubMenu.Check(2403, self.client.enableAxes[2])
+        self.axesSubMenu.Check(2404, self.client.enableAxes[3])
+        self.axesSubMenu.Check(2405, all(self.client.enableAxes[:2]))
+        self.axesSubMenu.Check(2406, all(self.client.enableAxes))
 
     def OnEnableAxesBottom(self, event):
-        old = self.client.EnableAxes
-        self.client.EnableAxes = (event.IsChecked(), old[1], old[2], old[3])
+        old = self.client.enableAxes
+        self.client.enableAxes = (event.IsChecked(), old[1], old[2], old[3])
         self._checkOtherAxesMenuItems()
 
     def OnEnableAxesLeft(self, event):
-        old = self.client.EnableAxes
-        self.client.EnableAxes = (old[0], event.IsChecked(), old[2], old[3])
+        old = self.client.enableAxes
+        self.client.enableAxes = (old[0], event.IsChecked(), old[2], old[3])
         self._checkOtherAxesMenuItems()
 
     def OnEnableAxesTop(self, event):
-        old = self.client.EnableAxes
-        self.client.EnableAxes = (old[0], old[1], event.IsChecked(), old[3])
+        old = self.client.enableAxes
+        self.client.enableAxes = (old[0], old[1], event.IsChecked(), old[3])
         self._checkOtherAxesMenuItems()
 
     def OnEnableAxesRight(self, event):
-        old = self.client.EnableAxes
-        self.client.EnableAxes = (old[0], old[1], old[2], event.IsChecked())
+        old = self.client.enableAxes
+        self.client.enableAxes = (old[0], old[1], old[2], event.IsChecked())
         self._checkOtherAxesMenuItems()
 
     def OnEnableAxesBottomLeft(self, event):
         checked = event.IsChecked()
-        old = self.client.EnableAxes
-        self.client.EnableAxes = (checked, checked, old[2], old[3])
+        old = self.client.enableAxes
+        self.client.enableAxes = (checked, checked, old[2], old[3])
         self._checkOtherAxesMenuItems()
 
     def OnEnableAxesAll(self, event):
         checked = event.IsChecked()
-        self.client.EnableAxes = (checked, checked, checked, checked)
+        self.client.enableAxes = (checked, checked, checked, checked)
         self._checkOtherAxesMenuItems()
 
     ### Ticks Events ###
 
     def _checkOtherTicksMenuItems(self):
         """ check or uncheck the submenu items """
-        self.ticksSubMenu.Check(2501, self.client.EnableTicks[0])
-        self.ticksSubMenu.Check(2502, self.client.EnableTicks[1])
-        self.ticksSubMenu.Check(2503, self.client.EnableTicks[2])
-        self.ticksSubMenu.Check(2504, self.client.EnableTicks[3])
-#        self.ticksSubMenu.Check(2505, all(self.client.EnableTicks[:2]))
-#        self.axesSubMenu.Check(2506, all(self.client.EnableTicks))
+        self.ticksSubMenu.Check(2501, self.client.enableTicks[0])
+        self.ticksSubMenu.Check(2502, self.client.enableTicks[1])
+        self.ticksSubMenu.Check(2503, self.client.enableTicks[2])
+        self.ticksSubMenu.Check(2504, self.client.enableTicks[3])
+#        self.ticksSubMenu.Check(2505, all(self.client.enableTicks[:2]))
+#        self.axesSubMenu.Check(2506, all(self.client.enableTicks))
 
     def OnEnableTicksBottom(self, event):
-        old = self.client.EnableTicks
-        self.client.EnableTicks = (event.IsChecked(), old[1],
+        old = self.client.enableTicks
+        self.client.enableTicks = (event.IsChecked(), old[1],
                                    old[2], old[3])
         self._checkOtherTicksMenuItems()
 
     def OnEnableTicksLeft(self, event):
-        old = self.client.EnableTicks
-        self.client.EnableTicks = (old[0], event.IsChecked(),
+        old = self.client.enableTicks
+        self.client.enableTicks = (old[0], event.IsChecked(),
                                    old[2], old[3])
         self._checkOtherTicksMenuItems()
 
     def OnEnableTicksTop(self, event):
-        old = self.client.EnableTicks
-        self.client.EnableTicks = (old[0], old[1],
+        old = self.client.enableTicks
+        self.client.enableTicks = (old[0], old[1],
                                    event.IsChecked(), old[3])
         self._checkOtherTicksMenuItems()
 
     def OnEnableTicksRight(self, event):
-        old = self.client.EnableTicks
-        self.client.EnableTicks = (old[0], old[1],
+        old = self.client.enableTicks
+        self.client.enableTicks = (old[0], old[1],
                                    old[2], event.IsChecked())
         self._checkOtherTicksMenuItems()
 
     ### AxesValues Events ###
 
     def OnEnableAxesValuesBottom(self, event):
-        old = self.client.EnableAxesValues
-        self.client.EnableAxesValues = (event.IsChecked(), old[1],
+        old = self.client.enableAxesValues
+        self.client.enableAxesValues = (event.IsChecked(), old[1],
                                         old[2], old[3])
 
     def OnEnableAxesValuesLeft(self, event):
-        old = self.client.EnableAxesValues
-        self.client.EnableAxesValues = (old[0], event.IsChecked(),
+        old = self.client.enableAxesValues
+        self.client.enableAxesValues = (old[0], event.IsChecked(),
                                         old[2], old[3])
 
     def OnEnableAxesValuesTop(self, event):
-        old = self.client.EnableAxesValues
-        self.client.EnableAxesValues = (old[0], old[1],
+        old = self.client.enableAxesValues
+        self.client.enableAxesValues = (old[0], old[1],
                                         event.IsChecked(), old[3])
 
     def OnEnableAxesValuesRight(self, event):
-        old = self.client.EnableAxesValues
-        self.client.EnableAxesValues = (old[0], old[1],
+        old = self.client.enableAxesValues
+        self.client.enableAxesValues = (old[0], old[1],
                                         old[2], event.IsChecked())
 
     ### Other Events ###
 
     def OnEnablePlotTitle(self, event):
-        self.client.EnablePlotTitle = event.IsChecked()
+        self.client.enablePlotTitle = event.IsChecked()
 
     def OnEnableAxesLabels(self, event):
-        self.client.EnableAxesLabels = event.IsChecked()
+        self.client.enableAxesLabels = event.IsChecked()
 
     def OnEnableCenterLines(self, event):
-        self.client.EnableCenterLines = event.IsChecked()
+        self.client.enableCenterLines = event.IsChecked()
 
     def OnEnableDiagonals(self, event):
-        self.client.EnableDiagonals = event.IsChecked()
+        self.client.enableDiagonals = event.IsChecked()
 
     def OnBackgroundGray(self, event):
         self.client.SetBackgroundColour("#CCCCCC")
@@ -5935,19 +5935,19 @@ class TestFrame(wx.Frame):
         self.client.Redraw()
 
     def OnLogX(self, event):
-        self.client.LogScale = (event.IsChecked(), self.client.LogScale[1])
+        self.client.logScale = (event.IsChecked(), self.client.logScale[1])
         self.client.Redraw()
 
     def OnLogY(self, event):
-        self.client.LogScale = (self.client.LogScale[0], event.IsChecked())
+        self.client.logScale = (self.client.logScale[0], event.IsChecked())
         self.client.Redraw()
 
     def OnAbsX(self, event):
-        self.client.AbsScale = (event.IsChecked(), self.client.AbsScale[1])
+        self.client.absScale = (event.IsChecked(), self.client.absScale[1])
         self.client.Redraw()
 
     def OnAbsY(self, event):
-        self.client.AbsScale = (self.client.AbsScale[0], event.IsChecked())
+        self.client.absScale = (self.client.absScale[0], event.IsChecked())
         self.client.Redraw()
 
     def OnScrUp(self, event):
@@ -5971,11 +5971,11 @@ class TestFrame(wx.Frame):
                                     wx.FONTSTYLE_NORMAL,
                                     wx.FONTWEIGHT_NORMAL)
                             )
-        self.client.FontSizeAxis = 10
-        self.client.FontSizeLegend = 7
-        self.client.LogScale = (False, False)
-        self.client.XSpec = 'auto'
-        self.client.YSpec = 'auto'
+        self.client.fontSizeAxis = 10
+        self.client.fontSizeLegend = 7
+        self.client.logScale = (False, False)
+        self.client.xSpec = 'auto'
+        self.client.ySpec = 'auto'
 
 
 def __test():

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -1447,30 +1447,21 @@ class BoxPlot(PolyPoints):
     ``legend=''``                      legend string  str
     =================================  =============  =======================
 
+    .. note::
+
+       ``np.NaN`` and ``np.inf`` values are ignored.
+
     .. admonition:: TODO
 
-       + [x] Separate out each draw into individual methods
-       + [x] Fix the median line extending outside of the box on the right
-       + [x] Allow for multiple box plots side-by-side
-
-         - It's a hack, but it works.
-
+       + [ ] Figure out a better way to get multiple box plots side-by-side
+         (current method is a hack).
        + [ ] change the X axis to some labels.
-       + [x] Add getLegend method
-
-         - Not Needed since we inherit from PolyPoints
-
-       + [x] Add getClosestPoint method - links to box plot or outliers
-
-         - Current method works and hits every point. Is that good enough?
-
-       + [ ] Add customization
-
-         - [ ] Pens and Fills for elements
-         - [ ] outlier shapes(?) and sizes
-         - [ ] box width
-
-       + [ ] Get log-y working
+       + [ ] Change getClosestPoint to only grab box plot items and outlers?
+             Currently grabs every data point.
+       + [ ] Add more customization such as Pens/Brushes, outlier shapes/size,
+         and box width.
+       + [ ] Figure out how I want to handle log-y: log data then calcBP? Or
+         should I calc the BP first then the plot it on a log scale?
     """
     _attributes = {'colour': 'black',
                    'width': 1,
@@ -1498,6 +1489,19 @@ class BoxPlot(PolyPoints):
 
         # Init the parent class
         PolyPoints.__init__(self, points, attr)
+
+    def _clean_data(self, data=None):
+        """
+        Removes NaN and Inf from the data.
+        """
+        if data is None:
+            data = self.points
+
+        # clean out NaN and infinity values.
+        data = data[~np.isnan(data)]
+        data = data[~np.isinf(data)]
+
+        return data
 
     def boundingBox(self):
         """
@@ -1576,13 +1580,8 @@ class BoxPlot(PolyPoints):
             Descriptive statistics for data:
             (min_data, low_whisker, q25, median, q75, high_whisker, max_data)
 
-        Notes:
-        ------
-        # TODO: Verify how NaN is handled then decide how I want to handle it.
-
         """
-        if data is None:
-            data = self.points
+        data = self._clean_data(data)
 
         min_data = float(np.min(data))
         max_data = float(np.max(data))
@@ -1608,8 +1607,7 @@ class BoxPlot(PolyPoints):
         """
         Calculates the outliers. Must be called after calcBpData.
         """
-        if data is None:
-            data = self.points
+        data = self._clean_data(data)
 
         outliers = data
         outlier_bool = np.logical_or(outliers > self._bpdata.high_whisker,
@@ -1744,16 +1742,11 @@ class BoxPlot(PolyPoints):
     @TempStyle('pen')
     def _draw_outliers(self, dc, printerScale):
         """Draws dots for the outliers"""
-        xpos = self.xpos
-
         # Set the pen
         outlier_pen = wx.Pen(wx.BLUE, 5, wx.PENSTYLE_SOLID)
         dc.SetPen(outlier_pen)
 
         outliers = self._outliers
-
-
-#        jitter = 0.05 * np.random.random_sample(len(outliers)) + xpos - 0.025
 
         # Scale the data for plotting
         pt_data = np.array([self.jitter, outliers]).T
@@ -5273,7 +5266,7 @@ def _draw8Objects():
     """
     Box plot
     """
-    data1 = np.array([912, 337, 607, 583, 512, 531, 558, 381, 621, 574,
+    data1 = np.array([np.NaN, 337, 607, 583, 512, 531, 558, 381, 621, 574,
                       538, 577, 679, 415, 454, 417, 635, 319, 350, 183,
                       863, 337, 607, 583, 512, 531, 558, 381, 621, 574,
                       538, 577, 679, 415, 454, 417, 635, 319, 350, 97])

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -1457,7 +1457,7 @@ class BoxPlot(PolyPoints):
          (current method is a hack).
        + [ ] change the X axis to some labels.
        + [ ] Change getClosestPoint to only grab box plot items and outlers?
-             Currently grabs every data point.
+         Currently grabs every data point.
        + [ ] Add more customization such as Pens/Brushes, outlier shapes/size,
          and box width.
        + [ ] Figure out how I want to handle log-y: log data then calcBP? Or

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -1935,6 +1935,43 @@ def scale_and_shift_point(x, y, scale=1, shift=0):
     return point
 
 
+def _set_displayside(value):
+    """
+    Wrapper around :class:`~wx.lib.plot._DisplaySide` that allowing for
+    "overloaded" calls.
+
+    If ``value`` is a boolean: all 4 sides are set to ``value``
+
+    If ``value`` is a 2-tuple: the bottom and left sides are set to ``value``
+    and the other sides are set to False.
+
+    If ``value`` is a 4-tuple, then each item is set individually: ``(bottom,
+    left, top, right)``
+
+    :param value: Which sides to display.
+    :type value:   bool, 2-tuple of bool, or 4-tuple of bool
+    :raises: `TypeError` if setting an invalid value.
+    :raises: `ValueError` if the tuple has incorrect length.
+    :rtype: :class:`~wx.lib.plot._DisplaySide`
+    """
+    err_txt = ("value must be a bool or a 2- or 4-tuple of bool")
+
+    # TODO: for 2-tuple, do not change other sides? rather than set to False.
+    if isinstance(value, bool):
+        # turns on or off all axes
+        _value = (value, value, value, value)
+    elif isinstance(value, tuple):
+        if len(value) == 2:
+            _value = (value[0], value[1], False, False)
+        elif len(value) == 4:
+            _value = value
+        else:
+            raise ValueError(err_txt)
+    else:
+        raise TypeError(err_txt)
+    return _DisplaySide(*_value)
+
+
 #-------------------------------------------------------------------------
 # Main window that you will want to import into your application.
 
@@ -3122,22 +3159,7 @@ class PlotCanvas(wx.Panel):
 
     @EnableAxes.setter
     def EnableAxes(self, value):
-        err_txt = ("Axis value must be a bool or a 2- or 4-tuple of bool")
-
-        # TODO: Refactor - same as EnableAxesValues and EnableTicks
-        if isinstance(value, bool):
-            # turns on or off all axes
-            _value = (value, value, value, value)
-        elif isinstance(value, tuple):
-            if len(value) == 2:
-                _value = (value[0], value[1], False, False)
-            elif len(value) == 4:
-                _value = value
-            else:
-                raise ValueError(err_txt)
-        else:
-            raise TypeError(err_txt)
-        self._axesEnabled = _DisplaySide(*_value)
+        self._axesEnabled = _set_displayside(value)
         self.Redraw()
 
     @property
@@ -3163,22 +3185,7 @@ class PlotCanvas(wx.Panel):
 
     @EnableAxesValues.setter
     def EnableAxesValues(self, value):
-        err_txt = ("value must be a bool or a 2- or 4-tuple of bool")
-
-        # TODO: Refactor - same as EnableAxes and EnableTicks
-        if isinstance(value, bool):
-            # turns on or off all axes
-            _value = (value, value, value, value)
-        elif isinstance(value, tuple):
-            if len(value) == 2:
-                _value = (value[0], value[1], False, False)
-            elif len(value) == 4:
-                _value = value
-            else:
-                raise ValueError(err_txt)
-        else:
-            raise TypeError(err_txt)
-        self._axesValuesEnabled = _DisplaySide(*_value)
+        self._axesValuesEnabled = _set_displayside(value)
         self.Redraw()
 
     @property
@@ -3204,22 +3211,7 @@ class PlotCanvas(wx.Panel):
 
     @EnableTicks.setter
     def EnableTicks(self, value):
-        err_txt = ("value must be a bool or a 2- or 4-tuple of bool")
-
-        # TODO: Refactor - same as EnableAxes and EnableAxesValues
-        if isinstance(value, bool):
-            # turns on or off all axes
-            _value = (value, value, value, value)
-        elif isinstance(value, tuple):
-            if len(value) == 2:
-                _value = (value[0], value[1], False, False)
-            elif len(value) == 4:
-                _value = value
-            else:
-                raise ValueError(err_txt)
-        else:
-            raise TypeError(err_txt)
-        self._ticksEnabled = _DisplaySide(*_value)
+        self._ticksEnabled = _set_displayside(value)
         self.Redraw()
 
     @property

--- a/wx/lib/plot.py
+++ b/wx/lib/plot.py
@@ -503,7 +503,7 @@ class PendingDeprecation(object):
     def __call__(self, func):
         """Support for functions"""
         self.func = func
-        self._update_docs()
+#        self._update_docs()
 
         @functools.wraps(self.func)
         def wrapper(*args, **kwargs):
@@ -1999,7 +1999,16 @@ class PlotCanvas(wx.Panel):
     ### Pen Properties
     @property
     def GridPen(self):
-        """Gets the grid's wx.Pen"""
+        """
+        The :class:`wx.Pen` used to draw the grid lines on the plot.
+
+        :getter: Returns the :class:`wx.Pen` used for drawing the grid
+                 lines.
+        :setter: Sets the :class:`wx.Pen` use for drawging the grid lines.
+        :type:   :class:`wx.Pen`
+        :raise:  `TypeError` when setting a value that is not a
+                 :class:`wx.Pen`.
+        """
         return self._gridPen
 
     @GridPen.setter
@@ -2010,7 +2019,16 @@ class PlotCanvas(wx.Panel):
 
     @property
     def DiagonalPen(self):
-        """Gets the diagonal wx.Pen"""
+        """
+        The :class:`wx.Pen` used to draw the diagonal lines on the plot.
+
+        :getter: Returns the :class:`wx.Pen` used for drawing the diagonal
+                 lines.
+        :setter: Sets the :class:`wx.Pen` use for drawging the diagonal lines.
+        :type:   :class:`wx.Pen`
+        :raise:  `TypeError` when setting a value that is not a
+                 :class:`wx.Pen`.
+        """
         return self._diagonalPen
 
     @DiagonalPen.setter
@@ -2021,7 +2039,16 @@ class PlotCanvas(wx.Panel):
 
     @property
     def CenterLinePen(self):
-        """Gets the CenterLine wx.Pen"""
+        """
+        The :class:`wx.Pen` used to draw the center lines on the plot.
+
+        :getter: Returns the :class:`wx.Pen` used for drawing the center
+                 lines.
+        :setter: Sets the :class:`wx.Pen` use for drawging the center lines.
+        :type:   :class:`wx.Pen`
+        :raise:  `TypeError` when setting a value that is not a
+                 :class:`wx.Pen`.
+        """
         return self._centerLinePen
 
     @CenterLinePen.setter
@@ -2032,7 +2059,16 @@ class PlotCanvas(wx.Panel):
 
     @property
     def AxesPen(self):
-        """Gets the axes wx.Pen"""
+        """
+        The :class:`wx.Pen` used to draw the axes lines on the plot.
+
+        :getter: Returns the :class:`wx.Pen` used for drawing the axes
+                 lines.
+        :setter: Sets the :class:`wx.Pen` use for drawging the axes lines.
+        :type:   :class:`wx.Pen`
+        :raise:  `TypeError` when setting a value that is not a
+                 :class:`wx.Pen`.
+        """
         return self._axesPen
 
     @AxesPen.setter
@@ -2043,7 +2079,15 @@ class PlotCanvas(wx.Panel):
 
     @property
     def TickPen(self):
-        """Gets the tick mark wx.Pen"""
+        """
+        The :class:`wx.Pen` used to draw the tick marks on the plot.
+
+        :getter: Returns the :class:`wx.Pen` used for drawing the tick marks.
+        :setter: Sets the :class:`wx.Pen` use for drawging the tick marks.
+        :type:   :class:`wx.Pen`
+        :raise:  `TypeError` when setting a value that is not a
+                 :class:`wx.Pen`.
+        """
         return self._tickPen
 
     @TickPen.setter
@@ -2054,12 +2098,18 @@ class PlotCanvas(wx.Panel):
 
     @property
     def TickLength(self):
-        """Returns the tick length."""
+        """
+        The length of the tick marks on an axis.
+
+        :getter: Returns the length of the tick marks.
+        :setter: Sets the length of the tick marks.
+        :type:   int or float
+        :raise:  `TypeError` when setting a value that is not an int or float.
+        """
         return self._tickLength
 
     @TickLength.setter
     def TickLength(self, length):
-        """Set the tick legnth. Value must be int or float."""
         if not isinstance(length, (int, float)):
             raise TypeError("`length` must be an integer or float")
         self._tickWidth = length
@@ -2201,21 +2251,45 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.LogScale property")
     def setLogScale(self, logscale):
+        """
+        Set the log scale boolean value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.LogScale property instead.
+        """
         self.LogScale = logscale
 
     @PendingDeprecation("self.LogScale property")
     def getLogScale(self):
+        """
+        Set the log scale boolean value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.LogScale property instead.
+        """
         return self.LogScale
 
     @property
     def LogScale(self):
+        """
+        The LogScale value as a 2-tuple of bools:
+        ``(x_axis_is_log_scale, y_axis_is_log_scale)``.
+
+        :getter: Returns the value of LogScale.
+        :setter: Sets the value of LogScale.
+        :type:   tuple of bools, length 2
+        :raise:  `TypeError` when setting an invalid value.
+        """
         return self._logscale
 
     @LogScale.setter
     def LogScale(self, logscale):
         if type(logscale) != tuple:
             raise TypeError(
-                'logscale must be a tuple of bools, e.g. (False, False)')
+                'logscale must be a tuple of bools, e.g. (False, False)'
+            )
         if self.last_draw is not None:
             graphics, xAxis, yAxis = self.last_draw
             graphics.LogScale = logscale
@@ -2226,12 +2300,23 @@ class PlotCanvas(wx.Panel):
 
     @property
     def AbsScale(self):
+        """
+        The AbsScale value as a 2-tuple of bools:
+        ``(x_axis_is_abs_scale, y_axis_is_abs_scale)``.
+
+        :getter: Returns the value of AbsScale.
+        :setter: Sets the value of AbsScale.
+        :type:   tuple of bools, length 2
+        :raise:  `TypeError` when setting an invalid value.
+        """
         return self._absScale
 
     @AbsScale.setter
     def AbsScale(self, absscale):
         if not isinstance(absscale, tuple):
-            raise TypeError("absscale must be tuple of bools.")
+            raise TypeError(
+                "absscale must be tuple of bools, e.g. (False, False)"
+            )
         if self.last_draw is not None:
             graphics, xAxis, yAxis = self.last_draw
             graphics.AbsScale = absscale
@@ -2242,57 +2327,114 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.FontSizeAxis property")
     def SetFontSizeAxis(self, point=10):
-        """Set the tick and axis label font size (default is 10 point)"""
+        """
+        Set the tick and axis label font size (default is 10 point)
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.FontSizeAxis property instead.
+        """
         self.FontSizeAxis = point
 
     @PendingDeprecation("self.FontSizeAxis property")
     def GetFontSizeAxis(self):
-        """Get current tick and axis label font size in points"""
+        """
+        Get current tick and axis label font size in points
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.FontSizeAxis property instead.
+        """
         return self.FontSizeAxis
 
     @property
     def FontSizeAxis(self):
-        """Get current tick and axis label font size in points"""
+        """
+        The current tick and axis label font size in points.
+
+        Default is 10pt font.
+
+        :getter: Returns the value of FontSizeAxis.
+        :setter: Sets the value of FontSizeAxis.
+        :type:   int or float
+        """
         return self._fontSizeAxis
 
     @FontSizeAxis.setter
     def FontSizeAxis(self, value):
-        """Set the tick and axis label font size (default is 10 point)"""
         self._fontSizeAxis = value
 
     @PendingDeprecation("self.FontSizeTitle property")
     def SetFontSizeTitle(self, point=15):
-        """Set Title font size (default is 15 point)"""
-#        self._fontSizeTitle = point
+        """
+        Set Title font size (default is 15 point)
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.FontSizeTitle property instead.
+        """
         self.FontSizeTitle = point
 
     @PendingDeprecation("self.FontSizeTitle property")
     def GetFontSizeTitle(self):
-        """Get current Title font size in points"""
-#        return self._fontSizeTitle
+        """
+        Get Title font size (default is 15 point)
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.FontSizeTitle property instead.
+        """
         return self.FontSizeTitle
 
     @property
     def FontSizeTitle(self):
-        """Get current Title font size in points"""
+        """
+        The current Title font size in points.
+
+        Default is 15pt font.
+
+        :getter: Returns the value of FontSizeAxis.
+        :setter: Sets the value of FontSizeAxis.
+        :type:   int or float
+        """
         return self._fontSizeTitle
 
     @FontSizeTitle.setter
     def FontSizeTitle(self, pointsize):
-        """Set Title font size (default is 15 point)"""
         self._fontSizeTitle = pointsize
 
     @PendingDeprecation("self.FontSizeLegend property")
     def SetFontSizeLegend(self, point=7):
-        """Set Legend font size (default is 7 point)"""
+        """
+        Set legend font size (default is 7 point)
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.FontSizeLegend property instead.
+        """
         self.FontSizeLegend = point
 
     def GetFontSizeLegend(self):
-        """Get current Legend font size in points"""
+        """
+        Get legend font size (default is 7 point)
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.FontSizeLegend property instead.
+        """
         return self.FontSizeLegend
 
     @property
     def FontSizeLegend(self):
+        """
+        The current Legned font size in points.
+
+        Default is 7pt font.
+
+        :getter: Returns the value of FontSizeLegend.
+        :setter: Sets the value of FontSizeLegend.
+        :type:   int or float
+        """
         return self._fontSizeLegend
 
     @FontSizeLegend.setter
@@ -2301,20 +2443,41 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.ShowScrollbars property")
     def SetShowScrollbars(self, value):
+        """
+        Set the ShowScrollbars value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.ShowScrollbars property instead.
+        """
         self.ShowScrollbars = value
 
     @PendingDeprecation("self.ShowScrollbars property")
     def GetShowScrollbars(self):
-        """Set True to show scrollbars"""
+        """
+        Get the ShowScrollbars value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.ShowScrollbars property instead.
+        """
         return self.ShowScrollbars
 
     @property
     def ShowScrollbars(self):
+        """
+        The current ShowScrollbars value.
+
+        :getter: Returns the value of ShowScrollbars.
+        :setter: Sets the value of ShowScrollbars.
+        :type:   bool
+        :raises: `TypeError` if setting a non-boolean value.
+        """
+        # XXX: should have sb_hor.IsShown() as well.
         return self.sb_vert.IsShown()
 
     @ShowScrollbars.setter
     def ShowScrollbars(self, value):
-        """Set True to show scrollbars"""
         if not isinstance(value, bool):
             raise TypeError("Value should be True or False")
         if value == self.ShowScrollbars:
@@ -2326,73 +2489,170 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.UseScientificNotation property")
     def SetUseScientificNotation(self, useScientificNotation):
+        """
+        Set the UseScientificNotation value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.UseScientificNotation property instead.
+        """
         self.UseScientificNotation = useScientificNotation
 
     @PendingDeprecation("self.UseScientificNotation property")
     def GetUseScientificNotation(self):
+        """
+        Get the UseScientificNotation value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.UseScientificNotation property instead.
+        """
         return self.UseScientificNotation
 
     @property
     def UseScientificNotation(self):
+        """
+        The current UseScientificNotation value.
+
+        :getter: Returns the value of UseScientificNotation.
+        :setter: Sets the value of UseScientificNotation.
+        :type:   bool
+        :raises: `TypeError` if setting a non-boolean value.
+        """
         return self._useScientificNotation
 
     @UseScientificNotation.setter
     def UseScientificNotation(self, value):
+        if not isinstance(value, bool):
+            raise TypeError("Value should be True or False")
         self._useScientificNotation = value
 
     @PendingDeprecation("self.EnableAntiAliasing property")
     def SetEnableAntiAliasing(self, enableAntiAliasing):
+        """
+        Set the EnableAntiAliasing value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableAntiAliasing property instead.
+        """
         self.EnableAntiAliasing = enableAntiAliasing
 
     @PendingDeprecation("self.EnableAntiAliasing property")
     def GetEnableAntiAliasing(self):
+        """
+        Get the EnableAntiAliasing value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableAntiAliasing property instead.
+        """
         return self.EnableAntiAliasing
 
     @property
     def EnableAntiAliasing(self):
+        """
+        The current EnableAntiAliasing value.
+
+        :getter: Returns the value of EnableAntiAliasing.
+        :setter: Sets the value of EnableAntiAliasing.
+        :type:   bool
+        :raises: `TypeError` if setting a non-boolean value.
+        """
         return self._antiAliasingEnabled
 
     @EnableAntiAliasing.setter
     def EnableAntiAliasing(self, value):
-        """Set True to enable anti-aliasing."""
+        if not isinstance(value, bool):
+            raise TypeError("Value should be True or False")
         self._antiAliasingEnabled = value
         self.Redraw()
 
     @PendingDeprecation("self.EnableHiRes property")
     def SetEnableHiRes(self, enableHiRes):
+        """
+        Set the EnableHiRes value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableHiRes property instead.
+        """
         self.EnableHiRes = enableHiRes
 
     @PendingDeprecation("self.EnableHiRes property")
     def GetEnableHiRes(self):
+        """
+        Get the EnableHiRes value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableHiRes property instead.
+        """
         return self._hiResEnabled
 
     @property
     def EnableHiRes(self):
+        """
+        The current EnableHiRes value.
+
+        :getter: Returns the value of EnableHiRes.
+        :setter: Sets the value of EnableHiRes.
+        :type:   bool
+        :raises: `TypeError` if setting a non-boolean value.
+        """
         return self._hiResEnabled
 
     @EnableHiRes.setter
     def EnableHiRes(self, value):
-        """
-        Set True to enable high-resolution mode when using anti-aliasing.
-        """
+        if not isinstance(value, bool):
+            raise TypeError("Value should be True or False")
         self._hiResEnabled = value
         self.Redraw()
 
     @PendingDeprecation("self.EnableDrag property")
     def SetEnableDrag(self, value):
+        """
+        Set the EnableDrag value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableDrag property instead.
+        """
         self.EnableDrag = value
 
     @PendingDeprecation("self.EnableDrag property")
     def GetEnableDrag(self):
+        """
+        Get the EnableDrag value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableDrag property instead.
+        """
         return self.EnableDrag
 
     @property
     def EnableDrag(self):
+        """
+        The current EnableDrag value.
+
+        :getter: Returns the value of EnableDrag.
+        :setter: Sets the value of EnableDrag.
+        :type:   bool
+        :raises: `TypeError` if setting a non-boolean value.
+
+        .. note::
+           This is mutually exclusive with
+           :attr:`~wx.lib.plot.PlotCanvas.EnableZoom`. Setting one will
+           disable the other.
+
+        .. seealso::
+           :attr:`~wx.lib.plot.PlotCanvas.EnableZoom`
+        """
         return self._dragEnabled
 
     @EnableDrag.setter
     def EnableDrag(self, value):
-        """Set True to enable drag."""
         if not isinstance(value, bool):
             raise TypeError("Value must be a bool.")
         if value:
@@ -2405,20 +2665,48 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.EnableZoom property")
     def SetEnableZoom(self, value):
+        """
+        Set the EnableZoom value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableZoom property instead.
+        """
         self.EnableZoom = value
 
     @PendingDeprecation("self.EnableZoom property")
     def GetEnableZoom(self):
-        """True if zooming enabled."""
+        """
+        Get the EnableZoom value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableZoom property instead.
+        """
         return self.EnableZoom
 
     @property
     def EnableZoom(self):
+        """
+        The current EnableZoom value.
+
+        :getter: Returns the value of EnableZoom.
+        :setter: Sets the value of EnableZoom.
+        :type:   bool
+        :raises: `TypeError` if setting a non-boolean value.
+
+        .. note::
+           This is mutually exclusive with
+           :attr:`~wx.lib.plot.PlotCanvas.EnableDrag`. Setting one will
+           disable the other.
+
+        .. seealso::
+           :attr:`~wx.lib.plot.PlotCanvas.EnableDrag`
+        """
         return self._zoomEnabled
 
     @EnableZoom.setter
     def EnableZoom(self, value):
-        """Set True to enable zooming."""
         if not isinstance(value, bool):
             raise TypeError("Value must be a bool.")
         if value:
@@ -2431,29 +2719,46 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.EnableGrid property")
     def SetEnableGrid(self, value):
+        """
+        Set the EnableGrid value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableGrid property instead.
+        """
         self.EnableGrid = value
 
     @PendingDeprecation("self.EnableGrid property")
     def GetEnableGrid(self):
-        """True if grid enabled."""
+        """
+        Get the EnableGrid value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableGrid property instead.
+        """
         return self.EnableGrid
 
     @property
     def EnableGrid(self):
+        """
+        The current EnableGrid value.
+
+        :getter: Returns the value of EnableGrid.
+        :setter: Sets the value of EnableGrid.
+        :type:   bool or 2-tuple of bools
+        :raises: `TypeError` if setting an invalid value.
+
+        If set to a single boolean value, then both X and y grids will be
+        enabled (``EnableGrid = True``) or disabled (``EnableGrid = False``).
+
+        If a 2-tuple of bools, the 1st value is the X (vertical) grid and
+        the 2nd value is the Y (horizontal) grid.
+        """
         return self._gridEnabled
 
     @EnableGrid.setter
     def EnableGrid(self, value):
-        """
-        Set to enable grid.
-
-        value must be a bool or 2-tuple of bools: (x_grid_bool, y_grid_bool)
-
-        If Value is a bool, then both X and Y grids are turned on/off
-
-        x_grid_bool: Tf True, gridlines in the vertical direction are shown.
-        y_grid_bool: If True, gridlines in the horizontal direction are shown.
-        """
         if isinstance(value, bool):
             value = (value, value)
         elif isinstance(value, tuple) and len(value) == 2:
@@ -2467,69 +2772,141 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.EnableCenterLines property")
     def SetEnableCenterLines(self, value):
+        """
+        Set the EnableCenterLines value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableCenterLines property instead.
+        """
         self.EnableCenterLines = value
 
     @PendingDeprecation("self.EnableCenterLines property")
     def GetEnableCenterLines(self):
-        """True if Centerlines are enabled."""
+        """
+        Get the EnableCenterLines value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableCenterLines property instead.
+        """
         return self.EnableCenterLines
 
     @property
     def EnableCenterLines(self):
+        """
+        The current EnableCenterLines value.
+
+        :getter: Returns the value of EnableCenterLines.
+        :setter: Sets the value of EnableCenterLines.
+        :type:   bool or str
+        :raises: `TypeError` if setting an invalid value.
+
+        If set to a single boolean value, then both horizontal and vertical
+        lines will be enabled or disabled.
+
+        If a string, must be one of ``('Horizontal', 'Vertical')``.
+        """
         return self._centerLinesEnabled
 
     @EnableCenterLines.setter
     def EnableCenterLines(self, value):
-        """Set True, 'Horizontal' or 'Vertical' to enable center line(s)."""
         if value not in [True, False, 'Horizontal', 'Vertical']:
             raise TypeError(
-                "Value should be True, False, Horizontal or Vertical")
+                "Value should be True, False, 'Horizontal' or 'Vertical'")
         self._centerLinesEnabled = value
         self.Redraw()
 
     @PendingDeprecation("self.EnableDiagonals property")
     def SetEnableDiagonals(self, value):
+        """
+        Set the EnableDiagonals value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableDiagonals property instead.
+        """
         self.EnableDiagonals = value
 
     @PendingDeprecation("self.EnableDiagonals property")
     def GetEnableDiagonals(self):
-        """True if Diagonals enabled."""
+        """
+        Get the EnableDiagonals value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableDiagonals property instead.
+        """
         return self.EnableDiagonals
 
     @property
     def EnableDiagonals(self):
+        """
+        The current EnableDiagonals value.
+
+        :getter: Returns the value of EnableDiagonals.
+        :setter: Sets the value of EnableDiagonals.
+        :type:   bool or str
+        :raises: `TypeError` if setting an invalid value.
+
+        If set to a single boolean value, then both diagonal lines will
+        be enabled or disabled.
+
+        If a string, must be one of ``('Bottomleft-Topright',
+        'Bottomright-Topleft')``.
+        """
         return self._diagonalsEnabled
 
     @EnableDiagonals.setter
     def EnableDiagonals(self, value):
-        """Set True, 'Bottomleft-Topright' or 'Bottomright-Topleft' to enable
-        center line(s)."""
         # TODO: Rename Bottomleft-TopRight, Bottomright-Topleft
         if value not in [True, False,
                          'Bottomleft-Topright', 'Bottomright-Topleft']:
             raise TypeError(
-                "Value should be True, False, Bottomleft-Topright or "
-                "Bottomright-Topleft"
+                "Value should be True, False, 'Bottomleft-Topright' or "
+                "'Bottomright-Topleft'"
             )
         self._diagonalsEnabled = value
         self.Redraw()
 
     @PendingDeprecation("self.EnableLegend property")
     def SetEnableLegend(self, value):
+        """
+        Set the EnableLegend value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableLegend property instead.
+        """
         self.EnableLegend = value
 
     @PendingDeprecation("self.EnableLegend property")
     def GetEnableLegend(self):
-        """True if Legend enabled."""
+        """
+        Get the EnableLegend value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableLegend property instead.
+        """
         return self.EnableLegend
 
     @property
     def EnableLegend(self):
+        """
+        The current EnableLegend value.
+
+        :getter: Returns the value of EnableLegend.
+        :setter: Sets the value of EnableLegend.
+        :type:   bool
+        :raises: `TypeError` if setting a non-boolean value.
+        """
         return self._legendEnabled
 
     @EnableLegend.setter
     def EnableLegend(self, value):
         """Set True to enable legend."""
+        # XXX: why not `if not isinstance(value, bool):`?
         if value not in [True, False]:
             raise TypeError("Value should be True or False")
         self._legendEnabled = value
@@ -2537,20 +2914,40 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.EnableTitle property")
     def SetEnableTitle(self, value):
+        """
+        Set the EnableTitle value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableTitle property instead.
+        """
         self.EnableTitle = value
 
     @PendingDeprecation("self.EnableTitle property")
     def GetEnableTitle(self):
-        """True if title enabled."""
+        """
+        Get the EnableTitle value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnableTitle property instead.
+        """
         return self.EnableTitle
 
     @property
     def EnableTitle(self):
+        """
+        The current EnableTitle value.
+
+        :getter: Returns the value of EnableTitle.
+        :setter: Sets the value of EnableTitle.
+        :type:   bool
+        :raises: `TypeError` if setting a non-boolean value.
+        """
         return self._titleEnabled
 
     @EnableTitle.setter
     def EnableTitle(self, value):
-        """Set True to enable title."""
         if not isinstance(value, bool):
             raise TypeError("Value must be a bool.")
         self._titleEnabled = value
@@ -2558,20 +2955,40 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.EnablePointLabel property")
     def SetEnablePointLabel(self, value):
+        """
+        Set the EnablePointLabel value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnablePointLabel property instead.
+        """
         self.EnablePointLabel = value
 
     @PendingDeprecation("self.EnablePointLabel property")
     def GetEnablePointLabel(self):
-        """True if pointLabel enabled."""
+        """
+        Set the EnablePointLabel value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnablePointLabel property instead.
+        """
         return self.EnablePointLabel
 
     @property
     def EnablePointLabel(self):
+        """
+        The current EnablePointLabel value.
+
+        :getter: Returns the value of EnablePointLabel.
+        :setter: Sets the value of EnablePointLabel.
+        :type:   bool
+        :raises: `TypeError` if setting a non-boolean value.
+        """
         return self._pointLabelEnabled
 
     @EnablePointLabel.setter
     def EnablePointLabel(self, value):
-        """Set True to enable pointLabel."""
         if not isinstance(value, bool):
             raise TypeError("Value must be a bool.")
         self._pointLabelEnabled = value
@@ -2580,19 +2997,27 @@ class PlotCanvas(wx.Panel):
 
     @property
     def EnableAxes(self):
-        """True if axes enabled."""
+        """
+        The current EnableAxes value.
+
+        :getter: Returns the value of EnableAxes.
+        :setter: Sets the value of EnableAxes.
+        :type:   bool, 2-tuple of bool, or 4-tuple of bool
+        :raises: `TypeError` if setting an invalid value.
+        :raises: `ValueError` if the tuple has incorrect length.
+
+        If bool, enable or disable all axis
+
+        If 2-tuple, enable or disable the bottom or left axes: ``(bottom,
+        left)``
+
+        If 4-tuple, enable or disable each axis individually: ``(bottom,
+        left, top, right)``
+        """
         return self._axesEnabled
 
     @EnableAxes.setter
     def EnableAxes(self, value):
-        """Set True to enable axes.
-
-        Acceptable values:
-        bool : all axes
-        2-tuple of bool : (bottom, left)
-        4-tuple of bool : (bottom, left, top, right)
-
-        """
         err_txt = ("Axis value must be a bool or a 2- or 4-tuple of bool")
 
         # TODO: Refactor - same as EnableAxesValues and EnableTicks
@@ -2607,25 +3032,33 @@ class PlotCanvas(wx.Panel):
             else:
                 raise ValueError(err_txt)
         else:
-            raise ValueError(err_txt)
+            raise TypeError(err_txt)
         self._axesEnabled = _DisplaySide(*_value)
         self.Redraw()
 
     @property
     def EnableAxesValues(self):
-        """True if axes values are enabled."""
+        """
+        The current EnableAxesValues value.
+
+        :getter: Returns the value of EnableAxesValues.
+        :setter: Sets the value of EnableAxesValues.
+        :type:   bool, 2-tuple of bool, or 4-tuple of bool
+        :raises: `TypeError` if setting an invalid value.
+        :raises: `ValueError` if the tuple has incorrect length.
+
+        If bool, enable or disable all axis values
+
+        If 2-tuple, enable or disable the bottom or left axes values:
+        ``(bottom, left)``
+
+        If 4-tuple, enable or disable each axis value individually:
+        ``(bottom, left, top, right)``
+        """
         return self._axesValuesEnabled
 
     @EnableAxesValues.setter
     def EnableAxesValues(self, value):
-        """Set True to enable axes values.
-
-        Acceptable values:
-        bool : all axes values
-        2-tuple of bool : (bottom, left)
-        4-tuple of bool : (bottom, left, top, right)
-
-        """
         err_txt = ("value must be a bool or a 2- or 4-tuple of bool")
 
         # TODO: Refactor - same as EnableAxes and EnableTicks
@@ -2640,25 +3073,33 @@ class PlotCanvas(wx.Panel):
             else:
                 raise ValueError(err_txt)
         else:
-            raise ValueError(err_txt)
+            raise TypeError(err_txt)
         self._axesValuesEnabled = _DisplaySide(*_value)
         self.Redraw()
 
     @property
     def EnableTicks(self):
-        """True if tick marks are enabled."""
+        """
+        The current EnableTicks value.
+
+        :getter: Returns the value of EnableTicks.
+        :setter: Sets the value of EnableTicks.
+        :type:   bool, 2-tuple of bool, or 4-tuple of bool
+        :raises: `TypeError` if setting an invalid value.
+        :raises: `ValueError` if the tuple has incorrect length.
+
+        If bool, enable or disable all ticks
+
+        If 2-tuple, enable or disable the bottom or left ticks:
+        ``(bottom, left)``
+
+        If 4-tuple, enable or disable each tick side individually:
+        ``(bottom, left, top, right)``
+        """
         return self._ticksEnabled
 
     @EnableTicks.setter
     def EnableTicks(self, value):
-        """Set True to enable tick marks.
-
-        Acceptable values:
-        bool : ticks on all 4 sides
-        2-tuple of bool : (bottom, left)
-        4-tuple of bool : (bottom, left, top, right)
-
-        """
         err_txt = ("value must be a bool or a 2- or 4-tuple of bool")
 
         # TODO: Refactor - same as EnableAxes and EnableAxesValues
@@ -2673,12 +3114,20 @@ class PlotCanvas(wx.Panel):
             else:
                 raise ValueError(err_txt)
         else:
-            raise ValueError(err_txt)
+            raise TypeError(err_txt)
         self._ticksEnabled = _DisplaySide(*_value)
         self.Redraw()
 
     @property
     def EnablePlotTitle(self):
+        """
+        The current EnablePlotTitle value.
+
+        :getter: Returns the value of EnablePlotTitle.
+        :setter: Sets the value of EnablePlotTitle.
+        :type:   bool
+        :raises: `TypeError` if setting an invalid value.
+        """
         return self._titleEnabled
 
     @EnablePlotTitle.setter
@@ -2690,6 +3139,14 @@ class PlotCanvas(wx.Panel):
 
     @property
     def EnableXAxisLabel(self):
+        """
+        The current EnableXAxisLabel value.
+
+        :getter: Returns the value of EnableXAxisLabel.
+        :setter: Sets the value of EnableXAxisLabel.
+        :type:   bool
+        :raises: `TypeError` if setting an invalid value.
+        """
         return self._xAxisLabelEnabled
 
     @EnableXAxisLabel.setter
@@ -2701,6 +3158,14 @@ class PlotCanvas(wx.Panel):
 
     @property
     def EnableYAxisLabel(self):
+        """
+        The current EnableYAxisLabel value.
+
+        :getter: Returns the value of EnableYAxisLabel.
+        :setter: Sets the value of EnableYAxisLabel.
+        :type:   bool
+        :raises: `TypeError` if setting an invalid value.
+        """
         return self._yAxisLabelEnabled
 
     @EnableYAxisLabel.setter
@@ -2710,8 +3175,17 @@ class PlotCanvas(wx.Panel):
         self._yAxisLabelEnabled = value
         self.Redraw()
 
+    # TODO: this conflicts with EnableXAxisLabel and EnableYAxisLabel
     @property
     def EnableAxesLabels(self):
+        """
+        The current EnableAxesLabels value.
+
+        :getter: Returns the value of EnableAxesLabels.
+        :setter: Sets the value of EnableAxesLabels.
+        :type:   bool
+        :raises: `TypeError` if setting an invalid value.
+        """
         return self._axesLabelsEnabled
 
     @EnableAxesLabels.setter
@@ -2723,25 +3197,42 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.PointLabelFunc property")
     def SetPointLabelFunc(self, func):
-        """Sets the function with custom code for pointLabel drawing
-            ******** more info needed ***************
+        """
+        Set the EnablePointLabel value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnablePointLabel property instead.
         """
         self.PointLabelFunc = func
 
     @PendingDeprecation("self.PointLabelFunc property")
     def GetPointLabelFunc(self):
-        """Returns pointLabel Drawing Function"""
+        """
+        Get the EnablePointLabel value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.EnablePointLabel property instead.
+        """
         return self.PointLabelFunc
 
     @property
     def PointLabelFunc(self):
+        """
+        The current PointLabelFunc value.
+
+        :getter: Returns the value of PointLabelFunc.
+        :setter: Sets the value of PointLabelFunc.
+        :type:   function
+
+        TODO: More information is needed.
+        Sets the function with custom code for pointLabel drawing
+        """
         return self._pointLabelFunc
 
     @PointLabelFunc.setter
     def PointLabelFunc(self, func):
-        """Sets the function with custom code for pointLabel drawing
-            ******** more info needed ***************
-        """
         self._pointLabelFunc = func
 
     def Reset(self):
@@ -2795,58 +3286,75 @@ class PlotCanvas(wx.Panel):
     @PendingDeprecation("self.XSpec property")
     def SetXSpec(self, spectype='auto'):
         """
-        xSpec- defines x axis type. Can be 'none', 'min' or 'auto'
-        where:
+        Set the XSpec value.
 
-        * 'none' - shows no axis or tick mark values
-        * 'min' - shows min bounding box values
-        * 'auto' - rounds axis range to sensible values
-        * <number> - like 'min', but with <number> tick marks
+        .. deprecated:: Feb 27, 2016
 
+           Use the self.XSpec property instead.
         """
         self.XSpec = spectype
 
     @PendingDeprecation("self.YSpec property")
     def SetYSpec(self, spectype='auto'):
         """
-        ySpec- defines x axis type. Can be 'none', 'min' or 'auto'
-        where:
+        Set the YSpec value.
 
-        * 'none' - shows no axis or tick mark values
-        * 'min' - shows min bounding box values
-        * 'auto' - rounds axis range to sensible values
-        * <number> - like 'min', but with <number> tick marks
+        .. deprecated:: Feb 27, 2016
 
+           Use the self.YSpec property instead.
         """
         self.YSpec = spectype
 
     @PendingDeprecation("self.XSpec property")
     def GetXSpec(self):
-        """Returns current XSpec for axis"""
+        """
+        Get the XSpec value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.XSpec property instead.
+        """
         return self.XSpec
 
     @PendingDeprecation("self.YSpec property")
     def GetYSpec(self):
-        """Returns current YSpec for axis"""
+        """
+        Get the YSpec value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the self.YSpec property instead.
+        """
         return self.YSpec
 
     @property
     def XSpec(self):
+        """
+        Defines the X axis type.
+
+        Default is 'auto'.
+
+        :getter: Returns the value of XSpec.
+        :setter: Sets the value of XSpec.
+        :type:   str, int, or length-2 sequence of floats
+        :raises: `TypeError` if setting an invalid value.
+
+        Valid strings:
+        + 'none' - shows no axis or tick mark values
+        + 'min' - shows min bounding box values
+        + 'auto' - rounds axis range to sensible values
+
+        Other valid values:
+        + <number> - like 'min', but with <number> tick marks
+        + list or tuple: a list of (min, max) values. Must be length 2.
+
+        .. seealso::
+           :attr:`~wx.lib.plot.PlotCanvas.YSpec`
+        """
         return self._xSpec
 
     @XSpec.setter
     def XSpec(self, value):
-        """
-        xSpec- defines x axis type. Can be 'none', 'min' or 'auto'
-        where:
-
-        * 'none' - shows no axis or tick mark values
-        * 'min' - shows min bounding box values
-        * 'auto' - rounds axis range to sensible values
-        * <number> - like 'min', but with <number> tick marks
-        * list or tuple - a list of (min, max) values. must be length 2
-
-        """
         ok_values = ('none', 'min', 'auto')
         if value not in ok_values and not isinstance(value, (int, float)):
             if not isinstance(value, (list, tuple)) and len(value != 2):
@@ -2857,21 +3365,32 @@ class PlotCanvas(wx.Panel):
 
     @property
     def YSpec(self):
+        """
+        Defines the Y axis type.
+
+        Default is 'auto'.
+
+        :getter: Returns the value of XSpec.
+        :setter: Sets the value of XSpec.
+        :type:   str, int, or length-2 sequence of floats
+        :raises: `TypeError` if setting an invalid value.
+
+        Valid strings:
+        + 'none' - shows no axis or tick mark values
+        + 'min' - shows min bounding box values
+        + 'auto' - rounds axis range to sensible values
+
+        Other valid values:
+        + <number> - like 'min', but with <number> tick marks
+        + list or tuple: a list of (min, max) values. Must be length 2.
+
+        .. seealso::
+           :attr:`~wx.lib.plot.PlotCanvas.XSpec`
+        """
         return self._ySpec
 
     @YSpec.setter
     def YSpec(self, value):
-        """
-        ySpec- defines x axis type. Can be 'none', 'min' or 'auto'
-        where:
-
-        * 'none' - shows no axis or tick mark values
-        * 'min' - shows min bounding box values
-        * 'auto' - rounds axis range to sensible values
-        * <number> - like 'min', but with <number> tick marks
-        * list or tuple - a list of (min, max) values. must be length 2
-
-        """
         ok_values = ('none', 'min', 'auto')
         if value not in ok_values and not isinstance(value, (int, float)):
             if not isinstance(value, (list, tuple)) and len(value != 2):
@@ -2882,10 +3401,25 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.XMaxRange property")
     def GetXMaxRange(self):
+        """
+        Get the XMaxRange value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotCanvas.XMaxRange` property instead.
+        """
         return self.XMaxRange
 
     @property
     def XMaxRange(self):
+        """
+        The plots' maximum X range as a tuple of ``(min, max)``.
+
+        :getter: Returns the value of XMaxRange.
+
+        .. seealso::
+           :attr:`~wx.lib.plot.PlotCanvas.YMaxRange`
+        """
         xAxis = self._getXMaxRange()
         if self.LogScale[0]:
             xAxis = np.power(10, xAxis)
@@ -2900,10 +3434,25 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.YMaxRange property")
     def GetYMaxRange(self):
+        """
+        Get the YMaxRange value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotCanvas.YMaxRange` property instead.
+        """
         return self.YMaxRange
 
     @property
     def YMaxRange(self):
+        """
+        The plots' maximum Y range as a tuple of ``(min, max)``.
+
+        :getter: Returns the value of YMaxRange.
+
+        .. seealso::
+           :attr:`~wx.lib.plot.PlotCanvas.XMaxRange`
+        """
         yAxis = self._getYMaxRange()
         if self.LogScale[1]:
             yAxis = np.power(10, yAxis)
@@ -2918,10 +3467,27 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.XCurrentRange property")
     def GetXCurrentRange(self):
+        """
+        Get the XCurrentRange value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotCanvas.XCurrentRange` property
+           instead.
+        """
         return self.XCurrentRange
 
     @property
     def XCurrentRange(self):
+        """
+        The plots' X range of the currently displayed portion as
+        a tuple of ``(min, max)``
+
+        :getter: Returns the value of XCurrentRange.
+
+        .. seealso::
+           :attr:`~wx.lib.plot.PlotCanvas.YCurrentRange`
+        """
         xAxis = self._getXCurrentRange()
         if self.LogScale[0]:
             xAxis = np.power(10, xAxis)
@@ -2934,10 +3500,27 @@ class PlotCanvas(wx.Panel):
 
     @PendingDeprecation("self.YCurrentRange property")
     def GetYCurrentRange(self):
+        """
+        Get the YCurrentRange value.
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.PlotCanvas.YCurrentRange` property
+           instead.
+        """
         return self.YCurrentRange
 
     @property
     def YCurrentRange(self):
+        """
+        The plots' Y range of the currently displayed portion as
+        a tuple of ``(min, max)``
+
+        :getter: Returns the value of YCurrentRange.
+
+        .. seealso::
+           :attr:`~wx.lib.plot.PlotCanvas.XCurrentRange`
+        """
         yAxis = self._getYCurrentRange()
         if self.LogScale[1]:
             yAxis = np.power(10, yAxis)
@@ -3607,30 +4190,26 @@ class PlotCanvas(wx.Panel):
         """
         Draws the gridlines
 
-        Parameters:
-        -----------
-        dc :
-            The Device Contect to draw on
-
-        p1 : np array of length 2
-            The lower-left hand corner of the plot, in plot coords.
-            So, if the plot ranges from x=-10 to 10, and y=-5 to 5, then
-            p1 = (-10, -5)
-
-        p2 : np array of length 2
-            The upper-right hand corner of the plot, in plot coords.
-            So, if the plot ranges from x=-10 to 10, and y=-5 to 5, then
-            p1 = (10, 5)
-
-        scale : np array of length 2
-            The [X, Y] scaling factor to convert plot coords to DC coords
-
-        shift : np array of length 2
-            The [X, Y] shift values to convert plot coords to DC coords.
-
-        xticks, yticks :
-            the x and y tick definitions
-
+        :param :class:`wx.DC` `dc`: The :class:`wx.DC` to draw on.
+        :type `dc`: :class:`wx.DC`
+        :param p1: The lower-left hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p1 = (-10, -5)
+        :type p1: :class:`np.array`, length 2
+        :param p2: The upper-right hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p2 = (10, 5)
+        :type p2: :class:`np.array`, length 2
+        :param scale: The [X, Y] scaling factor to convert plot coords to
+                      DC coords
+        :type scale: :class:`np.array`, length 2
+        :param shift: The [X, Y] shift values to convert plot coords to
+                      DC coords. Must be in plot units, not DC units.
+        :type shift: :class:`np.array`, length 2
+        :param xticks: The X tick definition
+        :type xticks: list of length-2 lists
+        :param yticks: The Y tick definition
+        :type yticks: list of length-2 lists
         """
         # increases thickness for printing only
         pen = self.GridPen
@@ -3654,7 +4233,29 @@ class PlotCanvas(wx.Panel):
 
     @TempStyle('pen')
     def _drawTicks(self, dc, p1, p2, scale, shift, xticks, yticks):
-        """Draw the tick marks"""
+        """Draw the tick marks
+
+        :param :class:`wx.DC` `dc`: The :class:`wx.DC` to draw on.
+        :type `dc`: :class:`wx.DC`
+        :param p1: The lower-left hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p1 = (-10, -5)
+        :type p1: :class:`np.array`, length 2
+        :param p2: The upper-right hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p2 = (10, 5)
+        :type p2: :class:`np.array`, length 2
+        :param scale: The [X, Y] scaling factor to convert plot coords to
+                      DC coords
+        :type scale: :class:`np.array`, length 2
+        :param shift: The [X, Y] shift values to convert plot coords to
+                      DC coords. Must be in plot units, not DC units.
+        :type shift: :class:`np.array`, length 2
+        :param xticks: The X tick definition
+        :type xticks: list of length-2 lists
+        :param yticks: The Y tick definition
+        :type yticks: list of length-2 lists
+        """
         # TODO: add option for ticks to extend outside of graph
         #       - done via negative ticklength values?
         #           + works but the axes values cut off the ticks.
@@ -3699,7 +4300,25 @@ class PlotCanvas(wx.Panel):
 
     @TempStyle('pen')
     def _drawCenterLines(self, dc, p1, p2, scale, shift):
-        """Draws the center lines"""
+        """Draws the center lines
+
+        :param :class:`wx.DC` `dc`: The :class:`wx.DC` to draw on.
+        :type `dc`: :class:`wx.DC`
+        :param p1: The lower-left hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p1 = (-10, -5)
+        :type p1: :class:`np.array`, length 2
+        :param p2: The upper-right hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p2 = (10, 5)
+        :type p2: :class:`np.array`, length 2
+        :param scale: The [X, Y] scaling factor to convert plot coords to
+                      DC coords
+        :type scale: :class:`np.array`, length 2
+        :param shift: The [X, Y] shift values to convert plot coords to
+                      DC coords. Must be in plot units, not DC units.
+        :type shift: :class:`np.array`, length 2
+        """
         # increases thickness for printing only
         pen = self.CenterLinePen
         penWidth = self.printerScale * pen.GetWidth()
@@ -3725,7 +4344,26 @@ class PlotCanvas(wx.Panel):
 
     @TempStyle('pen')
     def _drawDiagonals(self, dc, p1, p2, scale, shift):
-        """Draws the diagonal lines"""
+        """
+        Draws the diagonal lines.
+
+        :param :class:`wx.DC` `dc`: The :class:`wx.DC` to draw on.
+        :type `dc`: :class:`wx.DC`
+        :param p1: The lower-left hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p1 = (-10, -5)
+        :type p1: :class:`np.array`, length 2
+        :param p2: The upper-right hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p2 = (10, 5)
+        :type p2: :class:`np.array`, length 2
+        :param scale: The [X, Y] scaling factor to convert plot coords to
+                      DC coords
+        :type scale: :class:`np.array`, length 2
+        :param shift: The [X, Y] shift values to convert plot coords to
+                      DC coords. Must be in plot units, not DC units.
+        :type shift: :class:`np.array`, length 2
+        """
         pen = self.DiagonalPen
         penWidth = self.printerScale * pen.GetWidth()
         pen.SetWidth(penWidth)
@@ -3744,7 +4382,26 @@ class PlotCanvas(wx.Panel):
 
     @TempStyle('pen')
     def _drawAxes(self, dc, p1, p2, scale, shift):
-        """Draw the frame lines"""
+        """
+        Draw the frame lines.
+
+        :param :class:`wx.DC` `dc`: The :class:`wx.DC` to draw on.
+        :type `dc`: :class:`wx.DC`
+        :param p1: The lower-left hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p1 = (-10, -5)
+        :type p1: :class:`np.array`, length 2
+        :param p2: The upper-right hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p2 = (10, 5)
+        :type p2: :class:`np.array`, length 2
+        :param scale: The [X, Y] scaling factor to convert plot coords to
+                      DC coords
+        :type scale: :class:`np.array`, length 2
+        :param shift: The [X, Y] shift values to convert plot coords to
+                      DC coords. Must be in plot units, not DC units.
+        :type shift: :class:`np.array`, length 2
+        """
         # increases thickness for printing only
         pen = self.AxesPen
         penWidth = self.printerScale * pen.GetWidth()
@@ -3778,7 +4435,30 @@ class PlotCanvas(wx.Panel):
 
     @TempStyle('pen')
     def _drawAxesValues(self, dc, p1, p2, scale, shift, xticks, yticks):
-        """ Draws the axes values """
+        """
+        Draws the axes values
+
+        :param :class:`wx.DC` `dc`: The :class:`wx.DC` to draw on.
+        :type `dc`: :class:`wx.DC`
+        :param p1: The lower-left hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p1 = (-10, -5)
+        :type p1: :class:`np.array`, length 2
+        :param p2: The upper-right hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p2 = (10, 5)
+        :type p2: :class:`np.array`, length 2
+        :param scale: The [X, Y] scaling factor to convert plot coords to
+                      DC coords
+        :type scale: :class:`np.array`, length 2
+        :param shift: The [X, Y] shift values to convert plot coords to
+                      DC coords. Must be in plot units, not DC units.
+        :type shift: :class:`np.array`, length 2
+        :param xticks: The X tick definition
+        :type xticks: list of length-2 lists
+        :param yticks: The Y tick definition
+        :type yticks: list of length-2 lists
+        """
         # TODO: More code duplication? Same as _drawGrid and _drawTicks?
         # TODO: update the bounding boxes when adding right and top values
         axes = self.EnableAxesValues
@@ -3832,7 +4512,30 @@ class PlotCanvas(wx.Panel):
 
     @TempStyle('pen')
     def _drawPlotAreaItems(self, dc, p1, p2, scale, shift, xticks, yticks):
-        """Draws each frame element"""
+        """
+        Draws each frame element
+
+        :param :class:`wx.DC` `dc`: The :class:`wx.DC` to draw on.
+        :type `dc`: :class:`wx.DC`
+        :param p1: The lower-left hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p1 = (-10, -5)
+        :type p1: :class:`np.array`, length 2
+        :param p2: The upper-right hand corner of the plot in plot coords. So,
+                   if the plot ranges from x=-10 to 10 and y=-5 to 5, then
+                   p2 = (10, 5)
+        :type p2: :class:`np.array`, length 2
+        :param scale: The [X, Y] scaling factor to convert plot coords to
+                      DC coords
+        :type scale: :class:`np.array`, length 2
+        :param shift: The [X, Y] shift values to convert plot coords to
+                      DC coords. Must be in plot units, not DC units.
+        :type shift: :class:`np.array`, length 2
+        :param xticks: The X tick definition
+        :type xticks: list of length-2 lists
+        :param yticks: The Y tick definition
+        :type yticks: list of length-2 lists
+        """
         if self._gridEnabled:
             self._drawGrid(dc, p1, p2, scale, shift, xticks, yticks)
 
@@ -3853,7 +4556,9 @@ class PlotCanvas(wx.Panel):
 
     @TempStyle('pen')
     def _drawPlotTitle(self, dc, graphics, lhsW, rhsW, titleWH):
-        """Draws the plot title"""
+        """
+        Draws the plot title
+        """
         dc.SetFont(self._getFont(self._fontSizeTitle))
         titlePos = (
             self.plotbox_origin[0] + lhsW
@@ -3864,7 +4569,9 @@ class PlotCanvas(wx.Panel):
 
     def _drawAxesLabels(self, dc, graphics, lhsW, rhsW, bottomH, topH,
                         xLabelWH, yLabelWH):
-        """Draws the axes labels"""
+        """
+        Draws the axes labels
+        """
         # TODO: axes values get big when this is turned off
         dc.SetFont(self._getFont(self._fontSizeAxis))
         xLabelPos = (
@@ -3885,6 +4592,9 @@ class PlotCanvas(wx.Panel):
     @TempStyle('pen')
     def _drawPlotAreaLabels(self, dc, graphics, lhsW, rhsW, titleWH,
                             bottomH, topH, xLabelWH, yLabelWH):
+        """
+        Draw the plot area labels.
+        """
         if self._titleEnabled:
             self._drawPlotTitle(dc, graphics, lhsW, rhsW, titleWH)
 


### PR DESCRIPTION
This PR will (hopefully) finish off all the changes that I had planned for lib.plot.

It will also include any feedback from Robin and anyone else.

+ [ ] Add much more customization options (pens, brushes) to `PolyBars` and `PolyHistogram`
+ [ ] convert `PlotGraphics.LogScale` to `try..except`
+ [ ] rename items in `PlotCanvas.EnableDiagonals` to something else. Or perhaps switch to enums?
+ [ ] remove deep copy in `PolyPoints.points` property
+ [ ] clean up large `if` statement and math in `PlotCanvas._Draw`.
+ [ ] possibly able to modify event handlers in `PlotCanvas.UpdatePointLabel` so that the event is only bound if the item is enabled. This would remove many of the if statements within the event handlers.
+ [ ] Add an option to draw ticks outside to plot rather than only inside.
+ [ ] I have a note that `PlotCanvas._drawAxesValues` has potential code duplication (with `_drawGrid` and `_drawTicks`)
+ [ ] `PlotCanvas._drawAxesValues`: update the bounding boxes when adding right and top values
+ [ ] `PlotCanvas._drawAxesLabels`: Fix bug where axes values get too big when "this" is turned off. *Not sure what "this" is...*
+ [ ] Update pointLabels to be easier to read
  + add semi-opaque background
  + adjust label location if it would fall out of bounds.
+ [ ] More documentation updates based on Robin's comments in https://github.com/wxWidgets/Phoenix/pull/98#issuecomment-230351215