### PR TITLE
Suppress `framemanager` warnings and errors

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -4218,6 +4218,7 @@ class AuiManager(wx.EvtHandler):
         self.Bind(wx.EVT_TIMER, self.OnHintFadeTimer, self._hint_fadetimer)
         self.Bind(wx.EVT_TIMER, self.SlideIn, self._preview_timer)
         self.Bind(wx.EVT_WINDOW_DESTROY, self.OnDestroy)
+        self.Bind(wx.EVT_CLOSE, self.OnClose)
         if '__WXGTK__' in wx.PlatformInfo:
             self.Bind(wx.EVT_WINDOW_CREATE, self.DoUpdateEvt)
 
@@ -4598,7 +4599,20 @@ class AuiManager(wx.EvtHandler):
                     klass.RemoveEventHandler(handler)
 
 
+    def OnClose(self, ev):
+        """Called when the managed window is closed. Makes sure that :meth:`UnInit`
+        is called.
+        """
+
+        ev.Skip()
+        if ev.GetEventObject() == self._frame:
+            wx.CallAfter(self.UnInit)
+
+
     def OnDestroy(self, event) :
+        """Called when the managed window is destroyed. Makes sure that :meth:`UnInit`
+        is called.
+        """
 
         if self._frame == event.GetEventObject():
             self.UnInit()
@@ -4968,6 +4982,7 @@ class AuiManager(wx.EvtHandler):
                     # reparent to self._frame and destroy the pane
                     p.window.Reparent(self._frame)
                     p.frame.SetSizer(None)
+                    p.frame._mgr.UnInit()
                     p.frame.Destroy()
                     p.frame = None
 

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -6360,6 +6360,10 @@ class AuiManager(wx.EvtHandler):
         must be called. This construction allows pane flicker to be avoided by updating
         the whole layout at one time.
         """
+
+        if not self.GetManagedWindow():
+            return
+
         if '__WXGTK__' in wx.PlatformInfo:
             self.GetManagedWindow().Freeze()
         self._hover_button = None

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -3090,7 +3090,7 @@ class AuiFloatingFrame(wx.MiniFrame):
         :param `event`: a :class:`wx.SizeEvent` to be processed.
         """
 
-        if self._owner_mgr and self._send_size:
+        if self._owner_mgr and self._send_size and self.IsShownOnScreen():
             self._owner_mgr.OnFloatingPaneResized(self._pane_window, event.GetSize())
 
 
@@ -6869,7 +6869,8 @@ class AuiManager(wx.EvtHandler):
             if guide.dock_direction == AUI_DOCK_CENTER:
                 guide.host.ValidateNotebookDocking(paneInfo.IsNotebookDockable())
 
-            guide.host.UpdateDockGuide(mousePos)
+            if guide.host.IsShownOnScreen():
+                guide.host.UpdateDockGuide(mousePos)
 
         paneInfo.window.Lower()
 
@@ -8682,6 +8683,9 @@ class AuiManager(wx.EvtHandler):
         if not self._frame.GetSizer():
             return
 
+        if not self._frame.IsShownOnScreen():
+            return
+
         mouse = wx.GetMouseState()
         mousePos = wx.Point(mouse.GetX(), mouse.GetY())
         point = self._frame.ScreenToClient(mousePos)
@@ -9670,7 +9674,7 @@ class AuiManager(wx.EvtHandler):
                 ShowDockingGuides(self._guides, True)
                 break
 
-        self.DrawHintRect(pane.window, clientPt, action_offset)
+        wx.CallAfter(self.DrawHintRect, pane.window, clientPt, action_offset)
 
 
     def OnMotion_DragMovablePane(self, eventOrPt):

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -2195,6 +2195,9 @@ class AuiDockingGuideWindow(wx.Window):
         :param `pos`: a :class:`wx.Point` mouse position.
         """
 
+        if not self.GetTopLevelParent().IsShownOnScreen() and self.IsShownOnScreen():
+            return
+
         inside = self.GetScreenRect().Contains(pos)
 
         if inside:


### PR DESCRIPTION
This PR addresses a number of issues when using the `framemanager.py`, suppressing harmless, but annoying, warnings and errors. The test program in the first comment can be used to demonstrate all of the warnings and errors that are addressed.


`ClientToScreen cannot work when toplevel window is not shown`
--------------------------------------------------------------


    ClientToScreen cannot work when toplevel window is not shown
    ScreenToClient cannot work when toplevel window is not shown


These warnings occur under GTK when floating, moving, and docking panes in an AUI managed window.  They are output whenever a call to `wxWindow.ClientToScreen` or `ScreenToClient` (direct or indirect) is made on a window which is not visible.  They seem to occur due to `AuiFloatingFrame` and `AuiDockingGuide` instances being used before they have actually appeared on screen.


The suggested fix suppresses _most_ of these warnings. However, it is not perfect, because the GTK implementation of `IsShownOnScreen` seems to lie on occasion (i.e. it returns `True` when it shouldn't).


`RuntimeError: wrapped C/C++ object of type AuiNotebook has been deleted`
-------------------------------------------------------------------------


    Traceback (most recent call last):
      File "/home/paulmc/.virtualenvs/fsleyes3.5/lib/python3.5/site-packages/wx/core.py", line 3133, in <lambda>
        lambda event: event.callable(*event.args, **event.kw) )
      File "/home/paulmc/.virtualenvs/fsleyes3.5/lib/python3.5/site-packages/wx/lib/agw/aui/framemanager.py", line 6370, in DoUpdate
        self.GetManagedWindow().Freeze()
    RuntimeError: wrapped C/C++ object of type AuiNotebook has been deleted


This error occurs when a tabbed pane (a pane in an `AuiManager`, which has been grouped with one or more panes into a notebook) is either dragged out or closed.  Adding a guard at the beginning of `DoUpdate` suppresses this error.


`wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed`
-----------------------------------------------------------------------------


    wx._core.wxAssertionError: C++ assertion "GetEventHandler() == this" failed at /tmp/pip-build-jnz8ex_j/wxpython/ext/wxWidgets/src/common/wincmn.cpp(478) in ~wxWindowBase(): any pushed event handlers must have been removed

    During handling of the above exception, another exception occurred:

    SystemError: <class 'wx._core.EraseEvent'> returned a result with an error set


This is a trickier one. It occurs in two situations that I have found:

 - When a floating pane is programmatically detached from an `AuiManager`
 - When an Aui-mnaged top level frame is closed by the user.


It occurs because, in these situations, the `AuiManager.UnInit` method does not get called. This leaves the `AuiManager` instance on the event handler stack, causing the assertion error to occur. It seems that the `AuiManager.UnInit` method **must** be called when its managed window is destroyed to prevent this error. However, the guard in `AuiManager.OnDestroy` seems to prevent this from happening (Use the `OnDestroy` monkey patch in the test program to see this in action):


    if self._frame == event.GetEventObject():
        self.UnInit()


I'm not sure what is going on but, in my experimenting, the event object is *never* equal to the managed window, so `UnInit` never gets called. An inelegant but effective solution to this problem is to:

  1. Explicitly call `UnInit` when `DetachPane is called on a floating pane.

  2. Listen to the `EVT_CLOSE` event in addition to `EVT_WINDOW_DESTROY`.


This does the trick for me.
