### PR TITLE
PGEditorDialogAdapter.GetEditorDialog is a factory function,

### DIFF
--- a/etg/propgridproperty.py
+++ b/etg/propgridproperty.py
@@ -114,6 +114,7 @@ def run():
         doc="Alias for :meth:`SetClientData`",
         body="self.SetClientData(n, data)")
 
+    c.find('GetEditorDialog').factory = True
 
 
     c = module.find('wxPGChoicesData')


### PR DESCRIPTION
PGEditorDialogAdapter.GetEditorDialog is a factory function, mark it as such so the ownership of the returned value is handled correctly.

Fixes #544

