### PR TITLE
Additional Refactoring of lib.plot [Part 3: other changes]

### DIFF
--- a/wx/lib/plot/__init__.py
+++ b/wx/lib/plot/__init__.py
@@ -2,10 +2,7 @@
 # pylint: disable=C0413
 #   C0413: Import should be placed at the top of the module
 """
-wx.lib.plot
-===========
-
-This is a simple plotting library for the wxPython Phoenix project.
+A simple plotting library for the wxPython Phoenix project.
 
 """
 __version__ = "0.0.1"
@@ -42,7 +39,7 @@ from .polyobjects import PlotGraphics
 from .polyobjects import PlotPrintout
 
 from .utils import TempStyle
-from .utils import PendingDeprecation
+from .utils import pendingDeprecation
 
 # For backwards compat.
 BoxPlot = PolyBoxPlot

--- a/wx/lib/plot/examples/demo.py
+++ b/wx/lib/plot/examples/demo.py
@@ -509,7 +509,8 @@ class PlotDemoMainFrame(wx.Frame):
                     'Enables the display of the axes values')
 
         submenu = wx.Menu()
-        submenu_items = ("Bottom", "Left", "Top", "Right")
+        submenu_items = ("Bottom", "Left", "Top", "Right",
+                         "Bottom+Left", "All")
         help_txt = "Enables {} ticks"
         self.ticksSubMenu = submenu
         for _i, item in enumerate(submenu_items, 2501):
@@ -524,6 +525,8 @@ class PlotDemoMainFrame(wx.Frame):
         self.Bind(wx.EVT_MENU, self.OnEnableTicksLeft, id=2502)
         self.Bind(wx.EVT_MENU, self.OnEnableTicksTop, id=2503)
         self.Bind(wx.EVT_MENU, self.OnEnableTicksRight, id=2504)
+        self.Bind(wx.EVT_MENU, self.OnEnableTicksBottomLeft, id=2505)
+        self.Bind(wx.EVT_MENU, self.OnEnableTicksAll, id=2506)
 
         menu.Append(250, 'Enable Ticks', submenu,
                     'Enables the display of the ticks')
@@ -829,8 +832,8 @@ class PlotDemoMainFrame(wx.Frame):
         self.ticksSubMenu.Check(2502, self.client.enableTicks[1])
         self.ticksSubMenu.Check(2503, self.client.enableTicks[2])
         self.ticksSubMenu.Check(2504, self.client.enableTicks[3])
-#        self.ticksSubMenu.Check(2505, all(self.client.enableTicks[:2]))
-#        self.axesSubMenu.Check(2506, all(self.client.enableTicks))
+        self.ticksSubMenu.Check(2505, all(self.client.enableTicks[:2]))
+        self.ticksSubMenu.Check(2506, all(self.client.enableTicks))
 
     def OnEnableTicksBottom(self, event):
         old = self.client.enableTicks
@@ -854,6 +857,17 @@ class PlotDemoMainFrame(wx.Frame):
         old = self.client.enableTicks
         self.client.enableTicks = (old[0], old[1],
                                    old[2], event.IsChecked())
+        self._checkOtherTicksMenuItems()
+
+    def OnEnableTicksBottomLeft(self, event):
+        checked = event.IsChecked()
+        old = self.client.enableTicks
+        self.client.enableTicks = (checked, checked, old[2], old[3])
+        self._checkOtherTicksMenuItems()
+
+    def OnEnableTicksAll(self, event):
+        checked = event.IsChecked()
+        self.client.enableTicks = tuple([checked] * 4)
         self._checkOtherTicksMenuItems()
 
     # -----------------------------------------------------------------------

--- a/wx/lib/plot/plotcanvas.py
+++ b/wx/lib/plot/plotcanvas.py
@@ -14,6 +14,8 @@ __docformat__ = "restructuredtext en"
 
 # Standard Library
 import sys
+import string as _string
+import time as _time
 
 # Third-Party
 import wx
@@ -21,9 +23,10 @@ import numpy as np
 
 # Package
 from .polyobjects import PlotPrintout
+from .polyobjects import PolyMarker, PolyLine, PolyBoxPlot
 from .utils import DisplaySide
 from .utils import set_displayside
-from .utils import PendingDeprecation
+from .utils import pendingDeprecation
 from .utils import TempStyle
 from .utils import scale_and_shift_point
 
@@ -447,26 +450,28 @@ class PlotCanvas(wx.Panel):
         frame.Centre(wx.BOTH)
         frame.Show(True)
 
-    @PendingDeprecation("self.logScale property")
     def setLogScale(self, logscale):
         """
         Set the log scale boolean value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.logScale` property instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.logScale`
+           property instead.
         """
+        pendingDeprecation("self.logScale property")
         self.logScale = logscale
 
-    @PendingDeprecation("self.logScale property")
     def getLogScale(self):
         """
         Set the log scale boolean value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.logScale` property instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.logScale`
+           property instead.
         """
+        pendingDeprecation("self.logScale property")
         return self.logScale
 
     @property
@@ -523,28 +528,30 @@ class PlotCanvas(wx.Panel):
         self.ySpec = 'min'
         self._absScale = absscale
 
-    @PendingDeprecation("self.fontSizeAxis property")
     def SetFontSizeAxis(self, point=10):
         """
         Set the tick and axis label font size (default is 10 point)
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeAxis` property
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.fontSizeAxis`
+           property
            instead.
         """
+        pendingDeprecation("self.fontSizeAxis property")
         self.fontSizeAxis = point
 
