### PR TITLE
Fix wx.ListCtrl.SetItemData

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Changes in this release include the following:
 * Fixes to ensure that the locale message catalogs are included in the
   release files. (#464)
 
+* Fix wx.ListCtrl.SetItemData to check that the data value is not out of
+  the range of a C long. (#467)
 
 
 

--- a/etg/listctrl.py
+++ b/etg/listctrl.py
@@ -98,6 +98,10 @@ def run():
                                (wxIntPtr)fnSortCallBack);
     """)
 
+    # SetItemData takes a long, so lets return that type from GetItemData too,
+    # instead of a wxUIntPtr.
+    c.find('GetItemData').type = 'long'
+
     # Change the semantics of GetColumn to return the item as the return
     # value instead of through a prameter.
     # bool GetColumn(int col, wxListItem& item) const;

--- a/src/core_ex.cpp
+++ b/src/core_ex.cpp
@@ -138,6 +138,12 @@ void wxPyCoreModuleInject(PyObject* moduleDict)
 
     PyDict_SetItemString(moduleDict, "wxWidgets_version", wx2PyString(wxVERSION_STRING));
 
+    PyDict_SetItemString(moduleDict, "_sizeof_int", PyLong_FromLong(sizeof(int)));
+    PyDict_SetItemString(moduleDict, "_sizeof_long", PyLong_FromLong(sizeof(long)));
+    PyDict_SetItemString(moduleDict, "_sizeof_longlong", PyLong_FromLong(sizeof(long long)));
+    PyDict_SetItemString(moduleDict, "_sizeof_double", PyLong_FromLong(sizeof(double)));
+    PyDict_SetItemString(moduleDict, "_sizeof_size_t", PyLong_FromLong(sizeof(size_t)));
+
     // Make a tuple of strings that gives more info about the platform and build.
     PyObject* PlatformInfo = PyList_New(0);
     PyObject* obj;

--- a/src/core_ex.cpp
+++ b/src/core_ex.cpp
@@ -143,6 +143,10 @@ void wxPyCoreModuleInject(PyObject* moduleDict)
     PyDict_SetItemString(moduleDict, "_sizeof_longlong", PyLong_FromLong(sizeof(long long)));
     PyDict_SetItemString(moduleDict, "_sizeof_double", PyLong_FromLong(sizeof(double)));
     PyDict_SetItemString(moduleDict, "_sizeof_size_t", PyLong_FromLong(sizeof(size_t)));
+    PyDict_SetItemString(moduleDict, "_LONG_MIN", PyLong_FromLong(LONG_MIN));
+    PyDict_SetItemString(moduleDict, "_LONG_MAX", PyLong_FromLong(LONG_MAX));
+    PyDict_SetItemString(moduleDict, "_LLONG_MIN", PyLong_FromLongLong(PY_LLONG_MIN));
+    PyDict_SetItemString(moduleDict, "_LLONG_MAX", PyLong_FromLongLong(PY_LLONG_MAX));
 
     // Make a tuple of strings that gives more info about the platform and build.
     PyObject* PlatformInfo = PyList_New(0);

--- a/unittests/test_listctrl.py
+++ b/unittests/test_listctrl.py
@@ -172,7 +172,26 @@ class listctrl_Tests(wtc.WidgetTestCase):
         wx.LIST_FIND_RIGHT
 
 
+    def _makeListCtrl(self):
+        lc = wx.ListCtrl(self.frame, style=wx.LC_REPORT)
+        lc.AppendColumn('AAAA')
+        lc.AppendColumn('BBBB')
+        lc.InsertItem(0, 'item 1A')
+        lc.SetItem(0, 1, 'item 1B')
+        return lc
 
+
+    def test_listctrlItemData01(self):
+        lc = self._makeListCtrl()
+        lc.SetItemData(0, 12345)
+        data = lc.GetItemData(0)
+        assert data == 12345
+
+
+    def test_listctrlItemData02(self):
+        lc = self._makeListCtrl()
+        with self.assertRaises(OverflowError):
+            lc.SetItemData(0, wx._core._LONG_MAX + 100)
 
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #467

The data value for `wx.ListCtrl` items is constrained to a C long, but SIP isn't enforcing that for us currently.  Take care of this case, and also fix some things that made it less obvious that it was an overflow situation.
