### PR TITLE
Fix ImageHandler

### DIFF
--- a/etg/image.py
+++ b/etg/image.py
@@ -564,7 +564,6 @@ def run():
 
     #-------------------------------------------------------
     c = module.find('wxImageHandler')
-    c.abstract = True
     c.addPrivateCopyCtor()
     c.find('GetLibraryVersionInfo').ignore()
 

--- a/unittests/test_image.py
+++ b/unittests/test_image.py
@@ -237,6 +237,11 @@ class image_Tests(wtc.WidgetTestCase):
         img = wx.Image(100,100).Rescale(75,75).Resize((100,100), (0,0), 40,60,80)
         self.assertTrue(img.IsOk())
 
+    def test_imageHandlerDerivation(self):
+        class TestImageHandler(wx.ImageHandler):
+            def __init__(self):
+                wx.ImageHandler.__init__(self)
+        imghndlr = TestImageHandler()
 
     def test_imageOtherStuff(self):
         img = wx.Image(pngFile)


### PR DESCRIPTION
Fixes ImageHandler by removing abstract tweak from etg/image.py.
Adds unittest for verifying that ImageHandler can be derived successfully. 

Fixes #217 