### PR TITLE
DataView fixes

### DIFF
--- a/demo/DVC_CustomRenderer.py
+++ b/demo/DVC_CustomRenderer.py
@@ -27,7 +27,8 @@ class MyCustomRenderer(dv.DataViewCustomRenderer):
         # has a helper function we can use for measuring text that is
         # aware of any custom attributes that may have been set for
         # this item.
-        return self.GetTextExtent(self.value)
+        value = self.value if self.value else ""
+        return self.GetTextExtent(value)
 
 
     def Render(self, rect, dc, state):
@@ -45,14 +46,15 @@ class MyCustomRenderer(dv.DataViewCustomRenderer):
         # And then finish up with this helper function that draws the
         # text for us, dealing with alignment, font and color
         # attributes, etc
-        self.RenderText(self.value,
+        value = self.value if self.value else ""
+        self.RenderText(value,
                         4,   # x-offset, to compensate for the rounded rectangles
                         rect,
                         dc,
                         state # wxDataViewCellRenderState flags
                         )
-
         return True
+
 
     # The HasEditorCtrl, CreateEditorCtrl and GetValueFromEditorCtrl
     # methods need to be implemented if this renderer is going to
@@ -101,7 +103,7 @@ class MyCustomRenderer(dv.DataViewCustomRenderer):
 
 #----------------------------------------------------------------------
 
-# To help focus this sammple on the custom renderer, we'll reuse the
+# To help focus this sample on the custom renderer, we'll reuse the
 # model class from another sample.
 from DVC_IndexListModel import TestModel
 

--- a/demo/DVC_CustomRenderer.py
+++ b/demo/DVC_CustomRenderer.py
@@ -19,7 +19,7 @@ class MyCustomRenderer(dv.DataViewCustomRenderer):
         return True
 
     def GetValue(self):
-        #self.log.write('GetValue')
+        self.log.write('GetValue')
         return self.value
 
     def GetSize(self):
@@ -32,8 +32,8 @@ class MyCustomRenderer(dv.DataViewCustomRenderer):
 
 
     def Render(self, rect, dc, state):
-        if state != 0:
-            self.log.write('Render: %s, %d' % (rect, state))
+        #if state != 0:
+        #    self.log.write('Render: %s, %d' % (rect, state))
 
         if not state & dv.DATAVIEW_CELL_SELECTED:
             # we'll draw a shaded background to see if the rect correctly

--- a/demo/DVC_IndexListModel.py
+++ b/demo/DVC_IndexListModel.py
@@ -7,7 +7,7 @@ import wx.dataview as dv
 #----------------------------------------------------------------------
 
 # This model class provides the data to the view when it is asked for.
-# Since it is a list-only model (no hierachical data) then it is able
+# Since it is a list-only model (no hierarchical data) then it is able
 # to be referenced by row rather than by item object, so in this way
 # it is easier to comprehend and use than other model types.  In this
 # example we also provide a Compare function to assist with sorting of
@@ -39,6 +39,7 @@ class TestModel(dv.DataViewIndexListModel):
     def SetValueByRow(self, value, row, col):
         self.log.write("SetValue: (%d,%d) %s\n" % (row, col, value))
         self.data[row][col] = value
+        return True
 
     # Report how many columns this model provides data for.
     def GetColumnCount(self):

--- a/demo/run.py
+++ b/demo/run.py
@@ -25,7 +25,7 @@ import sys, os
 # stuff for debugging
 print("Python %s" % sys.version)
 print("wx.version: %s" % wx.version())
-##print("pid: %s" % os.getpid()); raw_input("Press Enter...")
+##print("pid: %s" % os.getpid()); input("Press Enter...")
 
 assertMode = wx.APP_ASSERT_DIALOG
 ##assertMode = wx.APP_ASSERT_EXCEPTION

--- a/etg/grid.py
+++ b/etg/grid.py
@@ -224,7 +224,7 @@ def run():
 
             # Code for C++ --> Python calls. This is used when a C++ method
             # call needs to be reflected to a call to the overridden Python
-            # method, so we need to translate between the real C++ siganture
+            # method, so we need to translate between the real C++ signature
             # and the Python signature.
             virtualCatcherCode="""\
                 // VirtualCatcherCode for wx.grid.GridCellEditor.EndEdit

--- a/samples/dataview/CustomRenderer.py
+++ b/samples/dataview/CustomRenderer.py
@@ -26,7 +26,8 @@ class MyCustomRenderer(dv.DataViewCustomRenderer):
         # has a helper function we can use for measuring text that is
         # aware of any custom attributes that may have been set for
         # this item.
-        size = self.GetTextExtent(self.value)
+        value = self.value if self.value else ""
+        size = self.GetTextExtent(value)
         return size
 
 
@@ -45,7 +46,8 @@ class MyCustomRenderer(dv.DataViewCustomRenderer):
         # And then finish up with this helper function that draws the
         # text for us, dealing with alignment, font and color
         # attributes, etc
-        self.RenderText(self.value,
+        value = self.value if self.value else ""
+        self.RenderText(value,
                         4,   # x-offset, to compensate for the rounded rectangles
                         rect,
                         dc,


### PR DESCRIPTION
Mainly fixing `DataViewCustomRenderer` so an overridden `GetValueFromEditorCtrl` can behave just like the tweaked API for calling the method, where the value is returned instead of being an "out" parameter. Some other cleanup and such done along the way.