### PR TITLE
Fix crash in ribbonbar sample

### DIFF
--- a/samples/ribbon/ribbonbar_demo.py
+++ b/samples/ribbon/ribbonbar_demo.py
@@ -335,7 +335,6 @@ class RibbonFrame(wx.Frame):
 
         if event.GetGalleryItem() != None:
             if provider == self._ribbon.GetArtProvider():
-                provider = provider.Clone()
                 gallery.SetArtProvider(provider)
 
             provider.SetColour(RB.RIBBON_ART_GALLERY_HOVER_BACKGROUND_COLOUR,


### PR DESCRIPTION
The ArtProvider shouldn't be cloned in this case because SetArtProvider() does
not take ownership of the object in this case.  Because of that, once the
cloned provider goes out of scope and gets garbage collected, future uses will
crash.

Fixes #141.