### PR TITLE
Tighten up allowed types in auto sequence conversions

### DIFF
--- a/etg/colour.py
+++ b/etg/colour.py
@@ -196,7 +196,7 @@ def run():
                 return 1;
             if (PyBytes_Check(sipPy) || PyUnicode_Check(sipPy))
                 return 1;
-            if (PySequence_Check(sipPy)) {
+            if (PyTuple_Check(sipPy) || PyList_Check(sipPy)) {
                 size_t len = PySequence_Size(sipPy);
                 if (len != 3 && len != 4)
                     return 0;
@@ -212,6 +212,7 @@ def run():
             }
             return 0;
         }
+
         // otherwise do the conversion
         // is it None?
         if (sipPy == Py_None) {

--- a/etg/colour.py
+++ b/etg/colour.py
@@ -202,9 +202,8 @@ def run():
                     return 0;
                 // ensure all the items in the sequence are numbers
                 for (int idx=0; idx<len; idx+=1) {
-                    PyObject* o = PySequence_ITEM(sipPy, idx);
+                    PyObject* o = PySequence_Fast_GET_ITEM(sipPy, idx);
                     bool isNum = PyNumber_Check(o);
-                    Py_DECREF(o);
                     if (!isNum)
                         return 0;
                 }
@@ -255,23 +254,19 @@ def run():
             }
         }
         // Is it a 3 or 4 element sequence?
-        else if (PySequence_Check(sipPy)) {
-            size_t len = PyObject_Length(sipPy);
+        else if (PyTuple_Check(sipPy) || PyList_Check(sipPy)) {
+            size_t len = PySequence_Size(sipPy);
 
-            PyObject* o1 = PySequence_GetItem(sipPy, 0);
-            PyObject* o2 = PySequence_GetItem(sipPy, 1);
-            PyObject* o3 = PySequence_GetItem(sipPy, 2);
+            PyObject* o1 = PySequence_Fast_GET_ITEM(sipPy, 0);
+            PyObject* o2 = PySequence_Fast_GET_ITEM(sipPy, 1);
+            PyObject* o3 = PySequence_Fast_GET_ITEM(sipPy, 2);
             if (len == 3)
                 *sipCppPtr = new wxColour(wxPyInt_AsLong(o1), wxPyInt_AsLong(o2), wxPyInt_AsLong(o3));
             else {
-                PyObject* o4 = PySequence_GetItem(sipPy, 3);
+                PyObject* o4 = PySequence_Fast_GET_ITEM(sipPy, 3);
                 *sipCppPtr = new wxColour(wxPyInt_AsLong(o1), wxPyInt_AsLong(o2), wxPyInt_AsLong(o3),
                                           wxPyInt_AsLong(o4));
-                Py_DECREF(o4);
             }
-            Py_DECREF(o1);
-            Py_DECREF(o2);
-            Py_DECREF(o3);
             return sipGetState(sipTransferObj);
         }
 

--- a/etg/gdicmn.py
+++ b/etg/gdicmn.py
@@ -91,8 +91,10 @@ def run():
 
     c.addItem(etgtools.WigCode("""\
         wxPoint operator+(const wxPoint& other);
+        wxPoint operator+(const wxSize& other);
         wxPoint operator-();
         wxPoint operator-(const wxPoint& other);
+        wxPoint operator-(const wxSize& other);
         wxPoint operator*(int i);
         wxPoint operator/(int i);
         """))

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -628,12 +628,10 @@ def convertTwoIntegersTemplate(CLASS):
 
        if ((PyTuple_Check(sipPy) || PyList_Check(sipPy)) && PySequence_Size(sipPy) == 2) {{
            int rval = 1;
-           PyObject* o1 = PySequence_ITEM(sipPy, 0);
-           PyObject* o2 = PySequence_ITEM(sipPy, 1);
+           PyObject* o1 = PySequence_Fast_GET_ITEM(sipPy, 0);
+           PyObject* o2 = PySequence_Fast_GET_ITEM(sipPy, 1);
            if (!PyNumber_Check(o1) || !PyNumber_Check(o2))
                rval = 0;
-           Py_DECREF(o1);
-           Py_DECREF(o2);
            return rval;
        }}
        return 0;
@@ -648,11 +646,9 @@ def convertTwoIntegersTemplate(CLASS):
     }}
 
     // or create a new instance
-    PyObject* o1 = PySequence_ITEM(sipPy, 0);
-    PyObject* o2 = PySequence_ITEM(sipPy, 1);
+    PyObject* o1 = PySequence_Fast_GET_ITEM(sipPy, 0);
+    PyObject* o2 = PySequence_Fast_GET_ITEM(sipPy, 1);
     *sipCppPtr = new {CLASS}(wxPyInt_AsLong(o1), wxPyInt_AsLong(o2));
