### PR TITLE
fixing code snippet - open even if contentNotSaved

### DIFF
--- a/docs/sphinx/rest_substitutions/snippets/python/converted/wx.FileDialog.1.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/converted/wx.FileDialog.1.py
@@ -7,21 +7,21 @@
                                  wx.ICON_QUESTION | wx.YES_NO, self) == wx.NO:
                     return
                 
-                # else: proceed asking to the user the new file to open
+            # else: proceed asking to the user the new file to open
+        
+            openFileDialog = wx.FileDialog(self, "Open XYZ file", "", "",
+                                           "XYZ files (*.xyz)|*.xyz", wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
+
+            if openFileDialog.ShowModal() == wx.ID_CANCEL:
+                return     # the user changed idea...
             
-                openFileDialog = wx.FileDialog(self, "Open XYZ file", "", "",
-                                               "XYZ files (*.xyz)|*.xyz", wx.FD_OPEN | wx.FD_FILE_MUST_EXIST)
-    
-                if openFileDialog.ShowModal() == wx.ID_CANCEL:
-                    return     # the user changed idea...
-                
-                # proceed loading the file chosen by the user
-                # this can be done with e.g. wxPython input streams:
-                input_stream = wx.FileInputStream(openFileDialog.GetPath())
-                
-                if not input_stream.IsOk():
-                
-                    wx.LogError("Cannot open file '%s'."%openFileDialog.GetPath())
-                    return
-                
+            # proceed loading the file chosen by the user
+            # this can be done with e.g. wxPython input streams:
+            input_stream = wx.FileInputStream(openFileDialog.GetPath())
             
+            if not input_stream.IsOk():
+            
+                wx.LogError("Cannot open file '%s'."%openFileDialog.GetPath())
+                return
+            
+        


### PR DESCRIPTION
Everything after the "else: proceed asking to the user the new file to open" I tabbed one less, so that *even if you don't have contentNotSaved* you will still be able to open a file.  

The way it currently stands you only get to the open dialog if you have contentNotSaved

Fixes #451 