### PR TITLE
Reworked .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,25 @@
 
 language: python
     
-python: 
-    - "2.7"
-    #- "3.4"  # Just do one Python for now.
-    
-sudo: false
-    
+matrix:
+  include:
+    - os: linux
+      dist: trusty
+      sudo: required
+      python: 2.7
+    - os: linux
+      dist: precise
+      sudo: required
+      python: 2.7
+    - os: linux
+      dist: trusty
+      sudo: required
+      python: 3.4
+    - os: linux
+      dist: precise
+      sudo: required
+      python: 3.4
+  # redundant specification of `sudo` and `python` because of travis-ci.org's way of parsing `.travis.yml`
     
 # Available build steps:
 # 1. before_install
@@ -52,6 +65,7 @@ script:
     - python build.py etg --nodoc
     - python build.py sip
     - python build.py build_py --jobs=4
+    - sudo python build.py install
     # TODO: Add running of the tests
     
     


### PR DESCRIPTION
Reworked .travis.yml:

  * added dist trusty
  * added python 3.4 to both dists (there's been no reason in comments why it's been disabled)
  * added `sudo python build.py install` in order to test installation