### PR TITLE
Give dataview.TreeListItem hash and equality operators.

### DIFF
--- a/etg/dataview.py
+++ b/etg/dataview.py
@@ -84,12 +84,8 @@ def run():
     c.addCppMethod('long', '__hash__', '()', """\
         return (long)self->GetID();
         """)
-    c.addCppMethod('bool', '__lt__', '(wxDataViewItem* other)', "return (self->GetID() <  other->GetID());")
-    c.addCppMethod('bool', '__le__', '(wxDataViewItem* other)', "return (self->GetID() <= other->GetID());")
     c.addCppMethod('bool', '__eq__', '(wxDataViewItem* other)', "return (self->GetID() == other->GetID());")
     c.addCppMethod('bool', '__ne__', '(wxDataViewItem* other)', "return (self->GetID() != other->GetID());")
-    c.addCppMethod('bool', '__ge__', '(wxDataViewItem* other)', "return (self->GetID() >= other->GetID());")
-    c.addCppMethod('bool', '__gt__', '(wxDataViewItem* other)', "return (self->GetID() >  other->GetID());")
     c.addAutoProperties()
 
 

--- a/etg/treelist.py
+++ b/etg/treelist.py
@@ -42,9 +42,17 @@ def run():
     #-----------------------------------------------------------------
     c = module.find('wxTreeListItem')
     assert isinstance(c, etgtools.ClassDef)
+
     c.addCppMethod('int', '__nonzero__', '()', """\
         return self->IsOk();
         """)
+
+    c.addCppMethod('long', '__hash__', '()', """\
+        return (long)self->GetID();
+        """)
+
+    c.addCppMethod('bool', '__eq__', '(wxTreeListItem* other)', "return (self->GetID() == other->GetID());")
+    c.addCppMethod('bool', '__ne__', '(wxTreeListItem* other)', "return (self->GetID() != other->GetID());")
 
 
     #-----------------------------------------------------------------

--- a/unittests/test_treelist.py
+++ b/unittests/test_treelist.py
@@ -65,6 +65,18 @@ class treelist_Tests(wtc.WidgetTestCase):
         self.assertTrue(isinstance(s, list))
         self.assertEqual(len(s), 1)
         self.assertTrue(isinstance(s[0], wx.dataview.TreeListItem))
+        self.assertTrue(root == s[0])
+
+
+    def test_treelistitem_hashable(self):
+        tlc = wx.dataview.TreeListCtrl(self.frame)
+        root = self._populateTree(tlc)
+        d = dict()
+        d[root] = 'root'
+
+        tlc.Select(root)
+        s = tlc.GetSelections()
+        assert d[s[0]] == 'root'
 
 
     def test_treelist3(self):


### PR DESCRIPTION
Give dataview.TreeListItem hash and equality operators.

Remove non equality operators from DataViewItem, as there is no implicit ordering of the items that makes sense.

See #274