### PR TITLE
Doc structure updates

### DIFF
--- a/build.py
+++ b/build.py
@@ -872,7 +872,7 @@ def cmd_docset_py(options, args):
     # update its Info.plist file
     docset = os.path.abspath(docset)
     runcmd('defaults write {}/Contents/Info isJavaScriptEnabled true'.format(docset))
-    runcmd('defaults write {}/Contents/Info dashIndexFilePath main.html'.format(docset))
+    runcmd('defaults write {}/Contents/Info dashIndexFilePath index.html'.format(docset))
     runcmd('defaults write {}/Contents/Info DocSetPlatformFamily wxpy'.format(docset))
     runcmd('plutil -convert xml1 {}/Contents/Info.plist'.format(docset))
 

--- a/docs/sphinx/_static/css/phoenix.css
+++ b/docs/sphinx/_static/css/phoenix.css
@@ -723,3 +723,14 @@ tt {
 .myactive {background-color: rgb(230, 230, 230);  background-position: 0 5px;}
 
 
+p.mybiglink a.mybiglink {
+    font-size: 1.2em;
+    color: #355f7c;
+    text-decoration: none;
+
+}
+
+table.contentstable p.mybiglink {
+    line-height: 150%;
+}
+

--- a/docs/sphinx/_templates/layout.html
+++ b/docs/sphinx/_templates/layout.html
@@ -1,7 +1,7 @@
 {% extends "basic/layout.html" %}
 
 {%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool)
-    and (sidebars != []) and (pagename != 'index') %}
+    and (sidebars != []) %}
 
 {% macro phoenixsidebar() %}
    {%- if render_sidebar %}{{ sidebar() }}{%- endif %}
@@ -30,9 +30,9 @@
       <h3>{{ _('Navigation') }}</h3>
       <ul class="row1">
         <li><img src="_static/images/sphinxdocs/phoenix_small.png" alt=""/></li>
-        <li><a href="index.html" style="color: rgb(238, 152, 22); hover: rgb(53, 95, 124);">Home</a> |&nbsp;</li>
+        <li><a href="https://wxPython.org/" style="color: rgb(238, 152, 22); hover: rgb(53, 95, 124);">Home</a> |&nbsp;</li>
         <li><a href="gallery.html" style="color: rgb(238, 152, 22); hover: rgb(53, 95, 124);;">Gallery</a> |&nbsp;</li>
-        <li><a href="main.html" style="color: rgb(238, 152, 22); hover: rgb(53, 95, 124);">API Docs</a> &raquo; </li>
+        <li><a href="index.html" style="color: rgb(238, 152, 22); hover: rgb(53, 95, 124);">API Docs</a> &raquo; </li>
 
         {%- for parent in parents %}
           <li><a href="{{ parent.link|e }}" {% if loop.last %}{{ accesskey("U") }}{% endif %}>

