### PR TITLE
Update test_window.py

### DIFF
--- a/unittests/test_window.py
+++ b/unittests/test_window.py
@@ -122,6 +122,12 @@ class WindowTests(wtc.WidgetTestCase):
         val = self.frame.DLG_UNIT((10, 10))
         _check(val)
 
+        val = wx.DLG_UNIT(self.frame, wx.Point(10, 10))
+        assert isinstance(val, wx.Point)
+        
+        val = wx.DLG_UNIT(self.frame, wx.Size(10, 10))
+        assert isinstance(val, wx.Size)
+        
         wx.DLG_SZE
         wx.DLG_PNT
 


### PR DESCRIPTION
Add checks to ensure correct type is returned per input.

Also, are the checks for `wx.DLG_PNT` and `wx.DLG_SIZE` necessary? I believe those helpers have been entirely removed at this point, so these lines should always fail.