### PR TITLE
Fixing missing Return Value

### DIFF
--- a/docs/sphinx/rest_substitutions/snippets/python/converted/wx.EventFilter.1.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/converted/wx.EventFilter.1.py
@@ -30,7 +30,7 @@
                 
     
                 # Continue processing the event normally as well.
-                self.Event_Skip
+                return self.Event_Skip
                 
         
             # This function could be called periodically from some timer to


### PR DESCRIPTION
I tested this change locally and found that because it didn't have a return of the int it was swallowing all events in this spot.