### PR TITLE
Fix TopicTreeTraverser when doing breadth traversal on Python 3

### DIFF
--- a/wx/lib/pubsub/core/topictreetraverser.py
+++ b/wx/lib/pubsub/core/topictreetraverser.py
@@ -55,6 +55,8 @@ class TopicTreeTraverser:
 
         def extendQueue(subtopics):
             topics.append(visitor._startChildren)
+            # put subtopics in list in alphabetical order
+            subtopics.sort(key=topicObj.__class__.getName)
             topics.extend(subtopics)
             topics.append(visitor._endChildren)
 


### PR DESCRIPTION
Python 3 orders maps differently from Python 2, so sort the subtopics before
traversing them like is done with depth traversal.