### PR TITLE
Add missing DeleteAllColumns

### DIFF
--- a/unittests/test_listctrl.py
+++ b/unittests/test_listctrl.py
@@ -194,6 +194,11 @@ class listctrl_Tests(wtc.WidgetTestCase):
             lc.SetItemData(0, wx._core._LONG_MAX + 100)
 
 
+    def test_listctrlDeleteAllColumns(self):
+        lc = self._makeListCtrl()
+        lc.DeleteAllColumns()
+
+
 #---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Update wxWidgets to add `DeleteAllColumns` in the interface, and pull that revision here.

Fixes #486

