### PR TITLE
Add docs to the release tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,6 +8,7 @@ recursive-include   wx  **
 recursive-include   license  *.txt
 include             LICENSE.txt
 graft               docs
+prune               docs/sphinx/build
 
 recursive-exclude   wx  .git
 recursive-exclude   wx  *.pyc

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@
 recursive-include   wx  **
 recursive-include   license  *.txt
 include             LICENSE.txt
+graft               docs
 
 recursive-exclude   wx  .git
 recursive-exclude   wx  *.pyc


### PR DESCRIPTION
The PyPI tarball is the canonical source for building packages on Linux distributions such as Debian. It would be desirable to have the docs shipped in the sdist, so that a corresponding documentation package can be built on the Debian side.