### PR TITLE
Use functools.cmp_to_key for sorting customtreectrl children

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,6 +70,8 @@ Changes in this release include the following:
 
 * Add wx.Simplebook class.
 
+* Fix exception in wx.lib.agw.customtreectrl when calling SortChildren. (#463,
+  #500)
 
 
 

--- a/wx/lib/agw/customtreectrl.py
+++ b/wx/lib/agw/customtreectrl.py
@@ -5935,8 +5935,8 @@ class CustomTreeCtrl(wx.ScrolledWindow):
 
         if len(children) > 1:
             self._dirty = True
-            children = six.sort(children, self.OnCompareItems)
-            item._children = children
+            from functools import cmp_to_key
+            children.sort(key=cmp_to_key(self.OnCompareItems))
 
 
     def GetImageList(self):


### PR DESCRIPTION
Fixes #463, #500