-    Py_DECREF(o1);
-    Py_DECREF(o2);
     return SIP_TEMPORARY;
     """.format(**locals())
 
@@ -668,16 +664,12 @@ def convertFourIntegersTemplate(CLASS):
 
         if ((PyTuple_Check(sipPy) || PyList_Check(sipPy)) && PySequence_Size(sipPy) == 4) {{
             int rval = 1;
-            PyObject* o1 = PySequence_ITEM(sipPy, 0);
-            PyObject* o2 = PySequence_ITEM(sipPy, 1);
-            PyObject* o3 = PySequence_ITEM(sipPy, 2);
-            PyObject* o4 = PySequence_ITEM(sipPy, 3);
+            PyObject* o1 = PySequence_Fast_GET_ITEM(sipPy, 0);
+            PyObject* o2 = PySequence_Fast_GET_ITEM(sipPy, 1);
+            PyObject* o3 = PySequence_Fast_GET_ITEM(sipPy, 2);
+            PyObject* o4 = PySequence_Fast_GET_ITEM(sipPy, 3);
             if (!PyNumber_Check(o1) || !PyNumber_Check(o2) || !PyNumber_Check(o3) || !PyNumber_Check(o4))
                 rval = 0;
-            Py_DECREF(o1);
-            Py_DECREF(o2);
-            Py_DECREF(o3);
-            Py_DECREF(o4);
             return rval;
         }}
         return 0;
@@ -691,14 +683,12 @@ def convertFourIntegersTemplate(CLASS):
         return 0; // not a new instance
     }}
     // or create a new instance
-    PyObject* o1 = PySequence_ITEM(sipPy, 0);
-    PyObject* o2 = PySequence_ITEM(sipPy, 1);
-    PyObject* o3 = PySequence_ITEM(sipPy, 2);
-    PyObject* o4 = PySequence_ITEM(sipPy, 3);
+    PyObject* o1 = PySequence_Fast_GET_ITEM(sipPy, 0);
+    PyObject* o2 = PySequence_Fast_GET_ITEM(sipPy, 1);
+    PyObject* o3 = PySequence_Fast_GET_ITEM(sipPy, 2);
+    PyObject* o4 = PySequence_Fast_GET_ITEM(sipPy, 3);
     *sipCppPtr = new {CLASS}(wxPyInt_AsLong(o1), wxPyInt_AsLong(o2),
                              wxPyInt_AsLong(o3), wxPyInt_AsLong(o4));
-    Py_DECREF(o1);
-    Py_DECREF(o2);
     return SIP_TEMPORARY;
     """.format(**locals())
 
@@ -715,12 +705,10 @@ def convertTwoDoublesTemplate(CLASS):
 
         if ((PyTuple_Check(sipPy) || PyList_Check(sipPy)) && PySequence_Size(sipPy) == 2) {{
             int rval = 1;
-            PyObject* o1 = PySequence_ITEM(sipPy, 0);
-            PyObject* o2 = PySequence_ITEM(sipPy, 1);
+            PyObject* o1 = PySequence_Fast_GET_ITEM(sipPy, 0);
+            PyObject* o2 = PySequence_Fast_GET_ITEM(sipPy, 1);
             if (!PyNumber_Check(o1) || !PyNumber_Check(o2))
                 rval = 0;
-            Py_DECREF(o1);
-            Py_DECREF(o2);
             return rval;
         }}
         return 0;
@@ -735,11 +723,9 @@ def convertTwoDoublesTemplate(CLASS):
     }}
 
     // or create a new instance
-    PyObject* o1 = PySequence_ITEM(sipPy, 0);
-    PyObject* o2 = PySequence_ITEM(sipPy, 1);
+    PyObject* o1 = PySequence_Fast_GET_ITEM(sipPy, 0);
+    PyObject* o2 = PySequence_Fast_GET_ITEM(sipPy, 1);
     *sipCppPtr = new {CLASS}(PyFloat_AsDouble(o1), PyFloat_AsDouble(o2));
