### PR TITLE
Classic wx.YieldIfNeeded() conversion error in CustomTreeCtrl 

### DIFF
--- a/wx/lib/agw/customtreectrl.py
+++ b/wx/lib/agw/customtreectrl.py
@@ -5867,7 +5867,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
             if wx.Platform in ["__WXMSW__", "__WXMAC__"]:
                 self.Update()
         else:
-            wx.SafeYield()
+            wx.SafeYield(onlyIfNeeded=True)
 
         # now scroll to the item
         item_y = item.GetY()


### PR DESCRIPTION
'Classic' wx.YieldIfNeeded() was translated into wx.SafeYield(), but it is not equivalent.
Cause a 'recursive Yield call' error in one of my project which works fine with Classic.
Change it into wx.SafeYield(onlyIfNeeded=True) resolve the issue.