### PR TITLE
enable pickling of PyEvent objects

### DIFF
--- a/etg/pyevent.py
+++ b/etg/pyevent.py
@@ -82,13 +82,13 @@ def run():
             """)
 
     cls.addPyMethod("__setstate__", "(self, state)",
-        doc = """Sets internal state of PyEvent object to allow pickling""",
+        doc = """Sets internal state of PyEvent object. This allows PyEvent to be reconstructed as part of the pickling process""",
         body = """\
             self.__dict__.update(state)
             """)
 
     cls.addPyMethod("__getstate__", "(self)",
-        doc = "Returns internal state. Precense enables pickling",
+        doc = "Returns this object's internal state. This is used as part of the pickling process",
         body = """\
             return self.__dict__
             """)
@@ -151,13 +151,13 @@ def run():
             """)
 
     cls.addPyMethod("__setstate__", "(self, state)",
-        doc = """Sets internal state of PyEvent object to allow pickling""",
+        doc = """Sets internal state of PyEvent object. This allows PyEvent to be reconstructed as part of the pickling process""",
         body = """\
             self.__dict__.update(state)
             """)
 
     cls.addPyMethod("__getstate__", "(self)",
-        doc = "Returns internal state. Precense enables pickling",
+        doc = "Returns this object's internal state. This is used as part of the pickling process",
         body = """\
             return self.__dict__
             """)

--- a/etg/pyevent.py
+++ b/etg/pyevent.py
@@ -81,6 +81,18 @@ def run():
             return clone
             """)
 
+    cls.addPyMethod("__setstate__", "(self, state)",
+        doc = """Sets internal state of PyEvent object to allow pickling""",
+        body = """\
+            self.__dict__.update(state)
+            """)
+
+    cls.addPyMethod("__getstate__", "(self)",
+        doc = "Returns internal state. Precense enables pickling",
+        body = """\
+            return self.__dict__
+            """)
+
     module.addItem(cls)
     cls.addCppCode("IMPLEMENT_DYNAMIC_CLASS(wxPyEvent, wxEvent);")
     cls.addHeaderCode('#include "pyevent.h"')
@@ -138,6 +150,18 @@ def run():
             return clone
             """)
 
+    cls.addPyMethod("__setstate__", "(self, state)",
+        doc = """Sets internal state of PyEvent object to allow pickling""",
+        body = """\
+            self.__dict__.update(state)
+            """)
+
+    cls.addPyMethod("__getstate__", "(self)",
+        doc = "Returns internal state. Precense enables pickling",
+        body = """\
+            return self.__dict__
+            """)
+
     module.addItem(cls)
     cls.addCppCode("IMPLEMENT_DYNAMIC_CLASS(wxPyCommandEvent, wxCommandEvent);")
     cls.addHeaderCode('#include "pyevent.h"')
@@ -162,4 +186,3 @@ def run():
 #---------------------------------------------------------------------------
 if __name__ == '__main__':
     run()
-


### PR DESCRIPTION
Adds __setstate__ and __getstate__ methods to wx.PyCommandEvent and wx.PyEvent objects, enabling them to be pickled.
This allows copying of object instances, fixing the issue detailed in #207 
Also, this preserves that python magic ;-)