-    Py_DECREF(o1);
-    Py_DECREF(o2);
     return SIP_TEMPORARY;
     """.format(**locals())
 
@@ -755,16 +741,12 @@ def convertFourDoublesTemplate(CLASS):
 
         if ((PyTuple_Check(sipPy) || PyList_Check(sipPy)) && PySequence_Size(sipPy) == 4) {{
             int rval = 1;
-            PyObject* o1 = PySequence_ITEM(sipPy, 0);
-            PyObject* o2 = PySequence_ITEM(sipPy, 1);
-            PyObject* o3 = PySequence_ITEM(sipPy, 2);
-            PyObject* o4 = PySequence_ITEM(sipPy, 3);
+            PyObject* o1 = PySequence_Fast_GET_ITEM(sipPy, 0);
+            PyObject* o2 = PySequence_Fast_GET_ITEM(sipPy, 1);
+            PyObject* o3 = PySequence_Fast_GET_ITEM(sipPy, 2);
+            PyObject* o4 = PySequence_Fast_GET_ITEM(sipPy, 3);
             if (!PyNumber_Check(o1) || !PyNumber_Check(o2) || !PyNumber_Check(o3) || !PyNumber_Check(o4))
                 rval = 0;
-            Py_DECREF(o1);
-            Py_DECREF(o2);
-            Py_DECREF(o3);
-            Py_DECREF(o4);
             return rval;
         }}
         return 0;
@@ -779,14 +761,12 @@ def convertFourDoublesTemplate(CLASS):
     }}
 
     // or create a new instance
-    PyObject* o1 = PySequence_ITEM(sipPy, 0);
-    PyObject* o2 = PySequence_ITEM(sipPy, 1);
-    PyObject* o3 = PySequence_ITEM(sipPy, 2);
-    PyObject* o4 = PySequence_ITEM(sipPy, 3);
+    PyObject* o1 = PySequence_Fast_GET_ITEM(sipPy, 0);
+    PyObject* o2 = PySequence_Fast_GET_ITEM(sipPy, 1);
+    PyObject* o3 = PySequence_Fast_GET_ITEM(sipPy, 2);
+    PyObject* o4 = PySequence_Fast_GET_ITEM(sipPy, 3);
     *sipCppPtr = new {CLASS}(PyFloat_AsDouble(o1), PyFloat_AsDouble(o2),
-    PyFloat_AsDouble(o3), PyFloat_AsDouble(o4));
-    Py_DECREF(o1);
-    Py_DECREF(o2);
+                             PyFloat_AsDouble(o3), PyFloat_AsDouble(o4));
     return SIP_TEMPORARY;
     """.format(**locals())
 

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -626,7 +626,7 @@ def convertTwoIntegersTemplate(CLASS):
        if (sipCanConvertToType(sipPy, sipType_{CLASS}, SIP_NO_CONVERTORS))
            return 1;
 
