### PR TITLE
Fix test_grid42 failure

### DIFF
--- a/unittests/test_grid.py
+++ b/unittests/test_grid.py
@@ -316,10 +316,10 @@ class grid_Tests(wtc.WidgetTestCase):
 
     def test_grid42(self):
         # old names
-        wx.grid.Grid.GridSelectCells
-        wx.grid.Grid.GridSelectRows
-        wx.grid.Grid.GridSelectColumns
-        wx.grid.Grid.GridSelectRowsOrColumns
+        wx.grid.Grid.wxGridSelectCells
+        wx.grid.Grid.wxGridSelectRows
+        wx.grid.Grid.wxGridSelectColumns
+        wx.grid.Grid.wxGridSelectRowsOrColumns
 
 
     def test_grid43(self):


### PR DESCRIPTION
Fixes:
```
____________________________ grid_Tests.test_grid42 ____________________________
self = <unittests.test_grid.grid_Tests testMethod=test_grid42>

    def test_grid42(self):
        # old names
>       wx.grid.Grid.GridSelectCells
E       AttributeError: type object 'Grid' has no attribute 'GridSelectCells'

unittests/test_grid.py:319: AttributeError
```