-    @PendingDeprecation("self.fontSizeAxis property")
     def GetFontSizeAxis(self):
         """
         Get current tick and axis label font size in points
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeAxis` property
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.fontSizeAxis`
+           property
            instead.
         """
+        pendingDeprecation("self.fontSizeAxis property")
         return self.fontSizeAxis
 
     @property
@@ -564,28 +571,28 @@ class PlotCanvas(wx.Panel):
     def fontSizeAxis(self, value):
         self._fontSizeAxis = value
 
-    @PendingDeprecation("self.fontSizeTitle property")
     def SetFontSizeTitle(self, point=15):
         """
         Set Title font size (default is 15 point)
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeTitle` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.fontSizeTitle`
+           property instead.
         """
+        pendingDeprecation("self.fontSizeTitle property")
         self.fontSizeTitle = point
 
-    @PendingDeprecation("self.fontSizeTitle property")
     def GetFontSizeTitle(self):
         """
         Get Title font size (default is 15 point)
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeTitle` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.fontSizeTitle`
+           property instead.
         """
+        pendingDeprecation("self.fontSizeTitle property")
         return self.fontSizeTitle
 
     @property
@@ -605,16 +612,16 @@ class PlotCanvas(wx.Panel):
     def fontSizeTitle(self, pointsize):
         self._fontSizeTitle = pointsize
 
-    @PendingDeprecation("self.fontSizeLegend property")
     def SetFontSizeLegend(self, point=7):
         """
         Set legend font size (default is 7 point)
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeLegend' property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.fontSizeLegend'
+           property instead.
         """
+        pendingDeprecation("self.fontSizeLegend property")
         self.fontSizeLegend = point
 
     def GetFontSizeLegend(self):
@@ -623,8 +630,8 @@ class PlotCanvas(wx.Panel):
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.fontSizeLegend' property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.fontSizeLegend'
+           property instead.
         """
         return self.fontSizeLegend
 
@@ -645,28 +652,28 @@ class PlotCanvas(wx.Panel):
     def fontSizeLegend(self, point):
         self._fontSizeLegend = point
 
-    @PendingDeprecation("self.showScrollbars property")
     def SetShowScrollbars(self, value):
         """
         Set the showScrollbars value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.showScrollbars` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.showScrollbars`
+           property instead.
         """
+        pendingDeprecation("self.showScrollbars property")
         self.showScrollbars = value
 
-    @PendingDeprecation("self.showScrollbars property")
     def GetShowScrollbars(self):
         """
         Get the showScrollbars value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.showScrollbars` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.showScrollbars`
+           property instead.
         """
+        pendingDeprecation("self.showScrollbars property")
         return self.showScrollbars
 
     @property
@@ -693,28 +700,30 @@ class PlotCanvas(wx.Panel):
         self.sb_hor.Show(value)
         wx.CallAfter(self.Layout)
 
-    @PendingDeprecation("self.useScientificNotation property")
     def SetUseScientificNotation(self, useScientificNotation):
         """
         Set the useScientificNotation value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.useScientificNotation`
+           Use the
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.useScientificNotation`
            property instead.
         """
+        pendingDeprecation("self.useScientificNotation property")
         self.useScientificNotation = useScientificNotation
 
-    @PendingDeprecation("self.useScientificNotation property")
     def GetUseScientificNotation(self):
         """
         Get the useScientificNotation value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.useScientificNotation`
+           Use the
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.useScientificNotation`
            property instead.
         """
+        pendingDeprecation("self.useScientificNotation property")
         return self.useScientificNotation
 
     @property
@@ -735,28 +744,30 @@ class PlotCanvas(wx.Panel):
             raise TypeError("Value should be True or False")
         self._useScientificNotation = value
 
-    @PendingDeprecation("self.enableAntiAliasing property")
     def SetEnableAntiAliasing(self, enableAntiAliasing):
         """
         Set the enableAntiAliasing value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableAntiAliasing`
+           Use the
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableAntiAliasing`
            property instead.
         """
+        pendingDeprecation("self.enableAntiAliasing property")
         self.enableAntiAliasing = enableAntiAliasing
 
-    @PendingDeprecation("self.enableAntiAliasing property")
     def GetEnableAntiAliasing(self):
         """
         Get the enableAntiAliasing value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableAntiAliasing`
+           Use the
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableAntiAliasing`
            property instead.
         """
+        pendingDeprecation("self.enableAntiAliasing property")
         return self.enableAntiAliasing
 
     @property
@@ -778,28 +789,28 @@ class PlotCanvas(wx.Panel):
         self._antiAliasingEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.enableHiRes property")
     def SetEnableHiRes(self, enableHiRes):
         """
         Set the enableHiRes value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableHiRes` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableHiRes`
+           property instead.
         """
+        pendingDeprecation("self.enableHiRes property")
         self.enableHiRes = enableHiRes
 
-    @PendingDeprecation("self.enableHiRes property")
     def GetEnableHiRes(self):
         """
         Get the enableHiRes value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableHiRes` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableHiRes`
+           property instead.
         """
+        pendingDeprecation("self.enableHiRes property")
         return self._hiResEnabled
 
     @property
@@ -821,28 +832,28 @@ class PlotCanvas(wx.Panel):
         self._hiResEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.enableDrag property")
     def SetEnableDrag(self, value):
         """
         Set the enableDrag value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableDrag` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableDrag`
+           property instead.
         """
+        pendingDeprecation("self.enableDrag property")
         self.enableDrag = value
 
-    @PendingDeprecation("self.enableDrag property")
     def GetEnableDrag(self):
         """
         Get the enableDrag value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableDrag` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableDrag`
