### PR TITLE
Fix for list.sort requiring keywords in python3.5

### DIFF
--- a/wx/lib/agw/ribbon/bar.py
+++ b/wx/lib/agw/ribbon/bar.py
@@ -766,7 +766,7 @@ class RibbonBar(RibbonControl):
                         # Sneaky obj array trickery to not copy the tab descriptors
                         sorted_pages.append(info)
 
-                    sorted_pages.sort(self.OrderPageTabInfoBySmallWidthAsc)
+                    sorted_pages.sort(key=self.OrderPageTabInfoBySmallWidthAsc)
                     width -= tabsep*(numtabs - 1)
 
                     for i, info in enumerate(self._pages):

--- a/wx/lib/agw/ribbon/bar.py
+++ b/wx/lib/agw/ribbon/bar.py
@@ -96,6 +96,7 @@ See Also
 
 
 import wx
+from functools import cmp_to_key
 
 import six
 
@@ -766,7 +767,7 @@ class RibbonBar(RibbonControl):
                         # Sneaky obj array trickery to not copy the tab descriptors
                         sorted_pages.append(info)
 
-                    sorted_pages.sort(key=self.OrderPageTabInfoBySmallWidthAsc)
+                    sorted_pages.sort(key=cmp_to_key(self.OrderPageTabInfoBySmallWidthAsc))
                     width -= tabsep*(numtabs - 1)
 
                     for i, info in enumerate(self._pages):

--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -236,6 +236,7 @@ import wx
 import math
 import bisect
 import zlib
+from functools import cmp_to_key
 
 import six
 
@@ -10406,7 +10407,7 @@ class UltimateListMainWindow(wx.ScrolledWindow):
         else:
             self.__func = func
 
-        self._lines.sort(key=self.OnCompareItems)
+        self._lines.sort(key=cmp_to_key(self.OnCompareItems))
 
         if self.IsShownOnScreen():
             self._dirty = True

--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -10406,7 +10406,7 @@ class UltimateListMainWindow(wx.ScrolledWindow):
         else:
             self.__func = func
 
-        self._lines.sort(self.OnCompareItems)
+        self._lines.sort(key=self.OnCompareItems)
 
         if self.IsShownOnScreen():
             self._dirty = True

--- a/wx/lib/docview.py
+++ b/wx/lib/docview.py
@@ -2219,7 +2219,7 @@ class DocManager(wx.EvtHandler):
         if sort:
             def tempcmp(a, b):
                 return cmp(a.GetDescription(), b.GetDescription())
-            templates.sort(tempcmp)
+            templates.sort(key=tempcmp)
 
         strings = []
         for temp in templates:
@@ -2259,7 +2259,7 @@ class DocManager(wx.EvtHandler):
         if sort:
             def tempcmp(a, b):
                 return cmp(a.GetViewTypeName(), b.GetViewTypeName())
-            templates.sort(tempcmp)
+            templates.sort(key=tempcmp)
 
         res = wx.GetSingleChoiceIndex(_("Select a document view:"),
                                       _("Views"),

--- a/wx/lib/docview.py
+++ b/wx/lib/docview.py
@@ -16,6 +16,7 @@ import os.path
 import shutil
 import wx
 import sys
+from functools import cmp_to_key
 _ = wx.GetTranslation
 
 
@@ -2219,7 +2220,7 @@ class DocManager(wx.EvtHandler):
         if sort:
             def tempcmp(a, b):
                 return cmp(a.GetDescription(), b.GetDescription())
-            templates.sort(key=tempcmp)
+            templates.sort(key=cmp_to_key(tempcmp))
 
         strings = []
         for temp in templates:
@@ -2259,7 +2260,7 @@ class DocManager(wx.EvtHandler):
         if sort:
             def tempcmp(a, b):
                 return cmp(a.GetViewTypeName(), b.GetViewTypeName())
-            templates.sort(key=tempcmp)
+            templates.sort(key=cmp_to_key(tempcmp))
 
         res = wx.GetSingleChoiceIndex(_("Select a document view:"),
                                       _("Views"),

--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -755,7 +755,7 @@ class Shell(editwindow.EditWindow):
         #sort lowercase
         def _cmp(a,b):
             return  ((a > b) - (a < b))
-        unlist.sort(lambda a, b: _cmp(a.lower(), b.lower()))
+        unlist.sort(key=lambda a, b: _cmp(a.lower(), b.lower()))
 
         #this is more convenient, isn't it?
         self.AutoCompSetIgnoreCase(True)

--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -14,6 +14,7 @@ import keyword
 import os
 import sys
 import time
+from functools import cmp_to_key
 
 from .buffer import Buffer
 from . import dispatcher
@@ -755,7 +756,7 @@ class Shell(editwindow.EditWindow):
         #sort lowercase
         def _cmp(a,b):
             return  ((a > b) - (a < b))
-        unlist.sort(key=lambda a, b: _cmp(a.lower(), b.lower()))
+        unlist.sort(key=cmp_to_key(lambda a, b: _cmp(a.lower(), b.lower())))
 
         #this is more convenient, isn't it?
         self.AutoCompSetIgnoreCase(True)

--- a/wx/py/sliceshell.py
+++ b/wx/py/sliceshell.py
@@ -21,6 +21,7 @@ import keyword
 import os
 import sys
 import time
+from functools import cmp_to_key
 
 from .buffer import Buffer
 from . import dispatcher
@@ -2140,7 +2141,7 @@ class SlicesShell(editwindow.EditWindow):
         unlist = [thlist[i] for i in xrange(len(thlist)) if thlist[i] not in thlist[:i]]
 
         #sort lowercase
-        unlist.sort(key=lambda a, b: cmp(a.lower(), b.lower()))
+        unlist.sort(key=cmp_to_key(lambda a, b: cmp(a.lower(), b.lower())))
 
         #this is more convenient, isn't it?
         self.AutoCompSetIgnoreCase(True)

--- a/wx/py/sliceshell.py
+++ b/wx/py/sliceshell.py
@@ -2140,7 +2140,7 @@ class SlicesShell(editwindow.EditWindow):
         unlist = [thlist[i] for i in xrange(len(thlist)) if thlist[i] not in thlist[:i]]
 
         #sort lowercase
-        unlist.sort(lambda a, b: cmp(a.lower(), b.lower()))
+        unlist.sort(key=lambda a, b: cmp(a.lower(), b.lower()))
 
         #this is more convenient, isn't it?
         self.AutoCompSetIgnoreCase(True)


### PR DESCRIPTION
Fixes #508

Python3.5 changed the parameters in list.sort to be keyword only arguments.
This fixes all the instances I could find.
