### PR TITLE
Fix wx._core.wxAssertionError at dragging a agw.aui tab

### DIFF
--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -2019,15 +2019,15 @@ class AuiTabCtrl(wx.Control, AuiTabContainer):
 
         if self._is_dragging:
 
-            if self.HasCapture():
-                self.ReleaseMouse()
-
             self._is_dragging = False
             if self._drag_image:
                 self._drag_image.EndDrag()
                 del self._drag_image
                 self._drag_image = None
                 self.GetParent().Refresh()
+                
+            if self.HasCapture():
+                self.ReleaseMouse()
 
             evt = AuiNotebookEvent(wxEVT_COMMAND_AUINOTEBOOK_END_DRAG, self.GetId())
             evt.SetSelection(self.GetIdxFromWindow(self._click_tab))


### PR DESCRIPTION
Fix the problem from issue #93.  It seems that any attempt to call self.ReleaseMouse(), despite of a self.HasCapture() query, leads to an error if wx.DragImage.BeginDrag() is active. So, I moved this block below the wx.DragImage.EndDrag() and it solves the problem.

I'm not sure whether this code block is necessary at all, because the [documentation](https://wxpython.org/Phoenix/docs/html/wx.DragImage.html?highlight=wx.dragimage#wx.DragImage.EndDrag) writes:
> This function automatically releases mouse capture.
