### PR TITLE
Fix reference before assignment

### DIFF
--- a/wx/lib/agw/supertooltip.py
+++ b/wx/lib/agw/supertooltip.py
@@ -317,7 +317,7 @@ class ToolTipWindowBase(object):
             # We got the header text
             dc.SetFont(headerFont)
             textWidth, textHeight = dc.GetTextExtent(header)
-        maxWidth = max(bmpWidth+(textWidth+self._spacing*3), maxWidth)
+            maxWidth = max(bmpWidth+(textWidth+self._spacing*3), maxWidth)
         # Calculate the header height
         height = max(textHeight, bmpHeight)
         if header:


### PR DESCRIPTION
Fix issue where textWidth can be referenced before it is actually assigned.

I've actually been monkey patching this since classic version 2.9.4, figured I should finally submit a pull to fix it, hopefully before the official 4.0 release.