--- a/docs/sphinx/_templates/main.html
+++ b/docs/sphinx/_templates/main.html
@@ -1,93 +1,10 @@
-{% extends "layout.html" %}
-{% set title = 'API Documentation' %}
-{% block body %}
-  <h1>wxPython Phoenix API Documentation</h1>
-
-  <p>|WELCOME|</p>
-
-    <p>
-        If you are porting your code from Classic wxPython, be sure to read the
-        <a href="MigrationGuide.html">Migration Guide</a> to get a better feel for
-        how some things have changed.
-    </p>
-
-<div class="admonition note">
- <p class="first admonition-title">Note</p>
-
-    If you wish to help in the documentation effort, the main docstrings guidelines are outlined in
-    the <a href="DocstringsGuidelines.html">Docstring Guidelines</a> document.
-</div>
-
-<br>
-
-
-  <h2>API Modules</h2>
-
-  <table class="contentstable" align="center" style="margin-left: 25px">
-    <tr>
-    <td width="50%" valign="top">
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.1moduleindex") }}">wx Core</a><br/>
-         <span class="linkdescr">The classes which appear in the main wx namespace</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.adv.1moduleindex") }}">wx.adv</a><br/>
-         <span class="linkdescr">Less commonly used or more advanced classes</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.grid.1moduleindex") }}">wx.grid</a><br/>
-         <span class="linkdescr">Widget and supporting classes for displaying and editing tabular data</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.dataview.1moduleindex") }}">wx.dataview</a><br/>
-         <span class="linkdescr">Classes for viewing tabular or hierarchical data</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.richtext.1moduleindex") }}">wx.richtext</a><br/>
-         <span class="linkdescr">A generic, ground-up implementation of a text control capable of showing multiple text styles and images.</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.ribbon.1moduleindex") }}">wx.ribbon</a><br/>
-         <span class="linkdescr">A set of classes for writing a ribbon-based UI, typically a combonation of tabs and toolbar, similar to the UI in MS Office and Windows 10.</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.html.1moduleindex") }}">wx.html</a><br/>
-         <span class="linkdescr">Widget and supporting classes for a generic html renderer</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.html2.1moduleindex") }}">wx.html2</a><br/>
-         <span class="linkdescr">Widget and supporting classes for a native html renderer, with CSS and javascript support</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.aui.1moduleindex") }}">wx.aui</a><br/>
-         <span class="linkdescr">Docking/floating window panes, draggable notebook tabs, etc.</span></p>
-
-
-    </td>
-    <td valign="top" width="50%" style="margin-left: 5px">
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.lib") }}">wx.lib</a><br/>
-         <span class="linkdescr">Our pure-Python library of widgets</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.glcanvas.1moduleindex") }}">wx.glcanvas</a><br/>
-         <span class="linkdescr">Classes for embedding OpenGL views in a window</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.stc.1moduleindex") }}">wx.stc</a><br/>
-         <span class="linkdescr">Classes for Styled Text Control, a.k.a Scintilla</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.msw.1moduleindex") }}">wx.msw</a><br/>
-         <span class="linkdescr">A few classes available only on Windows</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.media.1moduleindex") }}">wx.media</a><br/>
-         <span class="linkdescr">MediaCtrl and related classes</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.propgrid.1moduleindex") }}">wx.propgrid</a><br/>
-         <span class="linkdescr">PropertyGrid and related classes for editing a grid of name/value pairs. </span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.xrc.1moduleindex") }}">wx.xrc</a><br/>
-         <span class="linkdescr">Classes for loading widgets and layout from XML</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.xml.1moduleindex") }}">wx.xml</a><br/>
-         <span class="linkdescr">Some simple XML classes for use with XRC</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.py") }}">wx.py</a><br/>
-         <span class="linkdescr">The py package, containing PyCrust and related modules</span></p>
-
-      <p class="biglink"><a class="biglink" href="{{ pathto("wx.tools") }}">wx.tools</a><br/>
-         <span class="linkdescr">Some useful tools and utilities for wxPython.</span></p>
-
-    </td></tr>
-  </table>
-
-
-{% endblock %}
+<!DOCTYPE html>
+<head>
+<meta charset="utf-8">
+<title>Redirecting...</title>
+<meta name="robots" content="noindex">
+<meta http-equiv="refresh" content="0; url=index.html">
+</head>
+<body>
+<p>Page moved <a href="index.html">here</a>.</p>
+</body>

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -153,7 +153,7 @@ html_style = 'css/phoenix.css'
 
 # Custom sidebar templates, maps document names to template names.
 html_sidebars = {
-    'index': ['indexsidebar.html'], # TODO: index page doesn't have a sidebar??
+    'index': ['searchbox.html'],
     'main':  ['searchbox.html'],
     '**':    ['localtoc.html',
              #'relations.html',  # Next/Prev in the sidebar, disabled for now

--- a/docs/sphinx/rest_substitutions/overviews/index.rst
+++ b/docs/sphinx/rest_substitutions/overviews/index.rst
@@ -3,107 +3,94 @@
    Copyright: (c) 2011-2016 by Total Control Software
    License:   wxWindows License
 
-=======================================
-Welcome to the wxPython Phoenix Project
-=======================================
+.. include:: headings.inc
+
+==========================
+wxPython API Documentation
+==========================
+
+!WELCOME!
+
+If you are porting your code from Classic wxPython, be sure to read the
+`Migration Guide <MigrationGuide.html>`_  to get a better feel for
+how some things have changed.
 
 
-wxPython
-========
-
-wxPython is a **GUI toolkit** for the `Python <http://www.python.org/>`_
-programming language. It allows Python programmers to create programs with a
-robust, highly functional graphical user interface, simply and easily.
-
-.. figure:: _static/images/sphinxdocs/central_bar.png
-   :align: center
+.. note:: If you wish to help in the documentation effort, the main
+   docstrings guidelines are outlined in the
+   `Docstring Guidelines <https://docs.wxpython.org/DocstringsGuidelines.html>`_
+   document.
 
 
-|
+.. raw:: html
 
-What is wxPython
-----------------
+     <h2>API Modules</h2>
 
-wxPython is a **GUI toolkit** for the `Python <http://www.python.org/>`_
-programming language. It allows Python programmers to create programs with a
-robust, highly functional graphical user interface, simply and easily. It is
-implemented as a Python extension module (native code) that wraps the popular
-`wxWidgets <http://wxwidgets.org/>`_ cross platform GUI library, which is
-written in C++.
+     <table class="contentstable" align="center" style="margin-left: 25px">
+       <tr>
+       <td width="50%" valign="top">
+         <p class="mybiglink"><a class="mybiglink" href="wx.1moduleindex.html">wx Core</a><br/>
+            <span class="linkdescr">The classes which appear in the main wx namespace</span></p>
 
-Like Python and wxWidgets, wxPython is *Open Source* which means that it is
-free for anyone to use and the source code is available for anyone to look at
-and modify. Or anyone can contribute fixes or enhancements to the project.
+         <p class="mybiglink"><a class="mybiglink" href="wx.adv.1moduleindex.html">wx.adv</a><br/>
+            <span class="linkdescr">Less commonly used or more advanced classes</span></p>
 
-wxPython is a *cross-platform* toolkit. This means that the same program will
-run on multiple platforms without modification. Currently supported platforms
-are 32-bit Microsoft Windows, most Unix or unix-like systems, and Macintosh OS
-X+, in most cases the native widgets are used on each platform.
+         <p class="mybiglink"><a class="mybiglink" href="wx.grid.1moduleindex.html">wx.grid</a><br/>
+            <span class="linkdescr">Widget and supporting classes for displaying and editing tabular data</span></p>
 
-Since the language is Python, wxPython programs are **simple, easy** to write
-and easy to understand.
+         <p class="mybiglink"><a class="mybiglink" href="wx.dataview.1moduleindex.html">wx.dataview</a><br/>
+            <span class="linkdescr">Classes for viewing tabular or hierarchical data</span></p>
 
-As an example, this is a simple "Hello World" program with wxPython::
+         <p class="mybiglink"><a class="mybiglink" href="wx.richtext.1moduleindex.html">wx.richtext</a><br/>
+            <span class="linkdescr">A generic, ground-up implementation of a text control capable of showing multiple text styles and images.</span></p>
 
-    import wx
+         <p class="mybiglink"><a class="mybiglink" href="wx.ribbon.1moduleindex.html">wx.ribbon</a><br/>
+            <span class="linkdescr">A set of classes for writing a ribbon-based UI, typically a combonation of tabs and toolbar, similar to the UI in MS Office and Windows 10.</span></p>
 
-    app = wx.App()
+         <p class="mybiglink"><a class="mybiglink" href="wx.html.1moduleindex.html">wx.html</a><br/>
+            <span class="linkdescr">Widget and supporting classes for a generic html renderer</span></p>
 
-    frame = wx.Frame(None, -1, "Hello World")
-    frame.Show()
+         <p class="mybiglink"><a class="mybiglink" href="wx.html2.1moduleindex.html">wx.html2</a><br/>
+            <span class="linkdescr">Widget and supporting classes for a native html renderer, with CSS and javascript support</span></p>
 
-    app.MainLoop()
-
-
-The GUI layouts you can build with wxPython are almost infinite: it has an
-extremely rich set of widgets (derived from `wxWidgets`) and greatly extended
-by a huge set of pure-Python controls written over the years.
+         <p class="mybiglink"><a class="mybiglink" href="wx.aui.1moduleindex.html">wx.aui</a><br/>
+            <span class="linkdescr">Docking/floating window panes, draggable notebook tabs, etc.</span></p>
 
 
-What is wxPython Phoenix?
--------------------------
+       </td>
+       <td valign="top" width="50%" style="margin-left: 5px">
+         <p class="mybiglink"><a class="mybiglink" href="wx.lib.html">wx.lib</a><br/>
+            <span class="linkdescr">Our pure-Python library of widgets</span></p>
 
-**Phoenix** is the code name of a new implementation of wxPython.  The name comes
-from the `mythical bird <https://en.wikipedia.org/wiki/Phoenix_(mythology)>`_
-that bursts into flames at the end of its life and from the ashes is reborn as
-a new, stronger, and better phoenix.  Likewise the intent with the
-*wxPython Phoenix* project is throw almost everything from *wxPython Classic*
-into the fire to be built anew from the ashes of its former self, without all
-of the old crud that had built up over the long life of Classic.
+         <p class="mybiglink"><a class="mybiglink" href="wx.glcanvas.1moduleindex.html">wx.glcanvas</a><br/>
+            <span class="linkdescr">Classes for embedding OpenGL views in a window</span></p>
 
-Much of that crud were rather hacky things which had to be done to
-work around limitations of the technology available at the time.  Those are
-easy to get rid of.  Others are things that seemed good at the time, but in
-retrospect turned out to be bad ideas.  Some of those are a little more
-tricky, but still a good idea to change.  The end result will be a new
-wxPython that is better, stronger, and faster than he was before, and which is
-easier to maintain, extend and document.
+         <p class="mybiglink"><a class="mybiglink" href="wx.stc.1moduleindex.html">wx.stc</a><br/>
+            <span class="linkdescr">Classes for Styled Text Control, a.k.a Scintilla</span></p>
 
-Although there hasn't been a formal release yet, Phoenix is already in a
-usable state with snapshot builds available after new commits are merged,
-and is in active use on a number of projects already.  Progress is still being
-made and an official release is on the way.  Stay tuned to the wxPython
-developer and user groups for more information and announcements.
+         <p class="mybiglink"><a class="mybiglink" href="wx.msw.1moduleindex.html">wx.msw</a><br/>
+            <span class="linkdescr">A few classes available only on Windows</span></p>
 
-Meanwhile, here are some important links:
+         <p class="mybiglink"><a class="mybiglink" href="wx.media.1moduleindex.html">wx.media</a><br/>
+            <span class="linkdescr">MediaCtrl and related classes</span></p>
 
-  * The `MigrationGuide <MigrationGuide.html>`_ will help you understand the
-    differences between wxPython Phoenix and Classic.  In addition,
-    `classic_vs_phoenix <classic_vs_phoenix.html>`_ documents
-    some names that have been changed, or which haven't yet been ported to
-    Phoenix.
+         <p class="mybiglink"><a class="mybiglink" href="wx.propgrid.1moduleindex.html">wx.propgrid</a><br/>
+            <span class="linkdescr">PropertyGrid and related classes for editing a grid of name/value pairs. </span></p>
 
-  * The new wxPython API documentation is available `here <main.html>`_.
+         <p class="mybiglink"><a class="mybiglink" href="wx.xrc.1moduleindex,html">wx.xrc</a><br/>
+            <span class="linkdescr">Classes for loading widgets and layout from XML</span></p>
 
-  * The `Project Phoenix <http://wiki.wxpython.org/ProjectPhoenix>`_ section
-    of the wxPython wiki has information about the background of, and reasons
-    for this project, as well as information for developers who want to help
-    out.
+         <p class="mybiglink"><a class="mybiglink" href="wx.xml.1moduleindex.html">wx.xml</a><br/>
+            <span class="linkdescr">Some simple XML classes for use with XRC</span></p>
 
-  * Source code and issue tracking are available at the
-    `Phoenix GitHub <https://github.com/wxWidgets/Phoenix>`_ repository. Be
-    sure to read the README.rst file there to learn how to build wxWidgets and
-    Phoenix for yourself.
+         <p class="mybiglink"><a class="mybiglink" href="wx.py.html">wx.py</a><br/>
+            <span class="linkdescr">The py package, containing PyCrust and related modules</span></p>
+
+         <p class="mybiglink"><a class="mybiglink" href="wx.tools.html">wx.tools</a><br/>
+            <span class="linkdescr">Some useful tools and utilities for wxPython.</span></p>
+
+       </td></tr>
+     </table>
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ platform specific code.
 For more information please refer to the
 `README file <https://github.com/wxWidgets/Phoenix/blob/wxPython-{version}/README.rst>`_,
 the `Migration Guide <{docs_base}/MigrationGuide.html>`_,
-or the `wxPython API documentation <{docs_base}/main.html>`_.
+or the `wxPython API documentation <{docs_base}/index.html>`_.
 
 Archive files containing a copy of the wxPython documentation, the demo and
 samples, and also a set of MSVC .pdb files for Windows are available at sourceforge, 

--- a/sphinxtools/postprocess.py
+++ b/sphinxtools/postprocess.py
@@ -678,7 +678,7 @@ def postProcess(folder, options):
 
         split = os.path.split(files)[1]
 
-        if split == 'main.html':
+        if split == 'index.html':
             text = changeWelcomeText(text, options)
         else:
             text = text.replace('class="headerimage"', 'class="headerimage-noshow"')
@@ -751,7 +751,7 @@ def changeWelcomeText(text, options):
             from git revision: 
             <a href="https://github.com/wxWidgets/Phoenix/commit/{revhash}">{revhash}</a>.
             """.format(version=cfg.VERSION, today=TODAY, revhash=revhash)
-    text = text.replace('|WELCOME|', welcomeText)
+    text = text.replace('!WELCOME!', welcomeText)
     return text
 
 


### PR DESCRIPTION
In anticipation of the new website (coming soon to an Internet near you) I've made some slight changes to the API docs. Instead of the `index.html` being a home page of sorts, and `main.html` being the main page of the API Docs, I've tossed out the old `index.html` and made the old `main.html` be `index.html` with `main.html` redirecting to `index.html`. Also the "Home" link goes to the main wxpython site instead of the root of the docs site.