### PR TITLE
Don't auto set mustHaveApp for all staticmethods of classes with the flag

### DIFF
--- a/etg/artprov.py
+++ b/etg/artprov.py
@@ -46,6 +46,8 @@ def run():
     c.find('Insert.provider').transfer = True
     c.find('Remove.provider').transferBack = True
 
+    c.find('GetBitmap').mustHaveApp()
+    c.find('GetIcon').mustHaveApp()
 
     # Change the types of the art constants from wxString to const char*
     # since that is what they really are.

--- a/etg/button.py
+++ b/etg/button.py
@@ -33,6 +33,8 @@ def run():
 
     c = module.find('wxButton')
     tools.fixWindowClass(c)
+    c.find('GetDefaultSize').mustHaveApp()
+
 
     module.addGlobalStr('wxButtonNameStr', c)
 

--- a/etg/clipbrd.py
+++ b/etg/clipbrd.py
@@ -34,14 +34,15 @@ def run():
     c = module.find('wxClipboard')
     assert isinstance(c, etgtools.ClassDef)
     c.mustHaveApp()
+    c.find('Get').mustHaveApp()
 
     c.find('AddData.data').transfer = True
     c.find('SetData.data').transfer = True
 
 
-    # TODO: This init wrapper class may be useful elsewhere...
+    # TODO: This delayed initialization wrapper class may also be useful elsewhere...
     module.addPyCode("""\
-        # Since wxTheClipoard is not really a global varaiable (it is a macro
+        # Since wxTheClipboard is not really a global variable (it is a macro
         # that calls the Get static method) we can't declare it as a global
         # variable for the wrapper generator, otherwise it will try to run the
         # function at module import and the wxApp object won't exist yet.  So

--- a/etg/config.py
+++ b/etg/config.py
@@ -38,6 +38,8 @@ def run():
     c = module.find('wxConfigBase')
     assert isinstance(c, etgtools.ClassDef)
     c.mustHaveApp()
+    c.find('Get').mustHaveApp()
+    c.find('Create').mustHaveApp()
 
     c.abstract = True
     ctor = c.find('wxConfigBase')

--- a/etg/display.py
+++ b/etg/display.py
@@ -37,6 +37,9 @@ def run():
     c.addPrivateAssignOp()
     c.addPrivateCopyCtor()
     c.mustHaveApp()
+    c.find('GetCount').mustHaveApp()
+    c.find('GetFromPoint').mustHaveApp()
+    c.find('GetFromWindow').mustHaveApp()
 
 
     c.addProperty('ClientArea GetClientArea')

--- a/etg/font.py
+++ b/etg/font.py
@@ -45,6 +45,9 @@ def run():
     for func in c.find('New').all():
         func.mustHaveApp()
 
+    c.find('GetDefaultEncoding').mustHaveApp()
+    c.find('SetDefaultEncoding').mustHaveApp()
+
 
     # FFont factory function for backwards compatibility
     module.addCppFunction('wxFont*', 'FFont',

--- a/etg/image.py
+++ b/etg/image.py
@@ -43,6 +43,8 @@ def run():
 
     c.find('GetHandlers').ignore()  # TODO
 
+    c.find('wxImage').findOverload('wxBitmap').mustHaveApp()
+
 
     # Ignore the ctors taking raw data buffers, so we can add in our own
     # versions that are a little smarter (accept any buffer object, check

--- a/etg/renderer.py
+++ b/etg/renderer.py
@@ -37,8 +37,12 @@ def run():
 
     c = module.find('wxRendererNative')
     assert isinstance(c, etgtools.ClassDef)
-    c.mustHaveApp()
     c.addPrivateCopyCtor()
+    c.mustHaveApp()
+    c.find('Get').mustHaveApp()
+    c.find('GetGeneric').mustHaveApp()
+    c.find('GetDefault').mustHaveApp()
+    c.find('Set').mustHaveApp()
 
 
     #virtual void DrawTitleBarBitmap(wxWindow *win,

--- a/etg/settings.py
+++ b/etg/settings.py
@@ -34,6 +34,12 @@ def run():
     c = module.find('wxSystemSettings')
     assert isinstance(c, etgtools.ClassDef)
     c.mustHaveApp()
+    c.find('GetColour').mustHaveApp()
+    c.find('GetFont').mustHaveApp()
+    c.find('GetMetric').mustHaveApp()
+    c.find('HasFeature').mustHaveApp()
+    c.find('GetScreenType').mustHaveApp()
+
 
     #-----------------------------------------------------------------
     tools.doCommonTweaks(module)

--- a/etg/sound.py
+++ b/etg/sound.py
@@ -37,6 +37,8 @@ def run():
     c = module.find('wxSound')
     assert isinstance(c, etgtools.ClassDef)
     c.mustHaveApp()
+    c.find('Play').mustHaveApp()
+    c.find('Stop').mustHaveApp()
     c.addPrivateCopyCtor()
     c.addPublic()
 

--- a/etg/window.py
+++ b/etg/window.py
@@ -39,6 +39,8 @@ def run():
     assert isinstance(c, etgtools.ClassDef)
     module.addGlobalStr('wxPanelNameStr', c)
 
+    c.find('FindFocus').mustHaveApp()
+    c.find('GetCapture').mustHaveApp()
 
     # First we need to let the wrapper generator know about wxWindowBase since
     # AddChild and RemoveChild need to use that type in order to be virtualized.
@@ -390,7 +392,9 @@ def run():
             boxes; if non-None, the search will be limited to the given window
             hierarchy. The search is recursive in both cases.
             """,
-        body="return wxWindow::FindWindowById(id, parent);")
+        body="return wxWindow::FindWindowById(id, parent);",
+        mustHaveAppFlag=True)
+
 
     module.addCppFunction('wxWindow*', 'FindWindowByName', '(const wxString& name, const wxWindow* parent=NULL)',
         doc="""\
@@ -403,7 +407,9 @@ def run():
             cases.
 
             If no window with the name is found, wx.FindWindowByLabel is called.""",
-        body="return wxWindow::FindWindowByName(*name, parent);")
+        body="return wxWindow::FindWindowByName(*name, parent);",
+        mustHaveAppFlag=True)
+
 
     module.addCppFunction('wxWindow*', 'FindWindowByLabel', '(const wxString& label, const wxWindow* parent=NULL)',
         doc="""\
@@ -414,7 +420,8 @@ def run():
             search will start from all top-level frames and dialog boxes; if
             non-None, the search will be limited to the given window
             hierarchy. The search is recursive in both cases.""",
-        body="return wxWindow::FindWindowByLabel(*label, parent);")
+        body="return wxWindow::FindWindowByLabel(*label, parent);",
+        mustHaveAppFlag=True)
 
     #-----------------------------------------------------------------
     tools.doCommonTweaks(module)

--- a/etgtools/sip_generator.py
+++ b/etgtools/sip_generator.py
@@ -428,11 +428,10 @@ from .%s import *
         if klass.ignored:
             return
 
-        # Propagate mustHaveApp setting to the ctors and static methods
+        # Propagate mustHaveApp setting to the ctors
         if klass.mustHaveAppFlag:
             for item in klass.allItems():
-                if isinstance(item, extractors.MethodDef) and \
-                        (item.isCtor or item.isStatic):
+                if isinstance(item, extractors.MethodDef) and item.isCtor:
                     item.mustHaveApp(True)
 
         # write the class header


### PR DESCRIPTION
Revert auto-propagating the mustHaveAppFlag from classes to their static methods, if any, and instead explicitly set the flag on only those static methods that need it.

Fixes #249