### PR TITLE
Change ToolBar.AddTool help parameters to be consistent

### DIFF
--- a/etg/toolbar.py
+++ b/etg/toolbar.py
@@ -91,7 +91,6 @@ def run():
             except ExtractorError:
                 pass
 
-
     c.find('OnLeftClick').ignore()
     c.find('OnMouseEnter').ignore()
     c.find('OnRightClick').ignore()

--- a/etg/toolbar.py
+++ b/etg/toolbar.py
@@ -100,14 +100,14 @@ def run():
 
     # Add some deprecated methods to aid with Classic compatibility.
     # TODO: Which others are commonly enough used that they should be here too?
-    c.addPyMethod('AddSimpleTool', '(self, toolId, bitmap, shortHelp="", longHelp="", isToggle=0)',
+    c.addPyMethod('AddSimpleTool', '(self, toolId, bitmap, shortHelpString="", longHelpString="", isToggle=0)',
         doc='Old style method to add a tool to the toolbar.',
         deprecated='Use :meth:`AddTool` instead.',
         body="""\
             kind = wx.ITEM_NORMAL
             if isToggle: kind = wx.ITEM_CHECK
             return self.AddTool(toolId, '', bitmap, wx.NullBitmap, kind,
-                                shortHelp, longHelp)
+                                shortHelpString, longHelpString)
             """)
     c.addPyMethod('AddLabelTool',
                   '(self, id, label, bitmap, bmpDisabled=wx.NullBitmap, kind=wx.ITEM_NORMAL,'
@@ -119,14 +119,14 @@ def run():
                                 shortHelp, longHelp, clientData)
             """)
 
-    c.addPyMethod('InsertSimpleTool', '(self, pos, toolId, bitmap, shortHelp="", longHelp="", isToggle=0)',
+    c.addPyMethod('InsertSimpleTool', '(self, pos, toolId, bitmap, shortHelpString="", longHelpString="", isToggle=0)',
         doc='Old style method to insert a tool in the toolbar.',
         deprecated='Use :meth:`InsertTool` instead.',
         body="""\
             kind = wx.ITEM_NORMAL
             if isToggle: kind = wx.ITEM_CHECK
             return self.InsertTool(pos, toolId, '', bitmap, wx.NullBitmap, kind,
-                                   shortHelp, longHelp)
+                                   shortHelpString, longHelpString)
             """)
     c.addPyMethod('InsertLabelTool',
                   '(self, pos, id, label, bitmap, bmpDisabled=wx.NullBitmap, kind=wx.ITEM_NORMAL,'

--- a/etg/toolbar.py
+++ b/etg/toolbar.py
@@ -80,6 +80,11 @@ def run():
     c.find('AddTool.tool').transfer = True
     c.find('InsertTool.tool').transfer = True
 
+    # convert all *HelpString parameters in AddTool to just *Help
+    for h in ('longHelp', 'shortHelp'):
+        for param in c.find('AddTool.{}String'.format(h)):
+            param.name = h
+
     c.find('OnLeftClick').ignore()
     c.find('OnMouseEnter').ignore()
     c.find('OnRightClick').ignore()
@@ -88,14 +93,14 @@ def run():
 
     # Add some deprecated methods to aid with Classic compatibility.
     # TODO: Which others are commonly enough used that they should be here too?
-    c.addPyMethod('AddSimpleTool', '(self, toolId, bitmap, shortHelpString="", longHelpString="", isToggle=0)',
+    c.addPyMethod('AddSimpleTool', '(self, toolId, bitmap, shortHelp="", longHelp="", isToggle=0)',
         doc='Old style method to add a tool to the toolbar.',
         deprecated='Use :meth:`AddTool` instead.',
         body="""\
             kind = wx.ITEM_NORMAL
             if isToggle: kind = wx.ITEM_CHECK
             return self.AddTool(toolId, '', bitmap, wx.NullBitmap, kind,
-                                shortHelpString, longHelpString)
+                                shortHelp, longHelp)
             """)
     c.addPyMethod('AddLabelTool',
                   '(self, id, label, bitmap, bmpDisabled=wx.NullBitmap, kind=wx.ITEM_NORMAL,'
@@ -107,14 +112,14 @@ def run():
                                 shortHelp, longHelp, clientData)
             """)
 
-    c.addPyMethod('InsertSimpleTool', '(self, pos, toolId, bitmap, shortHelpString="", longHelpString="", isToggle=0)',
+    c.addPyMethod('InsertSimpleTool', '(self, pos, toolId, bitmap, shortHelp="", longHelp="", isToggle=0)',
         doc='Old style method to insert a tool in the toolbar.',
         deprecated='Use :meth:`InsertTool` instead.',
         body="""\
             kind = wx.ITEM_NORMAL
             if isToggle: kind = wx.ITEM_CHECK
             return self.InsertTool(pos, toolId, '', bitmap, wx.NullBitmap, kind,
-                                   shortHelpString, longHelpString)
+                                   shortHelp, longHelp)
             """)
     c.addPyMethod('InsertLabelTool',
                   '(self, pos, id, label, bitmap, bmpDisabled=wx.NullBitmap, kind=wx.ITEM_NORMAL,'

--- a/etg/toolbar.py
+++ b/etg/toolbar.py
@@ -9,6 +9,7 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
+from etgtools.extractors import ExtractorError
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -80,10 +81,16 @@ def run():
     c.find('AddTool.tool').transfer = True
     c.find('InsertTool.tool').transfer = True
 
-    # convert all *HelpString parameters in AddTool to just *Help
-    for h in ('longHelp', 'shortHelp'):
-        for param in c.find('AddTool.{}String'.format(h)):
-            param.name = h
+    # Conform the help text parameters.
+    m = c.find('AddTool')
+    for method in m.all():
+        for helper in ('shortHelp', 'longHelp'):
+            try:
+                param = method.find("{}String".format(helper))
+                param.name = helper
+            except ExtractorError:
+                pass
+
 
     c.find('OnLeftClick').ignore()
     c.find('OnMouseEnter').ignore()


### PR DESCRIPTION
Change all *HelpString parameters in ToolBar.AddTool to be consistent internally and with wxPython Classic. 

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's 
     okay to remove the "Fixes #..." below, but be sure to give an even better 
     description of the PR in that case.
     
     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #475 

