### PR TITLE
Fix TreeItemId.__[n]eq__ implementation to not crash when compared to None

### DIFF
--- a/etg/treectrl.py
+++ b/etg/treectrl.py
@@ -43,9 +43,11 @@ def run():
         """)
 
     c.addCppMethod('bool', '__eq__', '(const wxTreeItemId* other)', """\
+        if (other == NULL) return false; 
         return *self == *other;
         """)
     c.addCppMethod('bool', '__neq__', '(const wxTreeItemId* other)', """\
+        if (other == NULL) return true;
         return *self != *other;
         """)
 

--- a/etg/treectrl.py
+++ b/etg/treectrl.py
@@ -42,18 +42,19 @@ def run():
         return self->IsOk();
         """)
 
-    c.addCppMethod('bool', '__eq__', '(const wxTreeItemId* other)', """\
-        if (other == NULL) return false; 
+    c.addCppMethod('bool', '__eq__', '(const wxTreeItemId& other)', """\
         return *self == *other;
         """)
-    c.addCppMethod('bool', '__neq__', '(const wxTreeItemId* other)', """\
-        if (other == NULL) return true;
+    c.addCppMethod('bool', '__neq__', '(const wxTreeItemId& other)', """\
         return *self != *other;
         """)
 
     c.addPyMethod('__hash__', '(self)', """\
         return hash(int(self.GetID()))
         """)
+
+    module.find('operator==').ignore()
+    module.find('operator!=').ignore()
 
 
     td = etgtools.TypedefDef(name='wxTreeItemIdValue', type='void*')


### PR DESCRIPTION
fixes #373 