-       if (PySequence_Check(sipPy) && PySequence_Size(sipPy) == 2) {{
+       if ((PyTuple_Check(sipPy) || PyList_Check(sipPy)) && PySequence_Size(sipPy) == 2) {{
            int rval = 1;
            PyObject* o1 = PySequence_ITEM(sipPy, 0);
            PyObject* o2 = PySequence_ITEM(sipPy, 1);
@@ -666,7 +666,7 @@ def convertFourIntegersTemplate(CLASS):
         if (sipCanConvertToType(sipPy, sipType_{CLASS}, SIP_NO_CONVERTORS))
             return 1;
 
-        if (PySequence_Check(sipPy) && PySequence_Size(sipPy) == 4) {{
+        if ((PyTuple_Check(sipPy) || PyList_Check(sipPy)) && PySequence_Size(sipPy) == 4) {{
             int rval = 1;
             PyObject* o1 = PySequence_ITEM(sipPy, 0);
             PyObject* o2 = PySequence_ITEM(sipPy, 1);
@@ -713,7 +713,7 @@ def convertTwoDoublesTemplate(CLASS):
         if (sipCanConvertToType(sipPy, sipType_{CLASS}, SIP_NO_CONVERTORS))
             return 1;
 
-        if (PySequence_Check(sipPy) && PySequence_Size(sipPy) == 2) {{
+        if ((PyTuple_Check(sipPy) || PyList_Check(sipPy)) && PySequence_Size(sipPy) == 2) {{
             int rval = 1;
             PyObject* o1 = PySequence_ITEM(sipPy, 0);
             PyObject* o2 = PySequence_ITEM(sipPy, 1);
@@ -753,7 +753,7 @@ def convertFourDoublesTemplate(CLASS):
         if (sipCanConvertToType(sipPy, sipType_{CLASS}, SIP_NO_CONVERTORS))
             return 1;
 
-        if (PySequence_Check(sipPy) && PySequence_Size(sipPy) == 4) {{
+        if ((PyTuple_Check(sipPy) || PyList_Check(sipPy)) && PySequence_Size(sipPy) == 4) {{
             int rval = 1;
             PyObject* o1 = PySequence_ITEM(sipPy, 0);
             PyObject* o2 = PySequence_ITEM(sipPy, 1);

--- a/src/wxpy_api.sip
+++ b/src/wxpy_api.sip
@@ -174,6 +174,7 @@ static void i_wxPyEndBlockThreads(wxPyBlock_t blocked)
 
 //--------------------------------------------------------------------------
 // Commonly used helpers for converting small sequences of numbers
+// TODO: Are these still needed?
 
 // A helper for converting a 2 element sequence to a pair of integers
 static bool i_wxPy2int_seq_helper(PyObject* source, int* i1, int* i2)

--- a/unittests/test_colour.py
+++ b/unittests/test_colour.py
@@ -34,6 +34,14 @@ class Colour(wtc.WidgetTestCase):
         c1 = wx.Colour(1,2,3,4)
         p = c1.GetPixel()
 
+    def test_converters(self):
+        # Ensure that comparing different types don't accidentally work
+        # because of making the classes look like sequences
+        c = wx.Colour(1,2,3,4)
+        r = wx.Rect(1,2,3,4)
+        self.assertFalse( c == r )
+        self.assertFalse( r == c )
+
 
     if hasattr(wx, 'testColourTypeMap'):
         def test_ColourTypemaps(self):

--- a/unittests/test_colour.py
+++ b/unittests/test_colour.py
@@ -34,13 +34,12 @@ class Colour(wtc.WidgetTestCase):
         c1 = wx.Colour(1,2,3,4)
         p = c1.GetPixel()
 
+
     def test_converters(self):
-        # Ensure that comparing different types don't accidentally work
-        # because of making the classes look like sequences
-        c = wx.Colour(1,2,3,4)
-        r = wx.Rect(1,2,3,4)
-        self.assertFalse( c == r )
-        self.assertFalse( r == c )
+        # Ensure that other types that are sequence-like can't be
+        # auto-converted, the copy constructor is good-enough for testing this
+        with self.assertRaises(TypeError):
+            p = wx.Colour(wx.Rect(1,2,3,4))
 
 
     if hasattr(wx, 'testColourTypeMap'):

--- a/unittests/test_gdicmn.py
+++ b/unittests/test_gdicmn.py
@@ -117,6 +117,14 @@ class Point(unittest.TestCase):
         self.assertEqual(p6, (-4,-6))
 
 
+    def test_converters(self):
+        # Ensure that comparing different types don't accidentally work
+        # because of making the classes look like sequences
+        p = wx.Point(10,20)
+        s = wx.Size(10,20)
+        self.assertFalse( p == s )
+        self.assertFalse( s == p )
+
 
 #---------------------------------------------------------------------------
 

--- a/unittests/test_gdicmn.py
+++ b/unittests/test_gdicmn.py
@@ -118,12 +118,10 @@ class Point(unittest.TestCase):
 
 
     def test_converters(self):
-        # Ensure that comparing different types don't accidentally work
-        # because of making the classes look like sequences
-        p = wx.Point(10,20)
-        s = wx.Size(10,20)
-        self.assertFalse( p == s )
-        self.assertFalse( s == p )
+        # Ensure that other types that are sequence-like can't be
+        # auto-converted, the copy constructor is good-enough for testing this
+        with self.assertRaises(TypeError):
+            p = wx.Point(wx.Size(10,20))
 
 
 #---------------------------------------------------------------------------
@@ -243,6 +241,13 @@ class Size(unittest.TestCase):
             s[2]
 
 
+    def test_converters(self):
+        # Ensure that other types that are sequence-like can't be
+        # auto-converted, the copy constructor is good-enough for testing this
+        with self.assertRaises(TypeError):
+            p = wx.Size(wx.Point(10,20))
+
+
 #---------------------------------------------------------------------------
 
 
@@ -306,6 +311,12 @@ class Rect(unittest.TestCase):
         self.assertTrue(r.width == 50 and r.height == 100)
         self.assertTrue(r.x == 0 and r.y == 0)
 
+
+    def test_converters(self):
+        # Ensure that other types that are sequence-like can't be
+        # auto-converted, the copy constructor is good-enough for testing this
+        with self.assertRaises(TypeError):
+            p = wx.Rect(wx.Colour(1,2,3,4))
 
     # TODO: more tests!
 


### PR DESCRIPTION
Instead of allowing generic sequences to be convertible to wxPoint, wxSize, and others, explicitly allow only tuples and lists.  This is needed because these types also have methods that make them look like sequences, which meant that you could pass a wxSize where a wxPoint is expected, and so on.

Even worse is illogical stuff like this:

    wx.Point(10,20) == wx.Size(10,20)

evaluating to `True`.