### PR TITLE
Mark wxXmlSubclassFactory::Create as a factory function

### DIFF
--- a/etg/_xrc.py
+++ b/etg/_xrc.py
@@ -166,7 +166,7 @@ def run():
             MethodDef(name='wxXmlSubclassFactory', isCtor=True),
             MethodDef(name='~wxXmlSubclassFactory', isDtor=True),
             MethodDef(name='Create', type='wxObject*',
-                isVirtual=True, isPureVirtual=True,
+                isVirtual=True, isPureVirtual=True, factory=True,
                 items=[ParamDef(type='const wxString&', name='className')])
             ])
     module.addItem(cls)


### PR DESCRIPTION
wxXmlSubclassFactory::Create makes a new instance so it needs to be set as a factory function.

Fixes #318