+           property instead.
         """
+        pendingDeprecation("self.enableDrag property")
         return self.enableDrag
 
     @property
@@ -857,11 +868,11 @@ class PlotCanvas(wx.Panel):
 
         .. note::
            This is mutually exclusive with
-           :attr:`~wx.lib.plot.PlotCanvas.enableZoom`. Setting one will
-           disable the other.
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableZoom`. Setting
+           one will disable the other.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.enableZoom`
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableZoom`
         """
         return self._dragEnabled
 
@@ -877,28 +888,28 @@ class PlotCanvas(wx.Panel):
             self.SetCursor(self.defaultCursor)
         self._dragEnabled = value
 
-    @PendingDeprecation("self.enableZoom property")
     def SetEnableZoom(self, value):
         """
         Set the enableZoom value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableZoom` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableZoom`
+           property instead.
         """
+        pendingDeprecation("self.enableZoom property")
         self.enableZoom = value
 
-    @PendingDeprecation("self.enableZoom property")
     def GetEnableZoom(self):
         """
         Get the enableZoom value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableZoom` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableZoom`
+           property instead.
         """
+        pendingDeprecation("self.enableZoom property")
         return self.enableZoom
 
     @property
@@ -913,11 +924,11 @@ class PlotCanvas(wx.Panel):
 
         .. note::
            This is mutually exclusive with
