### PR TITLE
pycolourchooser now, er, works

### DIFF
--- a/wx/lib/colourchooser/canvas.py
+++ b/wx/lib/colourchooser/canvas.py
@@ -80,13 +80,16 @@ class Canvas(wx.Window):
     """
     def __init__(self, parent, id,
                  pos=wx.DefaultPosition,
-                 size=wx.DefaultSize,
-                 style=wx.SIMPLE_BORDER):
+                 style=wx.SIMPLE_BORDER,
+                 forceClientSize=None):
         """Creates a canvas instance and initializes the off-screen
         buffer. Also sets the handler for rendering the canvas
         automatically via size and paint calls from the windowing
         system."""
-        wx.Window.__init__(self, parent, id, pos, size, style)
+        wx.Window.__init__(self, parent, id, pos, style=style)
+        if forceClientSize:
+            self.SetMaxClientSize(forceClientSize)
+            self.SetMinClientSize(forceClientSize)
 
         # Perform an intial sizing
         self.ReDraw()
@@ -96,7 +99,7 @@ class Canvas(wx.Window):
         self.Bind(wx.EVT_PAINT, self.onPaint)
 
     def MakeNewBuffer(self):
-        size = self.GetSize()
+        size = self.GetClientSize()
         self.buffer = BitmapBuffer(size[0], size[1],
                                    self.GetBackgroundColour())
 

--- a/wx/lib/colourchooser/pycolourbox.py
+++ b/wx/lib/colourchooser/pycolourbox.py
@@ -67,6 +67,7 @@ class PyColourBox(wx.Panel):
         """Sets the box's current couple to the given tuple."""
         self.colour = colour
         self.colour_box.SetBackgroundColour(wx.Colour(*self.colour))
+        self.colour_box.Refresh()
 
     def Update(self):
         wx.Panel.Update(self)

--- a/wx/lib/colourchooser/pycolourchooser.py
+++ b/wx/lib/colourchooser/pycolourchooser.py
@@ -184,6 +184,7 @@ class PyColourChooser(wx.Panel):
         self.palette = pypalette.PyPalette(self, -1)
         self.colour_slider = pycolourslider.PyColourSlider(self, -1)
         self.colour_slider.Bind(wx.EVT_LEFT_DOWN, self.onSliderDown)
+        self.colour_slider.Bind(wx.EVT_LEFT_UP, self.onSliderUp)
         self.colour_slider.Bind(wx.EVT_MOTION, self.onSliderMotion)
         self.slider = wx.Slider(
                         self, self.idSCROLL, 86, 0, self.colour_slider.HEIGHT - 1,
@@ -447,6 +448,10 @@ class PyColourChooser(wx.Panel):
     def onSliderDown(self, event):
         """Handle mouse click on the colour slider palette"""
         self.onColourSliderClick(event.GetY())
+        self.colour_slider.CaptureMouse()
+        
+    def onSliderUp(self, event):
+        self.colour_slider.ReleaseMouse()
         
     def onSliderMotion(self, event):
         """Handle mouse-down drag on the colour slider palette"""

--- a/wx/lib/colourchooser/pycolourchooser.py
+++ b/wx/lib/colourchooser/pycolourchooser.py
@@ -209,6 +209,10 @@ class PyColourChooser(wx.Panel):
             (slabel, 0, wx.ALIGN_CENTER_VERTICAL), (self.sentry, 0, wx.FIXED_MINSIZE),
             (vlabel, 0, wx.ALIGN_CENTER_VERTICAL), (self.ventry, 0, wx.FIXED_MINSIZE),
         ])
+        
+        self.hentry.Bind(wx.EVT_KILL_FOCUS, self.onHSVKillFocus)
+        self.sentry.Bind(wx.EVT_KILL_FOCUS, self.onHSVKillFocus)
+        self.ventry.Bind(wx.EVT_KILL_FOCUS, self.onHSVKillFocus)
 
         rlabel = wx.StaticText(self, -1, _("R:"))
         self.rentry = wx.TextCtrl(self, -1)
@@ -225,6 +229,10 @@ class PyColourChooser(wx.Panel):
             (glabel, 0, wx.ALIGN_CENTER_VERTICAL), (self.gentry, 0, wx.FIXED_MINSIZE),
             (blabel, 0, wx.ALIGN_CENTER_VERTICAL), (self.bentry, 0, wx.FIXED_MINSIZE),
         ])
+
+        self.rentry.Bind(wx.EVT_KILL_FOCUS, self.onRGBKillFocus)
+        self.gentry.Bind(wx.EVT_KILL_FOCUS, self.onRGBKillFocus)
+        self.bentry.Bind(wx.EVT_KILL_FOCUS, self.onRGBKillFocus)
 
         gsizer = wx.GridSizer(rows=2, cols=1, vgap=0, hgap=0)
         gsizer.SetVGap (10)
