### PR TITLE
Transfer ownership of wx.EvtHandler when needed.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 .. title: wxPython Changelog
 .. slug: changes
 .. author: Robin
-.. description: 
+.. description: Summary of changes for wxPython releases
 .. type: text
 
 
@@ -13,7 +13,15 @@ wxPython Changelog
 -------
 * (not yet released)
 
-Added a deprecated compatibility helper for wx.CustomDataFormat.
+PyPI:   https://pypi.python.org/pypi/wxPython/4.0.0b1
+Extras: https://extras.wxPython.org/wxPython4/extras/
+
+Changes in this release include the following:
+
+* Added a deprecated compatibility helper for wx.CustomDataFormat.
+
+* Transfer ownership of the wx.EvtHandler when pushing/popping them, and also
+  for Set/RemoveEventHandler. (#443)
 
 
 

--- a/etg/window.py
+++ b/etg/window.py
@@ -233,6 +233,14 @@ def run():
     c.find('FindWindowByLabel.parent').default='NULL'
     c.find('FindWindowByName.parent').default='NULL'
 
+    # Transfer ownership of the wx.EvtHandler when pushing/popping them...
+    c.find('PushEventHandler.handler').transfer = True
+    c.find('PopEventHandler').transferBack = True
+
+    # ...and for Set/RemoveEventHandler too
+    c.find('SetEventHandler.handler').transfer = True
+    c.find('RemoveEventHandler.handler').transferBack = True
+
 
     # Define some properties using the getter and setter methods
     c.addProperty('AcceleratorTable GetAcceleratorTable SetAcceleratorTable')


### PR DESCRIPTION
Transfer ownership of the wx.EvtHandler when pushing/popping them, and also for Set/RemoveEventHandler.

Fixes #443