### PR TITLE
Fix GridTableBase.GetValue

### DIFF
--- a/build.py
+++ b/build.py
@@ -814,7 +814,7 @@ def _doDox(arg):
         os.environ['DOXYGEN'] = doxCmd
         os.environ['WX_SKIP_DOXYGEN_VERSION_CHECK'] = '1'
         pwd = pushDir(posixjoin(wxDir(), 'docs/doxygen'))
-        cmd = './regen.sh %s' % arg
+        cmd = 'bash ./regen.sh %s' % arg
     runcmd(cmd)
 
 

--- a/demo/GridCustTable.py
+++ b/demo/GridCustTable.py
@@ -141,7 +141,7 @@ class TestFrame(wx.Frame):
 
         p = wx.Panel(self, -1, style=0)
         grid = CustTableGrid(p, log)
-        b = wx.Button(p, -1, "Another Control...")
+        b = wx.Button(p, -1, "Testing with another control...")
         b.SetDefault()
         self.Bind(wx.EVT_BUTTON, self.OnButton, b)
         b.Bind(wx.EVT_SET_FOCUS, self.OnButtonFocus)


### PR DESCRIPTION
Fix GridTableBase.GetValue and related methods to work more like they did in Classic.

Fixes #345 