### PR TITLE
Add numpy to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests
 pytest
 pytest-xdist
 pytest-timeout
+numpy


### PR DESCRIPTION
numpy is required for a few unit tests.  Since requirements already includes pytest (and friends) for the sake of testing, it makes sense to ensure all required modules are present.