### PR TITLE
Set wx.RefCounter objects to be owned by C++.

### DIFF
--- a/etg/dataview.py
+++ b/etg/dataview.py
@@ -97,6 +97,7 @@ def run():
     #-----------------------------------------------------------------
     c = module.find('wxDataViewModel')
     c.addAutoProperties()
+    tools.fixRefCountedClass(c)
 
     c.find('~wxDataViewModel').ignore(False)
 
@@ -187,6 +188,7 @@ def run():
     #-----------------------------------------------------------------
     c = module.find('wxDataViewListModel')
     c.addAutoProperties()
+    tools.fixRefCountedClass(c)
 
     # Change the GetValueByRow method to return the value instead of passing
     # it through a parameter for modification.
@@ -520,6 +522,7 @@ def run():
 
     c = module.find('wxDataViewTreeStore')
     c.addAutoProperties()
+    tools.fixRefCountedClass(c)
 
 
     #-----------------------------------------------------------------

--- a/etg/grid.py
+++ b/etg/grid.py
@@ -134,6 +134,7 @@ def run():
     def fixRendererClass(name):
         klass = module.find(name)
         assert isinstance(klass, etgtools.ClassDef)
+        tools.fixRefCountedClass(klass)
         tools.addAutoProperties(klass)
 
         methods = [
@@ -152,6 +153,7 @@ def run():
     c.addPrivateCopyCtor()
     c.find('~wxGridCellRenderer').ignore(False)
     c.find('Clone').factory = True
+    tools.fixRefCountedClass(c)
 
     for name in ITEMS:
         if 'Cell' in name and 'Renderer' in name:
@@ -164,6 +166,7 @@ def run():
     def fixEditorClass(name):
         klass = module.find(name)
         assert isinstance(klass, etgtools.ClassDef)
+        tools.fixRefCountedClass(klass)
         tools.addAutoProperties(klass)
 
         methods = [
@@ -249,6 +252,7 @@ def run():
     c.addPrivateCopyCtor()
     c.find('~wxGridCellEditor').ignore(False)
     c.find('Clone').factory = True
+    tools.fixRefCountedClass(c)
 
     c = module.find('wxGridCellChoiceEditor')
     c.find('wxGridCellChoiceEditor').findOverload('count').ignore()
@@ -264,6 +268,7 @@ def run():
     c.addPrivateCopyCtor()
     c.find('~wxGridCellAttr').ignore(False)
     c.find('Clone').factory = True
+    tools.fixRefCountedClass(c)
 
     c.find('GetAlignment.hAlign').out = True
     c.find('GetAlignment.vAlign').out = True
@@ -272,7 +277,7 @@ def run():
     c.find('GetSize.num_rows').out = True
     c.find('GetSize.num_cols').out = True
 
-    c.find('SetEditor.editor').transfer = True
+    c.find('SetEditor.editor').transfer = True  # these are probably redundant now...
     c.find('SetRenderer.renderer').transfer = True
 
 

--- a/etg/object.py
+++ b/etg/object.py
@@ -48,6 +48,7 @@ def run():
     assert isinstance(c, etgtools.ClassDef)
     c.find('~wxRefCounter').ignore(False)
     c.addPrivateCopyCtor()
+    tools.fixRefCountedClass(c)
 
 
     #--------------------------------------------------

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -366,6 +366,15 @@ def fixSetStatusWidths(m):
         """)
 
 
+def fixRefCountedClass(klass):
+    # Set the Transfer annotation on the ctors, because the C++ objects
+    # own themselves and will delete themselves when their C++ refcount
+    # drops to zero.
+    for item in klass.allItems():
+        if isinstance(item, extractors.MethodDef) and item.isCtor:
+            item.transfer = True
+
+
 
 def removeVirtuals(klass):
     """


### PR DESCRIPTION
Set the /Transfer/ annotation on the ctors, because the C++ objects will always own themselves and will delete themselves when their C++ refcount drops to zero.

Fixes #366
