### PR TITLE
Created options for build.py for ensuring presence of required packages

### DIFF
--- a/build.py
+++ b/build.py
@@ -134,6 +134,9 @@ Usage: ./build.py [command(s)] [options]
       test          Run the unit test suite
       test_*        Run just the one named test module
 
+      checkdeps     Linux only. Print missing necessary packages
+      instdeps      Linux only. Attempt to install missing necessary packages
+
       clean_wx      Clean the wx parts of the build
       clean_py      Clean the wxPython parts of the build
       clean_sphinx  Clean the sphinx files
@@ -1792,7 +1795,21 @@ def cmd_setrev(options, args):
     cfg.resetVersion()
     msg('cfg.VERSION: %s' % cfg.VERSION)
 
+def cmd_checkdeps(options, args):
+    from buildtools import lnxdeps # not confusing at all... should fix that
 
+    checker = lnxdeps.Checker(options.gtk3)
+    exitcode = checker.CheckPkgs()
+    if exitcode:
+        sys.exit(exitcode)
+
+def cmd_instdeps(options, args):
+    from buildtools import lnxdeps
+
+    checker = lnxdeps.Checker(options.gtk3)
+    exitcode = checker.InstallPkgs()
+    if exitcode:
+        sys.exit(exitcode)
 
 #---------------------------------------------------------------------------
 

--- a/buildtools/lnxdep_manifest.yaml
+++ b/buildtools/lnxdep_manifest.yaml
@@ -1,0 +1,55 @@
+arch:
+  default:
+    freeglut: freeglut
+    glu: glu
+    gstreamer: gstreamer0.10-base-plugins
+    gtk2: gtk2
+    gtk3: gtk3
+    notify:
+    webkitgtk2: webkitgtk2
+    webkitgtk3: webkitgtk3
+    other:
+    recommended: libpng libtiff libjpeg-turbo
+
+cent:
+  default:
+    freeglut: freeglut freeglut-devel
+    glu: 
+    gstreamer: gstreamer gstreamer-devel gstreamer-plugins-base-devel
+    gtk2: gtk2 gtk2-devel
+    gtk3: gtk3 gtk3-devel
+    notify: libnotify-devel
+    webkitgtk2: webkitgtk webkitgtk-devel
+    webkitgtk3: webkitgtk3 webkitgtk3-devel
+    other: 
+    recommended: libpng-devel libjpeg-turbo-devel libtiff-devel SDL SDL-devel
+
+debian:
+  default:
+    freeglut: freeglut3 freeglut3-dev
+    glu: 
+    gstreamer: libgstreamer-plugins-base0.10-dev
+    gtk2: libgtk2.0-dev
+    gtk3: libgtk-3-dev
+    notify: libnotify-dev
+    webkitgtk2: libwebkitgtk-dev
+    webkitgtk3: libwebkitgtk-3.0-dev
+    other: libsm-dev
+    recommended: libpng-dev libtiff-dev libsdl1.2-dev
+
+ubuntu:
+  default:
+    freeglut: freeglut3 freeglut3-dev
+    glu: 
+    gstreamer: libgstreamer-plugins-base0.10-dev
+    gtk2: libgtk2.0-dev
+    gtk3: libgtk-3-dev
+    notify: libnotify-dev
+    webkitgtk2: libwebkitgtk-dev
+    webkitgtk3: libwebkitgtk-3.0-dev
+    other: libsm-dev
+    recommended: libpng-dev libtiff-dev libsdl1.2-dev
+  "16.10":
+    gstreamer: libgstreamer-plugins-base1.0-dev # No 0.10 available on 16.10, however
+                                                # wx's configure will still fail
+                                                # with this package installed..

--- a/buildtools/lnxdep_manifest.yaml
+++ b/buildtools/lnxdep_manifest.yaml
@@ -2,7 +2,7 @@ arch:
   default:
     freeglut: freeglut
     glu: glu
-    gstreamer: gstreamer0.10-base-plugins
+    gstreamer: gstreamer
     gtk2: gtk2
     gtk3: gtk3
     notify:

