### PR TITLE
etg: add eq+hash to value types

### DIFF
--- a/etg/colour.py
+++ b/etg/colour.py
@@ -165,6 +165,8 @@ def run():
 
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.Colour"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')

--- a/etg/gbsizer.py
+++ b/etg/gbsizer.py
@@ -52,6 +52,8 @@ def run():
         briefDoc="Set both the row and column properties.")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.GBPosition"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')
@@ -93,6 +95,8 @@ def run():
         briefDoc="Set both the rowspan and colspan properties.")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.GBSpan"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')

--- a/etg/gdicmn.py
+++ b/etg/gdicmn.py
@@ -108,6 +108,8 @@ def run():
         briefDoc="Return the x and y properties as a tuple.")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.Point"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')
@@ -179,6 +181,8 @@ def run():
         briefDoc="Return the width and height properties as a tuple.")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.Size"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')
@@ -257,6 +261,8 @@ def run():
         briefDoc="Return the rectangle's properties as a tuple.")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.Rect"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')
@@ -309,6 +315,8 @@ def run():
         briefDoc="Return the point's properties as a tuple.")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.RealPoint"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')

--- a/etg/geometry.py
+++ b/etg/geometry.py
@@ -66,6 +66,8 @@ def run():
         Return the x and y properties as a tuple.""")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.Point2D"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')
@@ -111,6 +113,8 @@ def run():
         Return the rectangle's properties as a tuple.""")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.Rect2D"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')

--- a/etg/grid.py
+++ b/etg/grid.py
@@ -104,6 +104,8 @@ def run():
         briefDoc="Return the row and col properties as a tuple.")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "GridCellCoords"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')

--- a/etg/position.py
+++ b/etg/position.py
@@ -43,6 +43,8 @@ def run():
         briefDoc="Return the row and col properties as a tuple.")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "wx.Position"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')

--- a/etg/richtextbuffer.py
+++ b/etg/richtextbuffer.py
@@ -172,6 +172,8 @@ def run():
         briefDoc="Return the start and end properties as a tuple.")
 
     # Add sequence protocol methods and other goodies
+    c.addPyMethod('__eq__', '(self, other)',       'return isinstance(other, type(self)) and self.Get() == other.Get()')
+    c.addPyMethod('__hash__', '(self)',            'return hash(self.Get())')
     c.addPyMethod('__str__', '(self)',             'return str(self.Get())')
     c.addPyMethod('__repr__', '(self)',            'return "RichTextRange"+str(self.Get())')
     c.addPyMethod('__len__', '(self)',             'return len(self.Get())')

--- a/unittests/test_colour.py
+++ b/unittests/test_colour.py
@@ -30,6 +30,24 @@ class Colour(wtc.WidgetTestCase):
         self.assertTrue(c1.Get() == c2.Get())
 
 