-           :attr:`~wx.lib.plot.PlotCanvas.enableDrag`. Setting one will
-           disable the other.
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableDrag`. Setting
+           one will disable the other.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.enableDrag`
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableDrag`
         """
         return self._zoomEnabled
 
@@ -933,28 +944,28 @@ class PlotCanvas(wx.Panel):
             self.SetCursor(self.defaultCursor)
         self._zoomEnabled = value
 
-    @PendingDeprecation("self.enableGrid property")
     def SetEnableGrid(self, value):
         """
         Set the enableGrid value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableGrid` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableGrid`
+           property instead.
         """
+        pendingDeprecation("self.enableGrid property")
         self.enableGrid = value
 
-    @PendingDeprecation("self.enableGrid property")
     def GetEnableGrid(self):
         """
         Get the enableGrid value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableGrid` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableGrid`
+           property instead.
         """
+        pendingDeprecation("self.enableGrid property")
         return self.enableGrid
 
     @property
@@ -988,28 +999,28 @@ class PlotCanvas(wx.Panel):
         self._gridEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.enableCenterLines property")
     def SetEnableCenterLines(self, value):
         """
         Set the enableCenterLines value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableCenterLines`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableCenterLines`
            property instead.
         """
+        pendingDeprecation("self.enableCenterLines property")
         self.enableCenterLines = value
 
-    @PendingDeprecation("self.enableCenterLines property")
     def GetEnableCenterLines(self):
         """
         Get the enableCenterLines value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableCenterLines`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableCenterLines`
            property instead.
         """
+        pendingDeprecation("self.enableCenterLines property")
         return self.enableCenterLines
 
     @property
@@ -1037,28 +1048,28 @@ class PlotCanvas(wx.Panel):
         self._centerLinesEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.enableDiagonals property")
     def SetEnableDiagonals(self, value):
         """
         Set the enableDiagonals value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableDiagonals`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableDiagonals`
            property instead.
         """
+        pendingDeprecation("self.enableDiagonals property")
         self.enableDiagonals = value
 
-    @PendingDeprecation("self.enableDiagonals property")
     def GetEnableDiagonals(self):
         """
         Get the enableDiagonals value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableDiagonals`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableDiagonals`
            property instead.
         """
+        pendingDeprecation("self.enableDiagonals property")
         return self.enableDiagonals
 
     @property
@@ -1091,28 +1102,28 @@ class PlotCanvas(wx.Panel):
         self._diagonalsEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.enableLegend property")
     def SetEnableLegend(self, value):
         """
         Set the enableLegend value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableLegend`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableLegend`
            property instead.
         """
+        pendingDeprecation("self.enableLegend property")
         self.enableLegend = value
 
-    @PendingDeprecation("self.enableLegend property")
     def GetEnableLegend(self):
         """
         Get the enableLegend value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableLegend`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableLegend`
            property instead.
         """
+        pendingDeprecation("self.enableLegend property")
         return self.enableLegend
 
     @property
@@ -1136,28 +1147,28 @@ class PlotCanvas(wx.Panel):
         self._legendEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.enableTitle property")
     def SetEnableTitle(self, value):
         """
         Set the enableTitle value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableTitle` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableTitle`
+           property instead.
         """
+        pendingDeprecation("self.enableTitle property")
         self.enableTitle = value
 
-    @PendingDeprecation("self.enableTitle property")
     def GetEnableTitle(self):
         """
         Get the enableTitle value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enableTitle` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enableTitle`
+           property instead.
         """
+        pendingDeprecation("self.enableTitle property")
         return self.enableTitle
 
     @property
@@ -1179,28 +1190,28 @@ class PlotCanvas(wx.Panel):
         self._titleEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.enablePointLabel property")
     def SetEnablePointLabel(self, value):
         """
         Set the enablePointLabel value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enablePointLabel`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enablePointLabel`
            property instead.
         """
+        pendingDeprecation("self.enablePointLabel property")
         self.enablePointLabel = value
 
-    @PendingDeprecation("self.enablePointLabel property")
     def GetEnablePointLabel(self):
         """
         Set the enablePointLabel value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enablePointLabel`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enablePointLabel`
            property instead.
         """
+        pendingDeprecation("self.enablePointLabel property")
         return self.enablePointLabel
 
     @property
@@ -1378,28 +1389,28 @@ class PlotCanvas(wx.Panel):
         self._axesLabelsEnabled = value
         self.Redraw()
 
-    @PendingDeprecation("self.pointLabelFunc property")
     def SetPointLabelFunc(self, func):
         """
         Set the enablePointLabel value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enablePointLabel`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enablePointLabel`
            property instead.
         """
+        pendingDeprecation("self.pointLabelFunc property")
         self.pointLabelFunc = func
 
-    @PendingDeprecation("self.pointLabelFunc property")
     def GetPointLabelFunc(self):
         """
         Get the enablePointLabel value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.enablePointLabel`
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.enablePointLabel`
            property instead.
         """
+        pendingDeprecation("self.pointLabelFunc property")
         return self.pointLabelFunc
 
     @property
@@ -1468,48 +1479,52 @@ class PlotCanvas(wx.Panel):
         x, y = (screenPos - self._pointShift) / self._pointScale
         return x, y
 
-    @PendingDeprecation("self.xSpec property")
     def SetXSpec(self, spectype='auto'):
         """
         Set the xSpec value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.xSpec` property instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.xSpec`
+           property instead.
         """
+        pendingDeprecation("self.xSpec property")
         self.xSpec = spectype
 
-    @PendingDeprecation("self.ySpec property")
     def SetYSpec(self, spectype='auto'):
         """
         Set the ySpec value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.ySpec` property instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.ySpec`
+           property instead.
         """
+        pendingDeprecation("self.ySpec property")
         self.ySpec = spectype
 
-    @PendingDeprecation("self.xSpec property")
     def GetXSpec(self):
         """
         Get the xSpec value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.xSpec` property instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.xSpec`
+           property instead.
         """
+        pendingDeprecation("self.xSpec property")
         return self.xSpec
 
-    @PendingDeprecation("self.ySpec property")
     def GetYSpec(self):
         """
         Get the ySpec value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.ySpec` property instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.ySpec`
+           property instead.
         """
+        pendingDeprecation("self.ySpec property")
         return self.ySpec
 
     @property
@@ -1534,7 +1549,7 @@ class PlotCanvas(wx.Panel):
         + list or tuple: a list of (min, max) values. Must be length 2.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.ySpec`
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.ySpec`
         """
         return self._xSpec
 
@@ -1570,7 +1585,7 @@ class PlotCanvas(wx.Panel):
         + list or tuple: a list of (min, max) values. Must be length 2.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.xSpec`
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.xSpec`
         """
         return self._ySpec
 
@@ -1584,15 +1599,16 @@ class PlotCanvas(wx.Panel):
                 raise TypeError(err_str)
         self._ySpec = value
 
-    @PendingDeprecation("self.xMaxRange property")
     def GetXMaxRange(self):
         """
         Get the xMaxRange value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.xMaxRange` property instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.xMaxRange`
+           property instead.
         """
+        pendingDeprecation("self.xMaxRange property")
         return self.xMaxRange
 
     @property
@@ -1603,7 +1619,7 @@ class PlotCanvas(wx.Panel):
         :getter: Returns the value of xMaxRange.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.yMaxRange`
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.yMaxRange`
         """
         xAxis = self._getXMaxRange()
         if self.logScale[0]:
@@ -1617,15 +1633,16 @@ class PlotCanvas(wx.Panel):
         xAxis = self._axisInterval(self._xSpec, p1[0], p2[0])  # in user units
         return xAxis
 
-    @PendingDeprecation("self.yMaxRange property")
     def GetYMaxRange(self):
         """
         Get the yMaxRange value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.yMaxRange` property instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.yMaxRange`
+           property instead.
         """
+        pendingDeprecation("self.yMaxRange property")
         return self.yMaxRange
 
     @property
@@ -1636,7 +1653,7 @@ class PlotCanvas(wx.Panel):
         :getter: Returns the value of yMaxRange.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.xMaxRange`
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.xMaxRange`
         """
         yAxis = self._getYMaxRange()
         if self.logScale[1]:
@@ -1650,16 +1667,16 @@ class PlotCanvas(wx.Panel):
         yAxis = self._axisInterval(self._ySpec, p1[1], p2[1])
         return yAxis
 
-    @PendingDeprecation("self.xCurrentRange property")
     def GetXCurrentRange(self):
         """
         Get the xCurrentRange value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.xCurrentRange` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.xCurrentRange`
+           property instead.
         """
+        pendingDeprecation("self.xCurrentRange property")
         return self.xCurrentRange
 
     @property
@@ -1671,7 +1688,7 @@ class PlotCanvas(wx.Panel):
         :getter: Returns the value of xCurrentRange.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.yCurrentRange`
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.yCurrentRange`
         """
         xAxis = self._getXCurrentRange()
         if self.logScale[0]:
@@ -1683,16 +1700,16 @@ class PlotCanvas(wx.Panel):
         portion of graph"""
         return self.last_draw[1]
 
-    @PendingDeprecation("self.yCurrentRange property")
     def GetYCurrentRange(self):
         """
         Get the yCurrentRange value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotCanvas.yCurrentRange` property