--- a/buildtools/lnxdeps.py
+++ b/buildtools/lnxdeps.py
@@ -1,0 +1,229 @@
+import platform
+import shlex
+import six
+import subprocess
+import sys
+import yaml
+
+# create a list of packages by generic name, assume that the user already has relevant python packages
+GENERIC = ["gtk2", "gtk3", "gstreamer", "webkitgtk2", "webkitgtk3", "freeglut", "glu"] 
+
+# package manager action lookup dictionary
+PMD = \
+{
+    "arch"  : {"install" : "pacman -S", "query" : "pacman -Q"},
+    "cent"  : {"install" : "yum install", "query" : "rpm -qi"},
+    "debian": {"install" : "apt-get install", "query" : "dpkg -s"},
+    "ubuntu": {"install" : "apt-get install", "query" : "dpkg -s"}
+}
+
+# Indirect OS, to avoid having a large volume of identical entries in the package
+# manifest, this dictionary is used to refine necessary configurations
+IDOS = \
+{
+    '' : '',     # python was not able to identify the dist name.
+    "arch"  : "arch",
+    "CentOS": "cent",
+    "CentOS Linux" : "cent",
+    
+    # until necessity proves otherwise, convert rhel onto cent
+    "Red Hat Enterprise Linux Workstation" : "cent",
+    "Red Hat Enterprise Linux" : "cent",
+    "debian" : "debian",
+    "Ubuntu": "ubuntu",
+    "elementary" : "debian",
+}
+
+class Checker:
+    def __init__(self, gtk3):
+        # gtk3 boolean value indicating if gtk3 is desired.
+
+        # currently only supports linux:
+        if platform.system() != "Linux":
+            six.print_("Dependency checker invoked on non-linux OS!", file=sys.stderr)
+            sys.exit()  # not worth erroring and halting any other modules.
+
+        # load manifest
+        with open("buildtools/lnxdep_manifest.yaml") as fd:
+            self.__manifest = yaml.load(fd, Loader=yaml.Loader)
+
+        # grab platform info:
+        platinfo = platform.linux_distribution()
+        
+        # assign distribution:
+        try:
+            self.__dist = IDOS[platinfo[0]]
+            self.__manifest[self.__dist]    # ensures that __dist is configured properly
+        except KeyError:
+            six.print_("Unknown distribution: %s" % platinfo[0], file=sys.stderr)
+            sys.exit(1)
+
+        if not self.__dist:
+            six.print_("Unable to identify this distribution.", file = sys.stderr)
+            sys.exit(2)
+
+        # load version, on the by and large this will just become  "default"
+        self.__ver = platinfo[1]
+        try:
+            self.__manifest[self.__dist][self.__ver]
+        except KeyError:
+            self.__ver = "default"
+
+        # can now locate necessary manifest data
+        self.__conf = self.__manifest[self.__dist][self.__ver]
+
+        # load require package lists:
+        self.__loadpkglists(gtk3)
+
+    def CheckPkgs(self):
+        """
+        loads package lists and checks for presence, printing results back to user.
+        """
+        six.print_("Checking for missing packages that are required to build Phoenix.")
+        six.print_("This can take some time on some distributions")
+
+        missing = self.__findmissing()
+        # report on missing packages
+        if len(missing["required"]):
+            six.print_("Missing required dependencies:")
+            for pkg in missing["required"]:
+                six.print_("\t%s" % pkg)
+        else:
+            six.print_("No missing required dependencies.")
+
+        if len(missing["recommended"]):
+            six.print_("Missing recommended packages:")
+            for pkg in missing["recommended"]:
+                six.print_("\t%s" % pkg)
+        else:
+            six.print_("No missing recommended packages")
+
+        return (len(missing["required"]))
+
+    def InstallPkgs(self):
+        """
+        attempts to use the package manager to install missing packages
+        this is NOT recommended, as it will require root permission and
+        is innately very risky
+        """
+        missing = self.__findmissing()
+        if not (len(missing["required"]) or len(missing["recommended"])):
+            six.print_("\nNo missing packages to install.\n")
+            return 0    # nothing to do
+
+        # prompt user for a final "are you really really sure?"?
+        if  self.__whoami() == "root":
+            if not self.__getyn("You are about to use your package manager as root.\n Are you sure this is okay? "):
+                six.print_("Okay, exiting now.")
+                return 1
+
+
+        if len(missing["required"]):
+            pkgs = " ".join(missing["required"])
+            success = self.__runpkgcmd("install", pkgs, True)
+
+            if not success:
+                return 1
+
+        if len(missing["recommended"]):
+            # do these one by one, as they may not be desired.
+            for pkg in missing["recommended"]:
+                # check to see if it the package has already been installed
+                # by another package
+                if not self.__runpkgcmd("query", pkg):
+                    six.print_("\n\nInstalling package: %s" % pkg)
+                    self.__runpkgcmd("install", pkg, True)
+        return 0
+
+    def __findmissing(self):
+        """
+        returns a dict with fields "required" and "recommended" that are lists of missing packages
+        """
+        missing = {"required" : [], "recommended" : []}
+        
+        for item in self.__required:
+            if not self.__runpkgcmd("query", item):
+                missing["required"].append(item)
+
+        for item in self.__recommended:
+            if not self.__runpkgcmd("query", item):
+                missing["recommended"].append(item)
+
+        return missing
+
+    def __runpkgcmd(self, command, pkg, showoutput = False):
+        """
+        runs the provided command type on provided package.
+        looks up the command from PMD itself.
+        """
+        cmd = shlex.split("%s %s" % (PMD[self.__dist][command], pkg))
+
+        out = subprocess.PIPE
+        err = subprocess.STDOUT
+        if showoutput:
+            out = sys.stdout
+            err = sys.stderr
+
+        p = subprocess.Popen(cmd, stdout = out, stderr = err)
+        while p.poll() is None:
+            pass
+        return not p.poll()
+
+    def __whoami(self):
+        """
+        returns the user's name using whoami
+        """
+        output = subprocess.check_output(["whoami"])
+        return output.decode("utf-8").split()[0]
+
+    def __getyn(self, prompt):
+        """
+        presents prompt to the user and will loop [y/n] until a valid response is
+        provided
+        returns True for yes, False for no
+        """
+        response = six.moves.input(prompt + "[y/n] ")
+        while response.lower() not in ["yes", "y", "no", "n"]:
+            response = six.moves.input("[y/n] ")
+
+        return response[0] == 'y'
+
+    def __loadpkglists(self, gtk3):
+        genericpkgs = GENERIC[:]
+        if gtk3:
+            genericpkgs.remove("gtk2")
+            genericpkgs.remove("webkitgtk2")
+        else:
+            genericpkgs.remove("gtk3")
+            genericpkgs.remove("webkitgtk3")
+
+        genericpkgs.append("other")
+        self.__required = []
+        for item in genericpkgs:
+            self.__required += self.__loadpkg(item)
+
+        self.__recommended = self.__loadpkg("recommended")
+
+    def __loadpkg(self, pkgname):
+        """
+        retrieves a field from the manifest and returns a lists of pkgs from that field
+        """
+        if self.__ver != "default":
+            # check to see if field is available:
+            try:
+                if self.__manifest[self.__dist][self.__ver][pkgname]:
+                    return self.__manifest[self.__dist][self.__ver][pkgname].split()
+                else: return []
+            except KeyError:
+                pass    # fall down to the default lookup block.
+
+        # using default lists.
+        # if a key error occurs here it is because the manifest isn't complete
+        if self.__manifest[self.__dist]["default"][pkgname]:
+            return self.__manifest[self.__dist]["default"][pkgname].split()
+        else: return []
+
+
+if __name__ == "__main__":
+    chkr = Checker()
+    chkr.CheckPkgs()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ wheel
 twine
 sphinx
 requests