+    def test_eq_hash(self):
+        tupl1 = (10, 20, 30, 40)
+        clr1 = wx.Colour(*tupl1)
+        clr12 = wx.Colour(*tupl1)
+        clr2 = wx.Colour(10, 20, 30, 1)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(clr1 == tupl1)
+        self.assertTrue(hash(clr1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(clr1 == clr12)
+        self.assertFalse(id(clr1) == id(clr12))
+        self.assertTrue(hash(clr1) == hash(clr12))
+
+        self.assertFalse(clr1 == clr2)
+        self.assertFalse(hash(clr1) == hash(clr2))
+
+
     def test_GetPixel(self):
         c1 = wx.Colour(1,2,3,4)
         p = c1.GetPixel()

--- a/unittests/test_gbsizer.py
+++ b/unittests/test_gbsizer.py
@@ -12,6 +12,23 @@ class gbsizer_Tests(wtc.WidgetTestCase):
         p3 = wx.GBPosition(p2)
         p4 = wx.GBPosition( (2,1) )
 
+    def test_gbposition_eq_hash(self):
+        tupl1 = (0, 10)
+        p1 = wx.GBPosition(*tupl1)
+        p12 = wx.GBPosition(*tupl1)
+        p2 = wx.GBPosition(2, 10)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(p1 == tupl1)
+        self.assertTrue(hash(p1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(p1 == p12)
+        self.assertFalse(id(p1) == id(p12))
+        self.assertTrue(hash(p1) == hash(p12))
+
+        self.assertFalse(p1 == p2)
+        self.assertFalse(hash(p1) == hash(p2))
+
     def test_gbsizer_pos2(self):
         p1 = wx.GBPosition(3,4)
         p1.row
@@ -47,6 +64,23 @@ class gbsizer_Tests(wtc.WidgetTestCase):
         s2 = wx.GBSpan(1,2)
         s3 = wx.GBSpan(s2)
         s4 = wx.GBSpan( (2,1) )
+
+    def test_gbspan_eq_hash(self):
+        tupl1 = (0, 10)
+        s1 = wx.GBSpan(*tupl1)
+        s12 = wx.GBSpan(*tupl1)
+        s2 = wx.GBSpan(2, 10)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(s1 == tupl1)
+        self.assertTrue(hash(s1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(s1 == s12)
+        self.assertFalse(id(s1) == id(s12))
+        self.assertTrue(hash(s1) == hash(s12))
+
+        self.assertFalse(s1 == s2)
+        self.assertFalse(hash(s1) == hash(s2))
 
     def test_gbsizer_span2(self):
         s1 = wx.GBSpan(3,4)

--- a/unittests/test_gbsizer.py
+++ b/unittests/test_gbsizer.py
@@ -43,10 +43,9 @@ class gbsizer_Tests(wtc.WidgetTestCase):
 
     def test_gbsizer_pos3(self):
         p1 = wx.GBPosition(3,4)
-        self.assertTrue(p1 == (3,4))
         self.assertTrue(p1.Get() == (3,4))
         p1.Set(5,6)
-        self.assertTrue(p1 == (5,6))
+        self.assertTrue(p1.Get() == (5,6))
 
     def test_gbsizer_pos4(self):
         p1 = wx.GBPosition(3,4)
@@ -66,10 +65,10 @@ class gbsizer_Tests(wtc.WidgetTestCase):
         s4 = wx.GBSpan( (2,1) )
 
     def test_gbspan_eq_hash(self):
-        tupl1 = (0, 10)
+        tupl1 = (3, 4)
         s1 = wx.GBSpan(*tupl1)
         s12 = wx.GBSpan(*tupl1)
-        s2 = wx.GBSpan(2, 10)
+        s2 = wx.GBSpan(3, 5)
         # __eq__ and __hash__ must both be defined
         # eq must assert that elements are of the same class
         self.assertFalse(s1 == tupl1)
@@ -96,10 +95,9 @@ class gbsizer_Tests(wtc.WidgetTestCase):
 
     def test_gbsizer_span3(self):
         s1 = wx.GBSpan(3,4)
-        self.assertTrue(s1 == (3,4))
         self.assertTrue(s1.Get() == (3,4))
         s1.Set(5,6)
-        self.assertTrue(s1 == (5,6))
+        self.assertTrue(s1.Get() == (5,6))
 
     def test_gbsizer_span4(self):
         s1 = wx.GBSpan(3,4)

--- a/unittests/test_gdicmn.py
+++ b/unittests/test_gdicmn.py
@@ -17,6 +17,24 @@ class Point(unittest.TestCase):
         p = wx.Point(wx.RealPoint(1.2, 2.9))
         self.assertTrue(p == (1,2))
 
+    def test_eq_hash(self):
+        for cls in (wx.Point, wx.RealPoint):
+            tupl1 = (0, 10)
+            p1 = cls(*tupl1)
+            p12 = cls(*tupl1)
+            p2 = cls(2, 10)
+            # __eq__ and __hash__ must both be defined
+            # eq must assert that elements are of the same class
+            self.assertFalse(p1 == tupl1)
+            self.assertTrue(hash(p1) == hash(tupl1))
+            # then within that class, hash must follow eq
+            self.assertTrue(p1 == p12)
+            self.assertFalse(id(p1) == id(p12))
+            self.assertTrue(hash(p1) == hash(p12))
+
+            self.assertFalse(p1 == p2)
+            self.assertFalse(hash(p1) == hash(p2))
+
     def test_copy_ctor(self):
         p1 = wx.Point(3,4)
         p2 = wx.Point(p1)
@@ -139,6 +157,23 @@ class Size(unittest.TestCase):
     def test_bogus_ctor(self):
         with self.assertRaises(TypeError):
             s = wx.Size("aa", "bb")
+
+    def test_eq_hash(self):
+        tupl1 = (0, 10)
+        s1 = wx.Size(*tupl1)
+        s12 = wx.Size(*tupl1)
+        s2 = wx.Size(2, 10)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(s1 == tupl1)
+        self.assertTrue(hash(s1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(s1 == s12)
+        self.assertFalse(id(s1) == id(s12))
+        self.assertTrue(hash(s1) == hash(s12))
+
+        self.assertFalse(s1 == s2)
+        self.assertFalse(hash(s1) == hash(s2))
 
     def test_DecBy(self):
         s = wx.Size(100,100)
@@ -297,6 +332,23 @@ class Rect(unittest.TestCase):
         r = wx.Rect(wx.Size(50,100))
         self.assertTrue(r.width == 50 and r.height == 100)
         self.assertTrue(r.x == 0 and r.y == 0)
+
+    def test_eq_hash(self):
+        tupl1 = (1, 2, 3, 4)
+        r1 = wx.Rect(*tupl1)
+        r12 = wx.Rect(*tupl1)
+        r2 = wx.Rect(1, 2, 4, 3)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(r1 == tupl1)
+        self.assertTrue(hash(r1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(r1 == r12)
+        self.assertFalse(id(r1) == id(r12))
+        self.assertTrue(hash(r1) == hash(r12))
+
+        self.assertFalse(r1 == r2)
+        self.assertFalse(hash(r1) == hash(r2))
 
 
     # TODO: more tests!

--- a/unittests/test_gdicmn.py
+++ b/unittests/test_gdicmn.py
@@ -8,14 +8,14 @@ class Point(unittest.TestCase):
 
     def test_default_ctor(self):
         p = wx.Point()
-        self.assertTrue(p == (0,0))
+        self.assertTrue(p.Get() == (0,0))
 
     def test_xy_ctor(self):
         p = wx.Point(123,456)
 
     def test_RealPoint_ctor(self):
         p = wx.Point(wx.RealPoint(1.2, 2.9))
-        self.assertTrue(p == (1,2))
+        self.assertTrue(p.Get() == (1,2))
 
     def test_eq_hash(self):
         for cls in (wx.Point, wx.RealPoint):
@@ -51,7 +51,7 @@ class Point(unittest.TestCase):
 
     def test_DefaultPosition(self):
         wx.DefaultPosition
-        self.assertTrue(wx.DefaultPosition == (-1,-1))
+        self.assertTrue(wx.DefaultPosition.Get() == (-1,-1))
 
     def test_FullySpecified(self):
         p = wx.Point(1,2)
@@ -65,7 +65,7 @@ class Point(unittest.TestCase):
         p.x += 1
         p.y += 2
         self.assertTrue(p.x == 3 and p.y == 5)
-        self.assertTrue(p == (3,5))
+        self.assertTrue(p.Get() == (3,5))
 
     def test_Get(self):
         p = wx.Point(5,6)
@@ -107,7 +107,7 @@ class Point(unittest.TestCase):
         self.assertTrue(x == 5 and y == 6)
         p[0] += 1  # tests both getitem and setitem
         p[1] += 2
-        self.assertTrue(p == (6,8))
+        self.assertTrue(p.Get() == (6,8))
         with self.assertRaises(IndexError):
             p[2]
 
@@ -127,12 +127,12 @@ class Point(unittest.TestCase):
         self.assertTrue(isinstance(p5, wx.Point))
         self.assertTrue(isinstance(p6, wx.Point))
 
-        self.assertEqual(p1, (8,8))
-        self.assertEqual(p2, (8,8))
-        self.assertEqual(p3, (8,12))
-        self.assertEqual(p4, (2,3))
-        self.assertEqual(p5, (0,4))
-        self.assertEqual(p6, (-4,-6))
+        self.assertEqual(p1.Get(), (8,8))
+        self.assertEqual(p2.Get(), (8,8))
+        self.assertEqual(p3.Get(), (8,12))
+        self.assertEqual(p4.Get(), (2,3))
+        self.assertEqual(p5.Get(), (0,4))
+        self.assertEqual(p6.Get(), (-4,-6))
 
 
 
@@ -143,7 +143,7 @@ class Size(unittest.TestCase):
 
     def test_default_ctor(self):
         s = wx.Size()
-        self.assertTrue(s == (0,0))
+        self.assertTrue(s.Get() == (0,0))
 
     def test_wh_ctor(self):
         s = wx.Size(100,200)
@@ -178,46 +178,46 @@ class Size(unittest.TestCase):
     def test_DecBy(self):
         s = wx.Size(100,100)
         s.DecBy(wx.Point(5,5))
-        self.assertTrue(s == (95,95))
+        self.assertTrue(s.Get() == (95,95))
         s.DecBy(wx.Size(5,5))
-        self.assertTrue(s == (90,90))
+        self.assertTrue(s.Get() == (90,90))
         s.DecBy(5,5)
-        self.assertTrue(s == (85,85))
+        self.assertTrue(s.Get() == (85,85))
         s.DecBy(5)
-        self.assertTrue(s == (80,80))
+        self.assertTrue(s.Get() == (80,80))
         s.DecBy( (5,5) )
-        self.assertTrue(s == (75,75))
+        self.assertTrue(s.Get() == (75,75))
 
 
     def test_IncBy(self):
         s = wx.Size(50,50)
         s.IncBy(wx.Point(5,5))
-        self.assertTrue(s == (55,55))
+        self.assertTrue(s.Get() == (55,55))
         s.IncBy(wx.Size(5,5))
-        self.assertTrue(s == (60,60))
+        self.assertTrue(s.Get() == (60,60))
         s.IncBy(5,5)
-        self.assertTrue(s == (65,65))
+        self.assertTrue(s.Get() == (65,65))
         s.IncBy(5)
-        self.assertTrue(s == (70,70))
+        self.assertTrue(s.Get() == (70,70))
         s.IncBy( (5,5) )
-        self.assertTrue(s == (75,75))
+        self.assertTrue(s.Get() == (75,75))
 
     def test_DecTo(self):
         s = wx.Size(5, 15)
         s.DecTo( (10,10) )
-        self.assertTrue(s == (5,10))
+        self.assertTrue(s.Get() == (5,10))
 
     def test_IncTo(self):
         s = wx.Size(5, 15)
         s.IncTo( (10,10) )
-        self.assertTrue(s == (10,15))
+        self.assertTrue(s.Get() == (10,15))
 
     def test_properties(self):
         s = wx.Size(23,34)
         self.assertTrue(s.width == 23 and s.height == 34)
         s.width += 1
         s.height += 1
-        self.assertTrue(s == (24,35))
+        self.assertTrue(s.Get() == (24,35))
 
     def test_operators(self):
         s1 = wx.Size(100,200)
@@ -236,7 +236,7 @@ class Size(unittest.TestCase):
 
     def test_DefaultSize(self):
         ds = wx.DefaultSize
-        self.assertTrue(ds == (-1,-1))
+        self.assertTrue(ds.Get() == (-1,-1))
 
     def test_GetSet(self):
         s = wx.Size(100,200)
@@ -249,7 +249,7 @@ class Size(unittest.TestCase):
     def test_SetDefaults(self):
         s = wx.Size(50, -1)
         s.SetDefaults( (25,25) )
-        self.assertTrue(s == (50,25))
+        self.assertTrue(s.Get() == (50,25))
 
     def test_FullySpecified(self):
         self.assertTrue(wx.Size(40,50).IsFullySpecified())
@@ -265,7 +265,7 @@ class Size(unittest.TestCase):
         self.assertTrue(5 == 5 and h == 6)
         s[0] += 1  # tests both getitem and setitem
         s[1] += 2
-        self.assertTrue(s == (6,8))
+        self.assertTrue(s.Get() == (6,8))
         with self.assertRaises(IndexError):
             s[2]
 
@@ -310,7 +310,7 @@ class Rect(unittest.TestCase):
         r1 = wx.Rect(x=1, y=2, width=3, height=4)
         r2 = wx.Rect(width=3, height=4, x=1, y=2)
         self.assertTrue(r1 == r2)
-        self.assertTrue(r2 == (1,2,3,4))
+        self.assertTrue(r2.Get() == (1,2,3,4))
 
     def test_possize_ctor(self):
         r = wx.Rect(wx.Point(10,10), wx.Size(100,100))

--- a/unittests/test_geometry.py
+++ b/unittests/test_geometry.py
@@ -19,6 +19,23 @@ class Point2D(unittest.TestCase):
         self.assertTrue(p1 is not p2)
         self.assertTrue(p1 == (1.23, 4.56))
 
+    def test_eq_hash(self):
+        tupl1 = (0, 10)
+        p1 = wx.Point2D(*tupl1)
+        p12 = wx.Point2D(*tupl1)
+        p2 = wx.Point2D(2, 10)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(p1 == tupl1)
+        self.assertTrue(hash(p1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(p1 == p12)
+        self.assertFalse(id(p1) == id(p12))
+        self.assertTrue(hash(p1) == hash(p12))
+
+        self.assertFalse(p1 == p2)
+        self.assertFalse(hash(p1) == hash(p2))
+
 
 
 class Rect2D(unittest.TestCase):
@@ -35,6 +52,23 @@ class Rect2D(unittest.TestCase):
         self.assertTrue(r1 == r2)
         self.assertTrue(r1 is not r2)
         self.assertTrue(r1 == (.5, .5, 100.1, 99.2))
+
+    def test_eq_hash(self):
+        tupl1 = (1, 2, 3, 4)
+        r1 = wx.Rect2D(*tupl1)
+        r12 = wx.Rect2D(*tupl1)
+        r2 = wx.Rect2D(1, 2, 4, 3)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(r1 == tupl1)
+        self.assertTrue(hash(r1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(r1 == r12)
+        self.assertFalse(id(r1) == id(r12))
+        self.assertTrue(hash(r1) == hash(r12))
+
+        self.assertFalse(r1 == r2)
+        self.assertFalse(hash(r1) == hash(r2))
 
 
 

--- a/unittests/test_geometry.py
+++ b/unittests/test_geometry.py
@@ -17,7 +17,7 @@ class Point2D(unittest.TestCase):
         p2 = wx.Point2D(p1)
         self.assertTrue(p1 == p2)
         self.assertTrue(p1 is not p2)
-        self.assertTrue(p1 == (1.23, 4.56))
+        self.assertTrue(p1.Get() == (1.23, 4.56))
 
     def test_eq_hash(self):
         tupl1 = (0, 10)
@@ -51,7 +51,7 @@ class Rect2D(unittest.TestCase):
         r2 = wx.Rect2D(r1)
         self.assertTrue(r1 == r2)
         self.assertTrue(r1 is not r2)
-        self.assertTrue(r1 == (.5, .5, 100.1, 99.2))
+        self.assertTrue(r1.Get() == (.5, .5, 100.1, 99.2))
 
     def test_eq_hash(self):
         tupl1 = (1, 2, 3, 4)

--- a/unittests/test_grid.py
+++ b/unittests/test_grid.py
@@ -20,6 +20,22 @@ class grid_Tests(wtc.WidgetTestCase):
         c1 = wx.grid.GridCellCoords()
         c2 = wx.grid.GridCellCoords(5,10)
 
+    def test_gridcellcoords_eq_hash(self):
+        tupl1 = (0, 10)
+        r1 = wx.grid.GridCellCoords(*tupl1)
+        r12 = wx.grid.GridCellCoords(*tupl1)
+        r2 = wx.grid.GridCellCoords(2, 10)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(r1 == tupl1)
+        self.assertTrue(hash(r1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(r1 == r12)
+        self.assertFalse(id(r1) == id(r12))
+        self.assertTrue(hash(r1) == hash(r12))
+
+        self.assertFalse(r1 == r2)
+        self.assertFalse(hash(r1) == hash(r2))
 
     def test_grid02(self):
         r = wx.grid.GridCellAutoWrapStringRenderer()

--- a/unittests/test_position.py
+++ b/unittests/test_position.py
@@ -8,8 +8,8 @@ class position_Tests(wtc.WidgetTestCase):
 
     def test_positionCtors(self):
         p = wx.Position()
-        self.assertTrue(p == (0,0))
-        self.assertTrue(p != (9,9))
+        self.assertTrue(p.Get() == (0,0))
+        self.assertTrue(p.Get() != (9,9))
         p2 = wx.Position(2, 3)
         self.assertTrue(p2.Get() == (2,3))
 
@@ -51,17 +51,17 @@ class position_Tests(wtc.WidgetTestCase):
         p1 = wx.Position(3,4)
         p2 = wx.Position(1,1)
         p1 -= p2
-        self.assertTrue(p1 == (2,3))
+        self.assertTrue(p1.Get() == (2,3))
         p1 += p2
-        self.assertTrue(p1 == (3,4))
+        self.assertTrue(p1.Get() == (3,4))
 
     def test_positionMath2(self):
         p1 = wx.Position(3,4)
         p2 = wx.Position(1,1)
         p3 = p1 + p2
-        self.assertTrue(p3 == (4,5))
+        self.assertTrue(p3.Get() == (4,5))
         p4 = p3 - p2
-        self.assertTrue(p4 == (3,4))
+        self.assertTrue(p4.Get() == (3,4))
         self.assertTrue(p4 == p1)
 
 

--- a/unittests/test_position.py
+++ b/unittests/test_position.py
@@ -19,6 +19,23 @@ class position_Tests(wtc.WidgetTestCase):
         self.assertTrue(p1 is not p2)
         self.assertTrue(p1 == p2)
 
+    def test_position_eq_hash(self):
+        tupl1 = (0, 10)
+        p1 = wx.Position(*tupl1)
+        p12 = wx.Position(*tupl1)
+        p2 = wx.Position(2, 10)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(p1 == tupl1)
+        self.assertTrue(hash(p1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(p1 == p12)
+        self.assertFalse(id(p1) == id(p12))
+        self.assertTrue(hash(p1) == hash(p12))
+
+        self.assertFalse(p1 == p2)
+        self.assertFalse(hash(p1) == hash(p2))
+
     def test_positionProperties1(self):
         p = wx.Position()
         p.Row

--- a/unittests/test_richtextbuffer.py
+++ b/unittests/test_richtextbuffer.py
@@ -197,6 +197,22 @@ class richtextbuffer_Tests(wtc.WidgetTestCase):
         r[1] = 222
         self.assertEqual(r.Get(), (111,222))
 
+    def test_richtextrange_eq_hash(self):
+        tupl1 = (0, 10)
+        r1 = wx.richtext.RichTextRange(*tupl1)
+        r12 = wx.richtext.RichTextRange(*tupl1)
+        r2 = wx.richtext.RichTextRange(2, 10)
+        # __eq__ and __hash__ must both be defined
+        # eq must assert that elements are of the same class
+        self.assertFalse(r1 == tupl1)
+        self.assertTrue(hash(r1) == hash(tupl1))
+        # then within that class, hash must follow eq
+        self.assertTrue(r1 == r12)
+        self.assertFalse(id(r1) == id(r12))
+        self.assertTrue(hash(r1) == hash(r12))
+
+        self.assertFalse(r1 == r2)
+        self.assertFalse(hash(r1) == hash(r2))
 
     def test_richtextbuffer15(self):
         s1 = wx.richtext.RichTextSelection()


### PR DESCRIPTION
I wanted to put wx.Colour in a dict(), but couldn't due to the lack of hash function.

There are probably more types that need \_\_hash__ defined (value types primarily) but this is a start.

r? @RobinD42

(By the way, instead of redefining a number of methods to use the internal tuple, I thought maybe wx.Colour could subclass tuple directly... I don't know if that would work, but is worth trying I think.)