### PR TITLE
Clear the error set by earlier (failed) tests when creating a wxVariant

### DIFF
--- a/src/wxpy_api.sip
+++ b/src/wxpy_api.sip
@@ -344,10 +344,11 @@ wxVariant i_wxVariant_in_helper(PyObject* obj)
         sipReleaseType(ptr, sipType_wxArrayString, state);
     }
 
-    else
+    else {
         // Just use the PyObject itself
         PyErr_Clear();
         value = new wxVariantDataPyObject(obj);
+    }
 
     return value;
 }

--- a/src/wxpy_api.sip
+++ b/src/wxpy_api.sip
@@ -346,6 +346,7 @@ wxVariant i_wxVariant_in_helper(PyObject* obj)
 
     else
         // Just use the PyObject itself
+        PyErr_Clear();
         value = new wxVariantDataPyObject(obj);
 
     return value;


### PR DESCRIPTION
Fixes #316