@@ -438,6 +446,57 @@ class PyColourChooser(wx.Panel):
         colour = self.getColourFromControls()
         self.solid.SetColour(colour)
         self.UpdateEntries(colour)
+        
+    def getValueAsFloat(self, textctrl):
+        """If you type garbage, you get, literally, nothing (0)"""
+        try:
+            return float(textctrl.GetValue())
+        except ValueError:
+            return 0
+        
+    def onHSVKillFocus(self, event):
+        
+        h = self.getValueAsFloat(self.hentry)    
+        s = self.getValueAsFloat(self.sentry)
+        v = self.getValueAsFloat(self.ventry)
+        
+        if h > 0.9999:
+            h = 0.9999
+        if s > 0.9999:
+            s = 0.9999
+        if v > 0.9999:
+            v = 0.9999
+        
+        if h < 0:
+            h = 0
+        if s < 0:
+            s = 0
+        if v < 0:
+            v = 0
+        
+        colour = self.hsvToColour((h, s, v))
+        self.SetValue(colour) # infinite loop?
+    
+    def onRGBKillFocus(self, event):
+        r = self.getValueAsFloat(self.rentry)
+        g = self.getValueAsFloat(self.gentry)
+        b = self.getValueAsFloat(self.bentry)
+        
+        if r > 255:
+            r = 255
+        if g > 255:
+            g = 255
+        if b > 255:
+            b = 255
+        
+        if r < 0:
+            r = 0
+        if g < 0:
+            g = 0
+        if b < 0:
+            b = 0
+        
+        self.SetValue(wx.Colour((r, g, b)))
         
     def SetValue(self, colour):
         """Updates the colour chooser to reflect the given wxColour."""

--- a/wx/lib/colourchooser/pycolourchooser.py
+++ b/wx/lib/colourchooser/pycolourchooser.py
@@ -442,7 +442,6 @@ class PyColourChooser(wx.Panel):
     def onScroll(self, event):
         """Updates the display to reflect the new "Value"."""
         value = self.slider.GetValue()
-        colour = self.colour_slider.GetValue(value)
         colour = self.getColourFromControls()
         self.solid.SetColour(colour)
         self.UpdateEntries(colour)

--- a/wx/lib/colourchooser/pycolourslider.py
+++ b/wx/lib/colourchooser/pycolourslider.py
@@ -54,7 +54,7 @@ class PyColourSlider(canvas.Canvas):
         # drawing function
         self.SetBaseColour(colour)
 
-        canvas.Canvas.__init__(self, parent, id, size=(self.WIDTH, self.HEIGHT))
+        canvas.Canvas.__init__(self, parent, id, forceClientSize=(self.WIDTH, self.HEIGHT))
 
     def SetBaseColour(self, colour):
         """Sets the base, or target colour, to use as the central colour
@@ -66,11 +66,17 @@ class PyColourSlider(canvas.Canvas):
         the slider."""
         return self.base_colour
 
-    def GetValue(self, pos):
-        """Returns the colour value for a position on the slider. The position
-        must be within the valid height of the slider, or results can be
-        unpredictable."""
-        return self.buffer.GetPixelColour(0, pos)
+    def GetVFromClick(self, pos):
+        """
+        Returns the HSV value "V" based on the location of a mouse click at y offset "pos"
+        """
+        _, height = self.GetClientSize()
+        if pos < 0:
+            return 1             # Snap to max
+        if pos >= height - 1:
+            return 0             # Snap to 0
+            
+        return 1 - (pos / self.HEIGHT)
 
     def DrawBuffer(self):
         """Actual implementation of the widget's drawing. We simply draw

--- a/wx/lib/colourchooser/pypalette.py
+++ b/wx/lib/colourchooser/pypalette.py
@@ -123,27 +123,42 @@ class PyPalette(canvas.Canvas):
         #wx.InitAllImageHandlers()
 
         self.palette = Image.GetBitmap()
+        self.point = None
         canvas.Canvas.__init__ (self, parent, id, size=(200, 192))
 
     def GetValue(self, x, y):
         """Returns a colour value at a specific x, y coordinate pair. This
         is useful for determining the colour found a specific mouse click
         in an external event handler."""
+        if x < 0:
+            x = 0
+        if y < 0:
+            y = 0
+        if x >= self.buffer.width:
+            x = self.buffer.width - 1
+        if y >= self.buffer.height:
+            y = self.buffer.height - 1
+            
         return self.buffer.GetPixelColour(x, y)
 
     def DrawBuffer(self):
         """Draws the palette XPM into the memory buffer."""
-        #self.GeneratePaletteBMP ("foo.bmp")
         self.buffer.DrawBitmap(self.palette, 0, 0, 0)
+        
+        if self.point:
+            colour = wx.Colour(0, 0, 0)
+            self.buffer.SetPen(wx.Pen(colour, 1, wx.PENSTYLE_SOLID))
+            self.buffer.SetBrush(wx.Brush(colour, wx.BRUSHSTYLE_TRANSPARENT))
+            self.buffer.DrawCircle(self.point[0], self.point[1], 3)
 
     def HighlightPoint(self, x, y):
         """Highlights an area of the palette with a little circle around
         the coordinate point"""
-        colour = wx.Colour(0, 0, 0)
-        self.buffer.SetPen(wx.Pen(colour, 1, wx.PENSTYLE_SOLID))
-        self.buffer.SetBrush(wx.Brush(colour, wx.BRUSHSTYLE_TRANSPARENT))
-        self.buffer.DrawCircle(x, y, 3)
-        self.Refresh()
+        self.point = (x, y)
+        self.ReDraw()
+        
+    def ReseetPoint(self):
+        self.point = None
 
     def GeneratePaletteBMP(self, file_name, granularity=1):
         """The actual palette drawing algorithm.

