### PR TITLE
Fix wxRibbonBar::SetArtProvider ownership

### DIFF
--- a/etg/ribbon_bar.py
+++ b/etg/ribbon_bar.py
@@ -38,6 +38,7 @@ def run():
     c = module.find('wxRibbonBar')
     assert isinstance(c, etgtools.ClassDef)
     tools.fixWindowClass(c)
+    c.find('SetArtProvider.art').transfer = True
 
 
     c = module.find('wxRibbonBarEvent')


### PR DESCRIPTION
SetArtProvider in RibbonBar takes ownership of the pointer so we need to use
transfer here.