### PR TITLE
Fix the [G|S]etClientData methods in wx.CommandEvent

### DIFF
--- a/etg/clntdatactnr.py
+++ b/etg/clntdatactnr.py
@@ -33,13 +33,13 @@ def run():
     c = module.find('wxClientDataContainer')
     assert isinstance(c, etgtools.ClassDef)
 
-    c.find('SetClientObject.data').transfer = True
 
     # The [G|S]etClientData methods deal with untyped void* values, which we
-    # don't support. The [G|S]etClientObject methods use wxClientData instaces
+    # don't support. The [G|S]etClientObject methods use wxClientData instances
     # which we have a MappedType for, so make the ClientData methods just be
     # aliases for ClientObjects. From the Python programmer's perspective they
     # would be virtually the same anyway.
+    c.find('SetClientObject.data').transfer = True
     c.find('GetClientData').ignore()
     c.find('SetClientData').ignore()
     c.find('GetClientObject').pyName = 'GetClientData'
@@ -50,7 +50,7 @@ def run():
     c.addPyMethod('SetClientObject', '(self, data)',
         doc="Alias for :meth:`SetClientData`",
         body="self.SetClientData(data)")
-
+    c.addPyProperty('ClientData GetClientData SetClientData')
 
     #-----------------------------------------------------------------
     tools.doCommonTweaks(module)

--- a/etg/event.py
+++ b/etg/event.py
@@ -357,15 +357,25 @@ def run():
     # wxCommandEvent
     c = module.find('wxCommandEvent')
 
+    # The [G|S]etClientData methods deal with untyped void* values, which we
+    # don't support. The [G|S]etClientObject methods use wxClientData instances
+    # which we have a MappedType for, so make the ClientData methods just be
+    # aliases for ClientObjects. From the Python programmer's perspective they
+    # would be virtually the same anyway.
+    c.find('SetClientObject.clientObject').transfer = True
+    c.find('SetClientObject.clientObject').name = 'data'
     c.find('GetClientData').ignore()
     c.find('SetClientData').ignore()
+    c.find('GetClientObject').pyName = 'GetClientData'
+    c.find('SetClientObject').pyName = 'SetClientData'
+    c.addPyMethod('GetClientObject', '(self)',
+        doc="Alias for :meth:`GetClientData`",
+        body="return self.GetClientData()")
+    c.addPyMethod('SetClientObject', '(self, data)',
+        doc="Alias for :meth:`SetClientData`",
+        body="self.SetClientData(data)")
+    c.addPyProperty('ClientData GetClientData SetClientData')
 
-    c.addPyCode("""\
-        CommandEvent.GetClientData = CommandEvent.GetClientObject
-        CommandEvent.SetClientData = CommandEvent.SetClientObject""")
-
-    c.addProperty('ClientObject GetClientObject SetClientObject')
-    c.addPyCode('CommandEvent.ClientData = CommandEvent.ClientObject')
     c.addProperty('ExtraLong GetExtraLong SetExtraLong')
     c.addProperty('Int GetInt SetInt')
     c.addProperty('Selection GetSelection')

--- a/unittests/test_clntdatactnr.py
+++ b/unittests/test_clntdatactnr.py
@@ -13,6 +13,27 @@ class clntdatactnr_Tests(wtc.WidgetTestCase):
         self.assertEqual(val, "This is a test")
 
 
+    def test_clntdatactnr2(self):
+        data = wx.ClientDataContainer()
+        data.SetClientObject("This is a test")
+        val = data.GetClientObject()
+        self.assertEqual(val, "This is a test")
+
+
+    def test_clntdatactnr3(self):
+        data = wx.ClientDataContainer()
+        data.SetClientData("This is a test")
+        val = data.GetClientData()
+        self.assertEqual(val, "This is a test")
+
+        val = data.ClientData
+        self.assertEqual(val, "This is a test")
+
+        data.ClientData = "another test"
+        val = data.ClientData
+        self.assertEqual(val, "another test")
+
+
 #---------------------------------------------------------------------------
 
 if __name__ == '__main__':

--- a/unittests/test_event.py
+++ b/unittests/test_event.py
@@ -172,6 +172,19 @@ class Events(unittest.TestCase):
         eh.Destroy()
 
 
+
+    def test_ClientData1(self):
+        evt = wx.CommandEvent()
+        evt.SetClientData('hello')
+        assert evt.GetClientData() == 'hello'
+
+
+    def test_ClientData2(self):
+        evt = wx.CommandEvent()
+        evt.SetClientObject('hello')
+        assert evt.GetClientObject() == 'hello'
+
+
 #---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Tweak them the same way they are in wx.ClientDataContainer, and add a ClientData property for each class. Update the unittests accordingly.

Fixes #324 