+pyaml
 pytest
 pytest-xdist
 pytest-timeout


### PR DESCRIPTION
# Overview
## Description

Adds the modes `checkdeps` and `instdeps` to build.py.
`checkdeps` can be used to list any missing packages, exiting the build should necessary packages be missing.
`instdeps` will attempt to install missing packages using the distributions native package manager. 

Internally packages are separated into two main groups, 'required' and `recommended`.
`recommended` packages are only libraries which wx can substitute for itself, such as libpng, libtiff, etc.
`required` packages are packages that will break Phoenix's build if not present such as glu, gtk2/3, webkitgtk.  If a required package is missing when checkdeps is used then the build will exit, if instdeps is used then it will prevent moving forward until it is installed.

## Usage
The common case I tested was for a new fresh-repository build:
`python build.py checkdeps dox etg --nodoc sip build`
If any required packages are missing the build will exit as expected.

`python build.py instdeps <other args>`
Will attempt to invoke the package manager as non-root and exit with the package manager's "you're not root" message

`sudo python build.py instdeps <other args>`
will ensure the user is aware they are running the script as root, and then proceed to use the native package manager to install missing packages.

## Side comments
I didn't test moving the new switches around within the command, I always used them first. I think it should be fine so long as they preceed `build`.

should the new modes need to exit they'll directly invoke sys.exit, I didn't read the rest of build.py enough to know if this direct exit will mess with any running processes or if it will affect user experience

I didn't include python-dev packages as requirements, which usually isn't a problem. I think it only affected me on a cent6 test, though I don't remember for sure. I think its fair to assume that the necessary python development files are already present for the common user. 

apt-get will internally adjust the name of some libraries, such as libpng and libtiff to be versioned. This will cause these libraries to show up as missing regardless of their versioned package being present.

I didn't spend too much time investigating, but I think yum doesn't exit with a non-zero value should an install fail. 
More on CentOS: I didn't include the installation of the user respository as a requirement for cent, this will cause webkitgtk and webkitgtk-devel to be missing but uninstallable. Making a comment about it somewhere cent users will see might prove beneficial

While testing this feature I realized that Phoenix does not work for Ubuntu16.10, as gstreamer 0.10 is not available causing wx's configuration to fail. The package may be available on a user repository somewhere, though I'm not sure. 
Edit: looks like issue #206 covers this

# The Manifest
A yaml manifest file was created for translating necessary packages to distribution specific names. Each `required` package common to every distribution has its own entry in the manifest per distribution.  An additional field "other" is provided for listing packages specific to a specific distribution.
The manifest is organized by first distribution, then version, then package fields, which will be read as strings and split by the python code. this leaves the manifest very human readable, so hopefully its easy to pick up and maintain.