### PR TITLE
Fix lib_pubsub_listener tests

### DIFF
--- a/unittests/test_lib_pubsub_listener.py
+++ b/unittests/test_lib_pubsub_listener.py
@@ -5,6 +5,7 @@
 
 """
 
+import six
 import unittest
 from unittests import wtc
 
@@ -194,7 +195,9 @@ class lib_pubsub_ArgsInfo(wtc.PubsubTestCase):
                 def tmpFn(self):
                     pass
             Listener( DOA.tmpFn, ArgsInfoMock() )
-        self.assertRaises(ValueError, getListener1)
+        # Py3 doesn't have unbound methods so this won't throw a ValueError
+        if not six.PY3:
+            self.assertRaises(ValueError, getListener1)
 
         # test DOA of tmp callable:
         def getListener2():


### PR DESCRIPTION
Python 3 doesn't have unbound methods and thus will not throw the ValueError
that is expected in Python 2.