### PR TITLE
A couple of fixes to lib/agw/aui to prevent segfaults under OSX

### DIFF
--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -5581,7 +5581,7 @@ class AuiNotebook(wx.Panel):
 
                 else:
                     main_idx = self._tabs.GetIdxFromWindow(close_wnd)
-                    self.DeletePage(main_idx)
+                    wx.CallAfter(self.DeletePage, main_idx)
 
                 # notify owner that the tab has been closed
                 e2 = AuiNotebookEvent(wxEVT_COMMAND_AUINOTEBOOK_PAGE_CLOSED, self.GetId())

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -7376,7 +7376,12 @@ class AuiManager(wx.EvtHandler):
                 if paneInfo.IsMaximized():
                     self.RestorePane(paneInfo)
                 paneInfo.Float()
-                self.Update()
+
+                # The call to Update may result in
+                # the notebook that generated this
+                # event being deleted, so we have
+                # to do the call asynchronously.
+                wx.CallAfter(self.Update)
 
                 self._action_window = paneInfo.window
 
@@ -7417,8 +7422,15 @@ class AuiManager(wx.EvtHandler):
                 if e.GetVeto():
                     return
 
-                self.ClosePane(p)
-                self.Update()
+                # Close/update asynchronously, because
+                # the notebook which generated the event
+                # (and triggered this method call) will
+                # be deleted. 
+                def close():
+                    self.ClosePane(p)
+                    self.Update()
+
+                wx.CallAfter(close)
             else:
                 event.Skip()
 


### PR DESCRIPTION
This PR makes a couple of tiny changes to `wx/lib/agw/aui/auibook.py` and `wx/lib/agw/aui/framemanager.py` to prevent segfaults under OSX. This addresses the following (now outdated) wxwidgets trac tickets:

 - http://trac.wxwidgets.org/ticket/17101
 - http://trac.wxwidgets.org/ticket/16377

There may be more instances of this problem in the code (an event handler causing deleting the window which was the source of the event), but I have not come across any yet.