-           instead.
+           Use the :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.yCurrentRange`
+           property instead.
         """
+        pendingDeprecation("self.yCurrentRange property")
         return self.yCurrentRange
 
     @property
@@ -1704,7 +1721,7 @@ class PlotCanvas(wx.Panel):
         :getter: Returns the value of yCurrentRange.
 
         .. seealso::
-           :attr:`~wx.lib.plot.PlotCanvas.xCurrentRange`
+           :attr:`~wx.lib.plot.plotcanvas.PlotCanvas.xCurrentRange`
         """
         yAxis = self._getYCurrentRange()
         if self.logScale[1]:
@@ -2238,7 +2255,7 @@ class PlotCanvas(wx.Panel):
         for i in range(len(graphics)):
             o = graphics[i]
             s = i * lineHeight
-            if isinstance(o, PolyMarker) or isinstance(o, BoxPlot):
+            if isinstance(o, PolyMarker) or isinstance(o, PolyBoxPlot):
                 # draw marker with legend
                 pnt = (trhc[0] + legendLHS + legendSymExt[0] / 2.,
                        trhc[1] + s + lineHeight / 2.)

--- a/wx/lib/plot/plotcanvas.py
+++ b/wx/lib/plot/plotcanvas.py
@@ -2084,7 +2084,7 @@ class PlotCanvas(wx.Panel):
                 np.array,
                 map(self.PositionScreenToUser,
                     [coordinates, self._screenCoordinates]
-                )
+                    )
             )
             dist = newpos - oldpos
             self._screenCoordinates = coordinates

--- a/wx/lib/plot/plotcanvas.py
+++ b/wx/lib/plot/plotcanvas.py
@@ -1781,7 +1781,7 @@ class PlotCanvas(wx.Panel):
             if not isinstance(dc, wx.GCDC):
                 try:
                     dc = wx.GCDC(dc)
-                except Exception:
+                except Exception:               # XXX: Yucky.
                     pass
                 else:
                     if self._hiResEnabled:
@@ -1842,34 +1842,27 @@ class PlotCanvas(wx.Panel):
             # upper right corner user scale (xmax,ymax)
             p2 = np.array([xAxis[1], yAxis[1]])
 
-        # saves most recient values
+        # saves most recent values
         self.last_draw = (graphics, np.array(xAxis), np.array(yAxis))
 
         # Get ticks and textExtents for axis if required
+        xticks = yticks = None
+        xTextExtent = yTextExtent = (0, 0)  # No text for ticks
         if self._xSpec is not 'none':
             xticks = self._xticks(xAxis[0], xAxis[1])
-        else:
-            xticks = None
-        if xticks:
             # w h of x axis text last number on axis
             xTextExtent = dc.GetTextExtent(xticks[-1][1])
-        else:
-            xTextExtent = (0, 0)  # No text for ticks
+
         if self._ySpec is not 'none':
             yticks = self._yticks(yAxis[0], yAxis[1])
-        else:
-            yticks = None
-        if yticks:
             if self.logScale[1]:
+                # make sure we have enough room to display SI notation.
                 yTextExtent = dc.GetTextExtent('-2e-2')
             else:
                 yTextExtentBottom = dc.GetTextExtent(yticks[0][1])
                 yTextExtentTop = dc.GetTextExtent(yticks[-1][1])
                 yTextExtent = (max(yTextExtentBottom[0], yTextExtentTop[0]),
                                max(yTextExtentBottom[1], yTextExtentTop[1]))
-        else:
-            yticks = None
-            yTextExtent = (0, 0)  # No text for ticks
 
         # TextExtents for Title and Axis Labels
         titleWH, xLabelWH, yLabelWH = self._titleLablesWH(dc, graphics)
@@ -1907,10 +1900,10 @@ class PlotCanvas(wx.Panel):
                              legendTextExt)
 
         # allow for scaling and shifting plotted points
-        scale = (self.plotbox_size - textSize_scale) / \
-            (p2 - p1) * np.array((1, -1))
-        shift = -p1 * scale + self.plotbox_origin + \
-            textSize_shift * np.array((1, -1))
+        scale = ((self.plotbox_size - textSize_scale) / (p2 - p1)
+                 * np.array((1, -1)))
+        shift = (-p1 * scale + self.plotbox_origin
+                 + textSize_shift * np.array((1, -1)))
         # make available for mouse events
         self._pointScale = scale / self._pointSize
         self._pointShift = shift / self._pointSize
@@ -1998,8 +1991,8 @@ class PlotCanvas(wx.Panel):
             if len(obj.points) == 0:
                 continue  # go to next obj
             #[curveNum, legend, closest pt index, pointXY, scaledXY, dist]
-            cn = [curveNum] + \
-                [obj.getLegend()] + obj.getClosestPoint(pntXY, pointScaled)
+            cn = ([curveNum] +
+                  [obj.getLegend()] + obj.getClosestPoint(pntXY, pointScaled))
             l.append(cn)
         return l
 
@@ -2186,13 +2179,13 @@ class PlotCanvas(wx.Panel):
                 fullrange, pagesize = self.sb_vert.GetRange(
                 ), self.sb_vert.GetPageSize()
                 sbpos = fullrange - pagesize - sbpos
-                dist = sbpos * self._sb_xunit - \
-                    (self._getXCurrentRange()[0] - self._sb_xfullrange)
+                dist = (sbpos * self._sb_xunit -
+                        (self._getXCurrentRange()[0] - self._sb_xfullrange))
                 self.ScrollUp(dist)
 
             if evt.GetOrientation() == wx.HORIZONTAL:
-                dist = sbpos * self._sb_xunit - \
-                    (self._getXCurrentRange()[0] - self._sb_xfullrange[0])
+                dist = (sbpos * self._sb_xunit -
+                        (self._getXCurrentRange()[0] - self._sb_xfullrange[0]))
                 self.ScrollRight(dist)
 
     # Private Methods **************************************************
@@ -2245,8 +2238,8 @@ class PlotCanvas(wx.Panel):
                     legendSymExt, legendTextExt):
         """Draws legend symbols and text"""
         # top right hand corner of graph box is ref corner
-        trhc = self.plotbox_origin + \
-            (self.plotbox_size - [rhsW, topH]) * [1, -1]
+        trhc = (self.plotbox_origin +
+                (self.plotbox_size - [rhsW, topH]) * [1, -1])
         # border space between legend sym and graph box
         legendLHS = .091 * legendBoxWH[0]
         # 1.1 used as space between lines
@@ -2483,7 +2476,7 @@ class PlotCanvas(wx.Panel):
                 lines = []
                 for x, label in xticks:
                     pt = scale_and_shift_point(x, p2[1], scale, shift)
-                    lines.appned((pt[0], pt[1], pt[0], pt[1] + xTickLength))
+                    lines.append((pt[0], pt[1], pt[0], pt[1] + xTickLength))
                 dc.DrawLineList(lines)
 
         if self.ySpec != 'none':

--- a/wx/lib/plot/plotcanvas.py
+++ b/wx/lib/plot/plotcanvas.py
@@ -20,6 +20,7 @@ import wx
 import numpy as np
 
 # Package
+from .polyobjects import PlotPrintout
 from .utils import DisplaySide
 from .utils import set_displayside
 from .utils import PendingDeprecation

--- a/wx/lib/plot/polyobjects.py
+++ b/wx/lib/plot/polyobjects.py
@@ -33,6 +33,7 @@ except:
 # Package
 from .utils import pendingDeprecation
 from .utils import TempStyle
+from .utils import pairwise
 
 
 # XXX: Comment out this line to disable deprecation warnings
@@ -577,8 +578,6 @@ class PolyMarker(PolyPoints):
                    'legend': ''}
 
     def __init__(self, points, **attr):
-
-
         PolyPoints.__init__(self, points, attr)
 
     def draw(self, dc, printerScale, coord=None):
@@ -842,14 +841,6 @@ class PolyHistogram(PolyBarsBase):
 
         self.hist = hist
         self.binspec = binspec
-
-        # need to create a series of points to be used by PolyPoints
-        import itertools
-        def pairwise(iterable):
-            "s -> (s0,s1), (s1,s2), (s2, s3), ..."
-            a, b = itertools.tee(iterable)
-            next(b, None)
-            return zip(a, b)
 
         # define the bins and center x locations
         self.bins = list(pairwise(self.binspec))
@@ -1238,11 +1229,6 @@ class PlotGraphics(object):
 
     @property
     def logScale(self):
-        # TODO: convert to try..except statement
-#        try:
-#        return [obj.logScale for obj in self.objects]
-#        except:     # what error would be returned?
-#            return
         if len(self.objects) == 0:
             return
         return [obj.logScale for obj in self.objects]
@@ -1448,9 +1434,7 @@ class PlotGraphics(object):
         return self.objects[item]
 
 
-
-
-#-------------------------------------------------------------------------
+# -------------------------------------------------------------------------
 # Used to layout the printer page
 
 

--- a/wx/lib/plot/polyobjects.py
+++ b/wx/lib/plot/polyobjects.py
@@ -13,9 +13,7 @@ This contains all of the PolyXXX objects used by :mod:`wx.lib.plot`.
 __docformat__ = "restructuredtext en"
 
 # Standard Library
-import string as _string
 import time as _time
-import sys
 import wx
 import warnings
 from collections import namedtuple
@@ -33,7 +31,7 @@ except:
     raise ImportError("NumPy not found.\n" + msg)
 
 # Package
-from .utils import PendingDeprecation
+from .utils import pendingDeprecation
 from .utils import TempStyle
 
 
@@ -90,13 +88,18 @@ class PolyPoints(object):
             raise ValueError("`logscale` must be a 2-tuple of bools")
         self._logscale = logscale
 
-    @PendingDeprecation("self.logScale property")
     def setLogScale(self, logscale):
         """
         Set to change the axes to plot Log10(values)
 
         Value must be a tuple of booleans (x_axis_bool, y_axis_bool)
+
+        .. deprecated:: Feb 27, 2016
+
+           Use the :attr:`~wx.lib.plot.polyobjects.PolyPoints.logScale`
+           property instead.
         """
+        pendingDeprecation("self.logScale property")
         self._logscale = logscale
 
     @property
@@ -1013,13 +1016,13 @@ class PolyBoxPlot(PolyPoints):
 
         outliers are outside of 1.5 * IQR
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         data : array-like
             The data to plot
 
-        Returns:
-        --------
+        Returns
+        -------
         bpdata : collections.namedtuple
             Descriptive statistics for data:
             (min_data, low_whisker, q25, median, q75, high_whisker, max_data)
@@ -1069,8 +1072,8 @@ class PolyBoxPlot(PolyPoints):
         """
         Draws a box plot on the DC.
 
-        Notes:
-        ------
+        Notes
+        -----
         The following draw order is required:
 
         1. First the whisker line
@@ -1254,16 +1257,16 @@ class PlotGraphics(object):
         for obj in self.objects:
             obj.logScale = logscale
 
-    @PendingDeprecation("self.logScale property")
     def setLogScale(self, logscale):
         """
         Set the log scale boolean value.
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.logScale` property
-           instead.
+           Use the :attr:`~wx.lib.plot.polyobjects.PlotGraphics.logScale`
+           property instead.
         """
+        pendingDeprecation("self.logScale property")
         self.logScale = logscale
 
     @property
@@ -1294,88 +1297,88 @@ class PlotGraphics(object):
         for o in self.objects:
             o.scaleAndShift(scale, shift)
 
-    @PendingDeprecation("self.printerScale property")
     def setPrinterScale(self, scale):
         """
         Thickens up lines and markers only for printing
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.printerScale` property
-           instead.
+           Use the :attr:`~wx.lib.plot.polyobjects.PlotGraphics.printerScale`
+           property instead.
         """
+        pendingDeprecation("self.printerScale property")
         self.printerScale = scale
 
-    @PendingDeprecation("self.xLabel property")
     def setXLabel(self, xLabel=''):
         """
         Set the X axis label on the graph
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.xLabel` property
-           instead.
-       """
+           Use the :attr:`~wx.lib.plot.polyobjects.PlotGraphics.xLabel`
+           property instead.
+        """
+        pendingDeprecation("self.xLabel property")
         self.xLabel = xLabel
 
