### PR TITLE
Reinit image handlers after clearing and reloading wxModules

### DIFF
--- a/src/wxpy_api.sip
+++ b/src/wxpy_api.sip
@@ -540,6 +540,7 @@ void i_wxPyReinitializeModules() {
         wxModule::CleanUpModules();
         wxModule::RegisterModules();
         wxModule::InitializeModules();
+        wxInitAllImageHandlers();
     }
 }
 


### PR DESCRIPTION
fixes #395 