### PR TITLE
Fix crash when running event tests

### DIFF
--- a/unittests/test_event.py
+++ b/unittests/test_event.py
@@ -45,6 +45,7 @@ class Events(unittest.TestCase):
         evt = wx.FocusEvent()
 
     def test_HelpEvent_ctor(self):
+        app = wx.App()
         evt = wx.HelpEvent()
 
     def test_IconizeEvent_ctor(self):


### PR DESCRIPTION
HelpEvent requires a wx.App to exist, at least on GTK as it ultimately fetches
the root window.