### PR TITLE
Set piBases for RichTextFormattingDialog

### DIFF
--- a/etg/richtextformatdlg.py
+++ b/etg/richtextformatdlg.py
@@ -36,6 +36,7 @@ def run():
     assert isinstance(c, etgtools.ClassDef)
     tools.fixTopLevelWindowClass(c)
     tools.ignoreConstOverloads(c)
+    c.piBases = ['wx.adv.PropertySheetDialog']
 
 
     #-----------------------------------------------------------------


### PR DESCRIPTION
Fixes:
======================================================================
FAIL: test_richtext_pi (__main__.PIImportTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "unittests/test_pi_import.py", line 60, in test_richtext_pi
    self.runPI('richtext.pi')
  File "unittests/test_pi_import.py", line 32, in runPI
    self.assertEqual(sp.returncode, 0, stdout)
AssertionError: 1 != 0 : b'Traceback (most recent call last):\n  File "richtext.pi", line 11292, in <module>\n    class RichTextFormattingDialog(PropertySheetDialog):\nNameError: name \'PropertySheetDialog\' is not defined\n'

----------------------------------------------------------------------