### PR TITLE
Use AppVeyor in addition to TravisCI to get merge validation for Windows

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,29 @@
+# Samuel Dunn
+# Simple Appveyor configuration file for Phoenix
+version: "{build}"
+configuration: Release
+platform:
+- x64
+environment:
+  matrix:
+    - py: C:\Python36-x64\python
+    - py: C:\Python36\python
+    - py: C:\Python27-x64\python
+    - py: C:\Python27\python
+
+build_script:
+- cmd: >-
+    git submodule init
+
+    git submodule update
+    
+    %py% -m pip install -U pip
+    
+    %py% -m pip install -U -r requirements.txt
+    
+    %py% build.py dox etg --nodoc sip build
+    
+    %py% build.py install
+
+#test_script:
+#- cmd: python build.py test


### PR DESCRIPTION
Allows appveyor to run builds on project. This performs the same role as TravisCI, except it covers windows rather than linux.
Currently configured to do four builds using 64 and 32 bit versions of python2.7 and python 3.6
No testing is currently being run, partly due to lack of boxed tests and partly to save build time.

Necessary appveyor config:
Need to set appveyor to use `.appveyor.yml` rather than `appveyor.yml`. This can be done in the general settings tab.
I suggest activating `Rolling Builds` in the same tab, to prevent a huge backlog of builds.