### PR TITLE
Update framemanager.py

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -4218,6 +4218,7 @@ class AuiManager(wx.EvtHandler):
         self.Bind(wx.EVT_TIMER, self.OnHintFadeTimer, self._hint_fadetimer)
         self.Bind(wx.EVT_TIMER, self.SlideIn, self._preview_timer)
         self.Bind(wx.EVT_WINDOW_DESTROY, self.OnDestroy)
+        self.Bind(wx.EVT_WINDOW_CREATE, self.DoUpdateEvt)
 
         self.Bind(wx.EVT_MOVE, self.OnMove)
         self.Bind(wx.EVT_SYS_COLOUR_CHANGED, self.OnSysColourChanged)
@@ -6339,7 +6340,7 @@ class AuiManager(wx.EvtHandler):
 
     def Update(self):
         if '__WXGTK__' in wx.PlatformInfo:
-            self.Bind(wx.EVT_WINDOW_CREATE, self.DoUpdateEvt)
+            wx.CallAfter(self.DoUpdate)
         else:
             self.DoUpdate()
 


### PR DESCRIPTION
After digging into Aui update issue under GTK (#243), I propose to move the bind on `EVT_WINDOW_CREATE` into the `AuiManager` constructor and call `wx.CallAfter(self.DoUpdate)` in the `Update` method.

Like @RobinD42 said, it is mandatory to wait for `EVT_WINDOW_CREATE` under GTK, and my own experience on my project shown it is true !
Using `wx.CallAfter` to call `self.DoUpdate` seems also mandatory to avoid the debug message below:

`Debug: ScreenToClient cannot work when toplevel window is not shown`