### PR TITLE
Make TreeItemId hashable

### DIFF
--- a/etg/treectrl.py
+++ b/etg/treectrl.py
@@ -42,6 +42,18 @@ def run():
         return self->IsOk();
         """)
 
+    c.addCppMethod('bool', '__eq__', '(const wxTreeItemId* other)', """\
+        return *self == *other;
+        """)
+    c.addCppMethod('bool', '__neq__', '(const wxTreeItemId* other)', """\
+        return *self != *other;
+        """)
+
+    c.addPyMethod('__hash__', '(self)', """\
+        return hash(int(self.GetID()))
+        """)
+
+
     td = etgtools.TypedefDef(name='wxTreeItemIdValue', type='void*')
     module.insertItemBefore(c, td)
 

--- a/src/treeitemdata.sip
+++ b/src/treeitemdata.sip
@@ -14,7 +14,7 @@
 %ModuleHeaderCode
 #include <wx/treebase.h>
 
-// A wxTreeItemData that knows what to do with PyObjects for maintianing the refcount
+// A wxTreeItemData that knows what to do with PyObjects for maintaining the refcount
 class wxPyTreeItemData : public wxPyUserDataHelper<wxTreeItemData>
 {
 public:

--- a/unittests/test_treectrl.py
+++ b/unittests/test_treectrl.py
@@ -28,6 +28,13 @@ class treectrl_Tests(wtc.WidgetTestCase):
         self.assertTrue(child is not root)
         self.assertTrue(child != root)
 
+        # Can TreeItemId be a dictionary key?
+        d = dict()
+        d[root] = 'root'
+        d[child] = 'child'
+        assert d[root] == 'root'
+        assert d[r] == 'root'
+
 
     def test_treectrlTreeItemData(self):
         value = 'Some Python Object'


### PR DESCRIPTION
Make TreeItemId hashable using the internal ID for the hash value, so IDs pointing to the same item will compare as equal and have the same hash values. This enables TreeItemIDs to be dictionary keys in Py3.