### PR TITLE
Ignore the GetVirtualSize in wxScrolled

### DIFF
--- a/etg/scrolwin.py
+++ b/etg/scrolwin.py
@@ -51,8 +51,8 @@ def run():
     scrolled.find('GetScrollPixelsPerUnit.xUnit').out = True
     scrolled.find('GetScrollPixelsPerUnit.yUnit').out = True
 
-    scrolled.find('GetVirtualSize.x').out = True
-    scrolled.find('GetVirtualSize.y').out = True
+    # Just ignore this one and let the already tweaked versions be inherited from wx.Window.
+    scrolled.find('GetVirtualSize').ignore()
 
     scrolled.addPrivateCopyCtor()
     scrolled.addPrivateAssignOp()

--- a/unittests/test_scrolwin.py
+++ b/unittests/test_scrolwin.py
@@ -26,6 +26,9 @@ class scrolwin_Tests(wtc.WidgetTestCase):
         self.assertEqual(w.CalcScrolledPosition( (0,0) ),  (-3*rate,-3*rate)) # pixels
         self.assertEqual(w.CalcUnscrolledPosition( (0,0) ),(3*rate,3*rate))   # pixels
 
+        vs = w.GetVirtualSize()
+        assert isinstance(vs, wx.Size)
+
 
     def test_scrolwinCtor(self):
         w = wx.ScrolledWindow(self.frame)


### PR DESCRIPTION
Fixes #474