--- a/wx/lib/colourchooser/pypalette.py
+++ b/wx/lib/colourchooser/pypalette.py
@@ -157,7 +157,7 @@ class PyPalette(canvas.Canvas):
         self.point = (x, y)
         self.ReDraw()
         
-    def ReseetPoint(self):
+    def ClearPoint(self):
         self.point = None
 
     def GeneratePaletteBMP(self, file_name, granularity=1):

--- a/wx/lib/colourchooser/pypalette.py
+++ b/wx/lib/colourchooser/pypalette.py
@@ -37,6 +37,9 @@ import  colorsys
 
 from wx.lib.embeddedimage import PyEmbeddedImage
 
+# Size of Image
+IMAGE_SIZE = (200,192)
+
 Image = PyEmbeddedImage(
     "iVBORw0KGgoAAAANSUhEUgAAAMgAAADACAYAAABBCyzzAAAABHNCSVQICAgIfAhkiAAACwNJ"
     "REFUeJztnc16o0YQRZHt8SJZJO//lMkiWWQsKwsLK7S49dNdjTyTczYYhBBd7vqoom7B6bIs"
@@ -112,7 +115,7 @@ class PyPalette(canvas.Canvas):
 
     HORIZONTAL_STEP = 2
     VERTICAL_STEP   = 4
-
+    
     def __init__(self, parent, id):
         """Creates a palette object."""
         # Load the pre-generated palette XPM
@@ -124,21 +127,35 @@ class PyPalette(canvas.Canvas):
 
         self.palette = Image.GetBitmap()
         self.point = None
-        canvas.Canvas.__init__ (self, parent, id, size=(200, 192))
+        
+        canvas.Canvas.__init__ (self, parent, id, forceClientSize=IMAGE_SIZE)
+        
+    def DoGetBestClientSize(self):
+        """Overridden to create a client window that exactly fits our bitmap"""
+        return self.palette.GetSize()
+        
+    def xInBounds(self, x):
+        """Limit x to [0,width)"""
+        if x < 0:
+            x = 0
+        if x >= self.buffer.width:
+            x = self.buffer.width - 1
+        return x
+
+    def yInBounds(self, y):
+        """Limit y to [0,height)"""
+        if y < 0:
+            y = 0
+        if y >= self.buffer.height:
+            y = self.buffer.height - 1
+        return y
 
     def GetValue(self, x, y):
         """Returns a colour value at a specific x, y coordinate pair. This
         is useful for determining the colour found a specific mouse click
         in an external event handler."""
-        if x < 0:
-            x = 0
-        if y < 0:
-            y = 0
-        if x >= self.buffer.width:
-            x = self.buffer.width - 1
-        if y >= self.buffer.height:
-            y = self.buffer.height - 1
-            
+        x = self.xInBounds(x)
+        y = self.yInBounds(y)
         return self.buffer.GetPixelColour(x, y)
 
     def DrawBuffer(self):
@@ -154,7 +171,7 @@ class PyPalette(canvas.Canvas):
     def HighlightPoint(self, x, y):
         """Highlights an area of the palette with a little circle around
         the coordinate point"""
-        self.point = (x, y)
+        self.point = (self.xInBounds(x), self.yInBounds(y))
         self.ReDraw()
         
     def ClearPoint(self):


### PR DESCRIPTION
Submitted for your approval, I have apparently finished implementing pycolourchooser. I assume that some of its code was removed over time to get it to compile, as it did not appear to be completely implemented.

It still does not want to resize, but otherwise works. 

Tested on osx. I'll definitely have to test on Windows this week, but in any case...

```
import wx.lib.colourchooser.pycolourchooser as PCC
PCC.main()
```

The other native-wrapping colourselect controls were giving me fits, so here you go. Share and enjoy.