### PR TITLE
Fix GTK bugs in lib/agw/aui/framemanager

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -3033,7 +3033,7 @@ class AuiFloatingFrame(wx.MiniFrame):
             self.SetMinSize(min_size)
 
         self._mgr.AddPane(self._pane_window, contained_pane)
-        self._mgr.Update()
+        self._mgr.DoUpdate()
 
         if pane.min_size.IsFullySpecified():
             # because SetSizeHints() calls Fit() too (which sets the window
@@ -9419,7 +9419,7 @@ class AuiManager(wx.EvtHandler):
             e = self.FireEvent(wxEVT_AUI_PANE_FLOATED, self._action_pane, canVeto=False)
 
             if not self._action_pane.frame:
-                self.Update()
+                self.DoUpdate()
 
             self._action_window = self._action_pane.window
 


### PR DESCRIPTION
This PR fixes two related bugs in `lib/agw/aui/framemanager.py`, both occurring due to a change from a couple of years back (d2fb67779939616972bac9db72e02906d220895a) which, under GTK, forces calls to `AuiManager.Update` to be executed asynchronously.


Bug 1
=====


This bug occurs when a new pane is added to an `AuiManager`, which has both the `Float` and `MinSize` properties set.


This test program demonstrates the error. A button is added as the centre pane of an `AuiManager`. When the button is pushed, a new floating pane is added.

```python
#!/usr/bin/env python

import wx
import wx.lib.agw.aui as aui


class MyFrame(wx.Frame):

    def __init__(self):

        wx.Frame.__init__(self, None)

        self.auiMgr = aui.AuiManager(self, agwFlags=aui.AUI_MGR_ALLOW_FLOATING)

        centre = wx.Panel(self)
        sizer  = wx.BoxSizer(wx.VERTICAL)
        btn    = wx.Button(centre, label='Make a floating pane')

        sizer.Add(btn, flag=wx.EXPAND, proportion=1)
        centre.SetSizer(sizer)
        btn.Bind(wx.EVT_BUTTON, self.onbtn)

        paneinfo = aui.AuiPaneInfo().CentrePane()

        self.auiMgr.AddPane(centre, paneinfo)
        self.auiMgr.Update()


    def onbtn(self, ev):
        floater = wx.Panel(self)
        text    = wx.StaticText(floater, label='Floating pane')
        sizer   = wx.BoxSizer(wx.VERTICAL)
        sizer.Add(text, flag=wx.EXPAND, proportion=1)
        floater.SetSizer(sizer)

        paneinfo = aui.AuiPaneInfo().Float().MinSize((50, 50)).Resizable()
        self.auiMgr.AddPane(floater, paneinfo)
        self.auiMgr.Update()


if __name__ == '__main__':

    app   = wx.App()
    frame = MyFrame()

    frame.Show()
    app.MainLoop()
```
    
        
When the button is clicked, the following error occurs:


    Traceback (most recent call last):
      File "/home/paulmc/.virtualenvs/fsleyes3/lib/python3.6/site-packages/wx/core.py", line 3133, in <lambda>
        lambda event: event.callable(*event.args, **event.kw) )
      File "/home/paulmc/.virtualenvs/fsleyes3/lib/python3.6/site-packages/wx/lib/agw/aui/framemanager.py", line 6453, in DoUpdate
        frame.SetPaneWindow(p)
      File "/home/paulmc/.virtualenvs/fsleyes3/lib/python3.6/site-packages/wx/lib/agw/aui/framemanager.py", line 3043, in SetPaneWindow
        self.GetSizer().SetSizeHints(self)
    AttributeError: 'NoneType' object has no attribute 'SetSizeHints'


[This code](https://github.com/wxWidgets/Phoenix/blob/cf02cd8ac4e39e2ba4a3346f8729141fb267b4d8/wx/lib/agw/aui/framemanager.py#L3035-L3044) is the source of the problem:

```python
        self._mgr.AddPane(self._pane_window, contained_pane)
        self._mgr.Update()

        if pane.min_size.IsFullySpecified():
            # because SetSizeHints() calls Fit() too (which sets the window
            # size to its minimum allowed), we keep the size before calling
            # SetSizeHints() and reset it afterwards...
            tmp = self.GetSize()
            self.GetSizer().SetSizeHints(self)
            self.SetSize(tmp)
```


In the scenario demonstrated by the test program above, where a `MinSize` for the floating pane has been specified, the conditional block above assumes that a `Sizer` has been created and set on the `AuiFloatingFrame`. Prior to the commit referenced above, this `Sizer` would have been created via the call to the `AuiManager.Update` method, just above the conditional block.


But now, `Update` just schedules the real work (`AuiManager.DoUpdate`) to be performed later on. So when the conditional block runs, the sizer will have not yet been created, and the error is raised.


My proposed solution is simple - in the above block of code, we can just change `self._mgr.Update` to `self._mgr.DoUpdate`, so the frame is initialised correctly. 


Bug 2
=====


This bug occurs when a panel is dragged out of an `AuiManager`-managed window. The same test case as above can be used to produce this error, after fixing Bug 1. Run the code, click the button, then dock the resulting frame, and drag it back out to float. This error occurs:


    Traceback (most recent call last):
      File "/home/paulmc/.virtualenvs/fsleyes3/lib/python3.6/site-packages/wx/lib/agw/aui/framemanager.py", line 9249, in OnMotion
        self.OnMotion_ClickCaption(event)
      File "/home/paulmc/.virtualenvs/fsleyes3/lib/python3.6/site-packages/wx/lib/agw/aui/framemanager.py", line 9426, in OnMotion_ClickCaption
        windowPt = self._action_pane.frame.GetRect().GetTopLeft()
    AttributeError: 'NoneType' object has no attribute 'GetRect'


The relevant code is [here](https://github.com/wxWidgets/Phoenix/blob/cf02cd8ac4e39e2ba4a3346f8729141fb267b4d8/wx/lib/agw/aui/framemanager.py#L3035-L3044):


```python
            if not self._action_pane.frame:
                self.Update()

            self._action_window = self._action_pane.window

            # adjust action offset for window frame
            windowPt = self._action_pane.frame.GetRect().GetTopLeft()
            originPt = self._action_pane.frame.ClientToScreen(wx.Point())
            self._toolbar_action_offset = originPt - windowPt
```


The scenario is essentially the same - the offset adjust code is assuming that the window has already been floated (which would have previously occurred in the `Update` call, but is now scheduled asynchronously, so has not yet run). The same fix as for Bug 1 is proposed - change `Update` to `DoUpdate`.

There are probably similar bugs lurking - the `framemanager.py` is big and complicated!