-    @PendingDeprecation("self.yLabel property")
     def setYLabel(self, yLabel=''):
         """
         Set the Y axis label on the graph
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.yLabel` property
-           instead.
-       """
+           Use the :attr:`~wx.lib.plot.polyobjects.PlotGraphics.yLabel`
+           property instead.
+        """
+        pendingDeprecation("self.yLabel property")
         self.yLabel = yLabel
 
-    @PendingDeprecation("self.title property")
     def setTitle(self, title=''):
         """
         Set the title at the top of graph
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.title` property
-           instead.
+           Use the :attr:`~wx.lib.plot.polyobjects.PlotGraphics.title`
+           property instead.
         """
+        pendingDeprecation("self.title property")
         self.title = title
 
-    @PendingDeprecation("self.xLabel property")
     def getXLabel(self):
         """
         Get X axis label string
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.xLabel` property
-           instead.
+           Use the :attr:`~wx.lib.plot.polyobjects.PlotGraphics.xLabel`
+           property instead.
         """
+        pendingDeprecation("self.xLabel property")
         return self.xLabel
 
-    @PendingDeprecation("self.yLabel property")
     def getYLabel(self):
         """
         Get Y axis label string
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.yLabel` property
-           instead.
+           Use the :attr:`~wx.lib.plot.polyobjects.PlotGraphics.yLabel`
+           property instead.
         """
+        pendingDeprecation("self.yLabel property")
         return self.yLabel
 
-    @PendingDeprecation("self.title property")
     def getTitle(self, title=''):
         """
         Get the title at the top of graph
 
         .. deprecated:: Feb 27, 2016
 
-           Use the :attr:`~wx.lib.plot.PlotGraphics.title` property
-           instead.
+           Use the :attr:`~wx.lib.plot.polyobjects.PlotGraphics.title`
+           property instead.
         """
+        pendingDeprecation("self.title property")
         return self.title
 
     @property

--- a/wx/lib/plot/utils.py
+++ b/wx/lib/plot/utils.py
@@ -22,8 +22,9 @@ import numpy as np
 
 class DisplaySide(object):
     """
-    Generic class for storing booleans describing which sides of a box are
-    displayed. Used for fine-tuning the axis, ticks, and values of a graph.
+    Generic class for describing which sides of a box are displayed.
+
+    Used for fine-tuning the axis, ticks, and values of a graph.
 
     This class somewhat mimics a collections.namedtuple factory function in
     that it is an iterable and can have indiviual elements accessible by name.
@@ -34,13 +35,13 @@ class DisplaySide(object):
     - it contains type checking, only allowing boolean values
     - it contains name checking, only allowing valid_names as attributes
 
-    :param bottom: Display the bottom side?
+    :param bottom: Display the bottom side
     :type bottom: bool
-    :param left: Display the left side?
+    :param left: Display the left side
     :type left: bool
-    :param top: Display the top side?
+    :param top: Display the top side
     :type top: bool
-    :param right: Display the right side?
+    :param right: Display the right side
     :type right: bool
     """
     # TODO: Do I want to replace with __slots__?
@@ -108,11 +109,14 @@ class DisplaySide(object):
         return iter([self.bottom, self.left, self.top, self.right])
 
 
-# TODO: New name: RevertStyle? SavedStyle? Something else?
+# TODO: replace with wx.DCPenChanger/wx.DCBrushChanger, etc.
+#       Alternatively, replace those with this function...
 class TempStyle(object):
     """
-    Combination Decorator and Context Manager to revert pen or brush changes
-    after a method call or block finish.
+    Decorator / Context Manager to revert pen or brush changes.
+
+    Will revert pen, brush, or both to their previous values after a method
+    call or block finish.
 
     :param which: The item to save and revert after execution. Can be
                   one of ``{'both', 'pen', 'brush'}``.
@@ -136,7 +140,6 @@ class TempStyle(object):
        As of 2016-06-15, this can only be used as a decorator for **class
        methods**, not standard functions. There is a plan to try and remove
        this restriction, but I don't know when that will happen...
-
 
     .. epigraph::
 
@@ -237,8 +240,7 @@ class TempStyle(object):
 
 class PendingDeprecation(object):
     """
-    Decorator which warns the developer about methods that are
-    pending deprecation.
+    Decorator which raises warnings for methods that are pending deprecation.
 
     :param new_func: The new class, method, or function that should be used.
     :type new_func: str
@@ -280,6 +282,8 @@ def scale_and_shift_point(x, y, scale=1, shift=0):
     """
     Creates a scaled and shifted 2x1 numpy array of [x, y] values.
 
+    The shift value must be in the scaled units.
+
     :param float `x`:        The x value of the unscaled, unshifted point
     :param float `y`:        The y valye of the unscaled, unshifted point
     :param np.array `scale`: The scale factor to use ``[x_sacle, y_scale]``
@@ -290,6 +294,7 @@ def scale_and_shift_point(x, y, scale=1, shift=0):
     :rtype: np.array
 
     .. note::
+
        :math:`new = (scale * old) + shift`
     """
     point = scale * np.array([x, y]) + shift
@@ -298,8 +303,7 @@ def scale_and_shift_point(x, y, scale=1, shift=0):
 
 def set_displayside(value):
     """
-    Wrapper around :class:`~wx.lib.plot._DisplaySide` that allowing for
-    "overloaded" calls.
+    Wrapper around :class:`~wx.lib.plot._DisplaySide` that allows for "overloaded" calls.
 
     If ``value`` is a boolean: all 4 sides are set to ``value``
 

--- a/wx/lib/plot/utils.py
+++ b/wx/lib/plot/utils.py
@@ -15,6 +15,7 @@ __docformat__ = "restructuredtext en"
 # Standard Library
 import functools
 import inspect
+import itertools
 from warnings import warn as _warn
 
 # Third Party
@@ -312,6 +313,12 @@ def set_displayside(value):
         raise TypeError(err_txt)
     return DisplaySide(*_value)
 
+
+def pairwise(iterable):
+    "s -> (s0,s1), (s1,s2), (s2, s3), ..."
+    a, b = itertools.tee(iterable)
+    next(b, None)
+    return zip(a, b)
 
 if __name__ == "__main__":
     raise RuntimeError("This module is not intended to be run by itself.")

--- a/wx/lib/plot/utils.py
+++ b/wx/lib/plot/utils.py
@@ -14,6 +14,7 @@ __docformat__ = "restructuredtext en"
 
 # Standard Library
 import functools
+import inspect
 from warnings import warn as _warn
 
 # Third Party
@@ -238,44 +239,19 @@ class TempStyle(object):
         dc.SetBrush(self.prevBrush)
 
 
-class PendingDeprecation(object):
+def pendingDeprecation(new_func):
     """
-    Decorator which raises warnings for methods that are pending deprecation.
+    Raise `PendingDeprecationWarning` and display a message.
 
-    :param new_func: The new class, method, or function that should be used.
-    :type new_func: str
+    Uses inspect.stack() to determine the name of the item that this
+    is called from.
 
-    ::
-
-        @PendingDeprecation("new_func")
-        def old_func():
-            pass
-
-        # prints the warning:
-        # `old_func` is pending deprecation. Please use `new_func` instead.
-
+    :param new_func: The name of the function that should be used instead.
+    :type new_func: string.
     """
-    _warn_txt = "`{}` is pending deprecation. Please use `{}` instead."
-
-    def __init__(self, new_func):
-        self.new_func = new_func
-
-    def __call__(self, func):
-        """Support for functions"""
-        self.func = func
-#        self._update_docs()
-
-        @functools.wraps(self.func)
-        def wrapper(*args, **kwargs):
-            _warn(self._warn_txt.format(self.func.__name__, self.new_func),
-                  PendingDeprecationWarning)
-            return self.func(*args, **kwargs)
-        return wrapper
-
-    def _update_docs(self):
-        """ Set the docs to that of the decorated function. """
-        self.__name__ = self.func.__name__
-        self.__doc__ = self.func.__doc__
+    warn_txt = "`{}` is pending deprecation. Please use `{}` instead."
+    _warn(warn_txt.format(inspect.stack()[1][3], new_func),
+          PendingDeprecationWarning)
 
 
 def scale_and_shift_point(x, y, scale=1, shift=0):


### PR DESCRIPTION
## Update 2017-09-08

I will not be able to finish all the items in the PR 😢 

Per @RobinD42's suggestion, I have made issues for all unfinished items so that someone else can complete them.

This PR now only makes the following changes:
+ Add an option to draw ticks outside to plot rather than only inside.
+ Fix instances of `wrapper(*args, **kwargs)` in built docs
+ Updates docs
+ Addes additional "Ticks" demos
+ Miscellaneous cleanup

All the other items that I wanted to accomplish have their related Issue listed below.

+ #512
+ #513 
+ #514 
+ #515 
+ #516
+ #517 
+ #518
+ #519 


## Original PR message

(This PR replaces #112, as I mucked up the git history too much)

This PR will (hopefully) finish off all the changes that I had planned for lib.plot.

It will also include any feedback from Robin and anyone else.
- [ ] Add much more customization options (pens, brushes) to `PolyBars` and `PolyHistogram` (#512)
- ~~[ ] convert `PlotGraphics.LogScale` to `try..except`~~
- ~~[ ] rename items in `PlotCanvas.EnableDiagonals` to something else. Or perhaps switch to enums?~~
- [ ] remove deep copy in `PolyPoints.points` property (#513)
- [ ] clean up large `if` statement and math in `PlotCanvas._Draw`. (#514)
- [ ] possibly able to modify event handlers in `PlotCanvas.UpdatePointLabel` so that the event is only bound if the item is enabled. This would remove many of the if statements within the event handlers. (#515)
- [x] Add an option to draw ticks outside to plot rather than only inside.
- [ ] I have a note that `PlotCanvas._drawAxesValues` has potential code duplication (with `_drawGrid` and `_drawTicks`) (#516)
- [ ] `PlotCanvas._drawAxesValues`: update the bounding boxes when adding right and top values (#517)
- [ ] `PlotCanvas._drawAxesLabels`: Fix bug where axes values get too big when "this" is turned off. _Not sure what "this" is..._
- [ ] Update pointLabels to be easier to read (#518)
  - add semi-opaque background
  - adjust label location if it would fall out of bounds.
- [ ] More documentation updates based on Robin's comments in https://github.com/wxWidgets/Phoenix/pull/98#issuecomment-230351215
  - [x] Fix instances of `wrapper(*args, **kwargs)` in built docs [**needs confirmation**]
