### PR TITLE
Turn "public" back on after emitting some private methods

### DIFF
--- a/etg/dataobj.py
+++ b/etg/dataobj.py
@@ -132,6 +132,7 @@ def addBaseVirtuals(c):
         private:
         virtual size_t GetDataSize(const wxDataFormat& format) const;
         virtual bool   GetDataHere(const wxDataFormat& format, void* buf) const;
+        public:
         """))
 
 

--- a/etg/dataobj.py
+++ b/etg/dataobj.py
@@ -376,12 +376,12 @@ def run():
     c.bases = ['wxDataObject']
 
     addGetAllFormats(c)
+    addBaseVirtuals(c)
 
     # It also causes mismatches regarding what virtuals are available
-    # in the base classes. For now just ignore them for this class, if
-    # they are needed then something more creative will need to be
-    # done.
-    #addBaseVirtuals(c)
+    # in the base classes. For now just ignore them for this class. If
+    # they really are needed then something more creative will need to
+    # be done.
     #addSimpleVirtuals(c)
 
 

--- a/etg/dataobj.py
+++ b/etg/dataobj.py
@@ -376,8 +376,13 @@ def run():
     c.bases = ['wxDataObject']
 
     addGetAllFormats(c)
-    addBaseVirtuals(c)
-    addSimpleVirtuals(c)
+
+    # It also causes mismatches regarding what virtuals are available
+    # in the base classes. For now just ignore them for this class, if
+    # they are needed then something more creative will need to be
+    # done.
+    #addBaseVirtuals(c)
+    #addSimpleVirtuals(c)
 
 
     #------------------------------------------------------------

--- a/etg/window.py
+++ b/etg/window.py
@@ -63,7 +63,7 @@ def run():
     # We now return you to our regularly scheduled programming...
     c.includeCppCode('src/window_ex.cpp')
 
-    # ignore some overloads that will be ambiguous afer wrapping
+    # ignore some overloads that will be ambiguous after wrapping
     c.find('GetChildren').overloads = []
     c.find('GetChildren').noCopy = True
     for name in ['GetVirtualSize',

--- a/unittests/test_dataobj.py
+++ b/unittests/test_dataobj.py
@@ -254,6 +254,7 @@ class DataObjTests(wtc.WidgetTestCase):
         data1 = list(range(10))
         obj = wx.CustomDataObject('my custom format')
         obj.SetData(pickle.dumps(data1))
+        assert obj.GetDataSize() > 0
         data2 = pickle.loads(obj.GetData().tobytes())
         self.assertEqual(data1, data2)
 


### PR DESCRIPTION
Turn "public" back on after emitting some private methods

Fixes #480

