### PR TITLE
In demos using wx.ListCtrl, replaced sys.maxsize with GetItemCount()

### DIFF
--- a/demo/CheckListCtrlMixin.py
+++ b/demo/CheckListCtrlMixin.py
@@ -47,7 +47,7 @@ class TestPanel(wx.Panel):
         self.list.InsertColumn(2, "Genre")
 
         for key, data in musicdata.items():
-            index = self.list.InsertStringItem(sys.maxsize, data[0])
+            index = self.list.InsertItem(self.list.GetItemCount(), data[0])
             self.list.SetItem(index, 1, data[1])
             self.list.SetItem(index, 2, data[2])
             self.list.SetItemData(index, key)

--- a/demo/ListCtrl.py
+++ b/demo/ListCtrl.py
@@ -113,8 +113,8 @@ class TestListCtrlPanel(wx.Panel, listmix.ColumnSorterMixin):
                                  #| wx.BORDER_SUNKEN
                                  | wx.BORDER_NONE
                                  | wx.LC_EDIT_LABELS
-                                 | wx.LC_SORT_ASCENDING
-                                 #| wx.LC_NO_HEADER
+                                 #| wx.LC_SORT_ASCENDING    # disabling initial auto sort gives a
+                                 #| wx.LC_NO_HEADER         # better illustration of col-click sorting
                                  #| wx.LC_VRULES
                                  #| wx.LC_HRULES
                                  #| wx.LC_SINGLE_SEL
@@ -183,7 +183,7 @@ class TestListCtrlPanel(wx.Panel, listmix.ColumnSorterMixin):
 
         items = musicdata.items()
         for key, data in items:
-            index = self.list.InsertItem(sys.maxsize, data[0], self.idx1)
+            index = self.list.InsertItem(self.list.GetItemCount(), data[0], self.idx1)
             self.list.SetItem(index, 1, data[1])
             self.list.SetItem(index, 2, data[2])
             self.list.SetItemData(index, key)

--- a/demo/ListCtrl_edit.py
+++ b/demo/ListCtrl_edit.py
@@ -52,7 +52,7 @@ class TestListCtrl(wx.ListCtrl,
 
         items = listctrldata.items()
         for key, data in items:
-            index = self.InsertItem(sys.maxsize, data[0])
+            index = self.InsertItem(self.GetItemCount(), data[0])
             self.SetItem(index, 1, data[1])
             self.SetItem(index, 2, data[2])
             self.SetItemData(index, key)
@@ -101,8 +101,8 @@ class TestListCtrlPanel(wx.Panel):
         self.list = TestListCtrl(self, tID,
                                  style=wx.LC_REPORT
                                  | wx.BORDER_NONE
-                                 | wx.LC_SORT_ASCENDING
-                                 | wx.LC_HRULES | wx.LC_VRULES
+                                 #| wx.LC_SORT_ASCENDING            # Content of list as instructions is
+                                 | wx.LC_HRULES | wx.LC_VRULES      # nonsense with auto-sort enabled
                                  )
 
         sizer.Add(self.list, 1, wx.EXPAND)


### PR DESCRIPTION
In demos using wx.ListCtrl, replaced sys.maxsize with GetItemCount()
in InsertItem() when appending, fixing problem with 64 bit Python
passing a value > 32 bits to underlying C++ widget.

Also disabled automatic initial list sort via wx.LC_SORT_ASCENDING style
where appropriate.

sys.maxsize is also used in agw ListCtrl demos but widgets there are pure Python so 
problem doesn't occur. In any case, sys.maxsize is replaced with GetItemCount()
internally there anyway.