### PR TITLE
Extra check to avoid error under OSX when dragging AUI toolbars

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -9940,7 +9940,7 @@ class AuiManager(wx.EvtHandler):
         if not pane.IsOk():
             raise Exception("Pane window not found")
 
-        if pane.IsFloating():
+        if pane.IsFloating() and pane.frame is not None:
             pane.floating_pos = pane.frame.GetPosition()
             if pane.frame._transparent != pane.transparent or self._agwFlags & AUI_MGR_TRANSPARENT_DRAG:
                 pane.frame.SetTransparent(pane.transparent)


### PR DESCRIPTION
This PR fixes an issue under OSX/Cocoa, when using `wx.lib.agw.aui` toolbars. 

Without this extra check, when floating/docking toolbars, the following steps will reliably generate an error (simple test program listed below):

1.  Drag out the toolbar to make it float, and release the mouse.
2. Drag that floating toolbar back onto the frame to dock it. Without releasing the mouse, drag the toolbar back out to float.

The following error occurs:
```
Traceback (most recent call last):
  File "/Users/paulmc/.virtualenvs/fsleyes_py3/lib/python3.6/site-packages/wx/lib/agw/aui/framemanager.py", line 9242, in OnMotion
    self.OnMotion_DragToolbarPane(event)
  File "/Users/paulmc/.virtualenvs/fsleyes_py3/lib/python3.6/site-packages/wx/lib/agw/aui/framemanager.py", line 9877, in OnMotion_DragToolbarPane
    self.OnLeftUp_DragToolbarPane(eventOrPt)
  File "/Users/paulmc/.virtualenvs/fsleyes_py3/lib/python3.6/site-packages/wx/lib/agw/aui/framemanager.py", line 9931, in OnLeftUp_DragToolbarPane
    pane.floating_pos = pane.frame.GetPosition()
AttributeError: 'NoneType' object has no attribute 'GetPosition'
```

This corrupts the internal `AuiManager` state, so that subsequent interactions with the toolbar will result in other errors:

```
Traceback (most recent call last):
  File "/Users/paulmc/.virtualenvs/fsleyes_py3/lib/python3.6/site-packages/wx/lib/agw/aui/framemanager.py", line 9036, in OnLeftDown
    rootManager.OnGripperClicked(part.pane.window, event.GetPosition(), offset)
  File "/Users/paulmc/.virtualenvs/fsleyes_py3/lib/python3.6/site-packages/wx/lib/agw/aui/framemanager.py", line 8632, in OnGripperClicked
    self._frame.CaptureMouse()
wx._core.wxAssertionError: C++ assertion "!wxMouseCapture::IsInCaptureStack(this)" failed at /Users/robind/projects/buildbots/macosx-vm4/dist-osx-py36/Phoenix/ext/wxWidgets/src/common/wincmn.cpp(3271) in CaptureMouse(): Recapturing the mouse in the same window?
```

Here is a simple test program that can be used to demonstrate the error:

```python
#!/usr/bin/env python


import wx
import wx.lib.agw.aui as aui


class MyFrame(wx.Frame):

    def __init__(self):

        wx.Frame.__init__(self, None)

        mgr = aui.AuiManager(self, aui.AUI_MGR_ALLOW_FLOATING)

        toolbar = wx.Panel(self)
        sizer   = wx.BoxSizer(wx.HORIZONTAL)
        btn     = wx.Button(toolbar, label='Click')
        sizer.Add(btn)
        toolbar.SetSizer(sizer)

        paneInfo  = aui.AuiPaneInfo()
        paneInfo.ToolbarPane()
        paneInfo.Dockable()
        paneInfo.Floatable()

        mgr.AddPane(toolbar, paneInfo)
        mgr.Update()


if __name__ == '__main__':

    app   = wx.App()
    frame = MyFrame()
    frame.Show()
    app.MainLoop()
```