### PR TITLE
Enable wxArray wrappers to return a copy from __getitem__.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,12 @@ Changes in this release include the following:
   in wx.DropTarget.OnData. (#550) Also fixed the CustomDragAndDrop sample to
   not fail on Python 2.7.
 
+* Add ability for wxArray wrappers to return a copy of the item in the
+  ``__getitem__`` method. This solves problems where an array that is the
+  return value of some method call is indexed immediately and a reference to
+  the array is not held, which could result in garbage values for the indexed
+  item. Currently this is turned on for just GridCellCoordsArray, but others
+  can be switched in the future if needed. (#297)
 
 
 

--- a/etg/grid.py
+++ b/etg/grid.py
@@ -122,7 +122,8 @@ def run():
     c.addPyCode('GridCellCoords.__safe_for_unpickling__ = True')
 
     module.addItem(
-        tools.wxArrayWrapperTemplate('wxGridCellCoordsArray', 'wxGridCellCoords', module))
+        tools.wxArrayWrapperTemplate('wxGridCellCoordsArray', 'wxGridCellCoords', module,
+                                     getItemCopy=True))
 
 
     #-----------------------------------------------------------------

--- a/unittests/test_grid.py
+++ b/unittests/test_grid.py
@@ -341,6 +341,31 @@ class grid_Tests(wtc.WidgetTestCase):
         assert obj == obj2
 
 
+    def test_grid44(self):
+        g = wx.grid.Grid(self.frame)
+        g.CreateGrid(10,10)
+        g.SelectBlock((1,1), (5,5))
+
+        tl = g.GetSelectionBlockTopLeft()
+        br = g.GetSelectionBlockBottomRight()
+
+        assert tl[0].Get() == (1,1)
+        assert br[0].Get() == (5,5)
+
+
+    def test_grid45(self):
+        # See issue #297
+        g = wx.grid.Grid(self.frame)
+        g.CreateGrid(10,10)
+        g.SelectBlock((1,1), (5,5))
+
+        tl = g.GetSelectionBlockTopLeft()[0]
+        br = g.GetSelectionBlockBottomRight()[0]
+
+        assert tl.Get() == (1,1)
+        assert br.Get() == (5,5)
+
+
 #---------------------------------------------------------------------------
 
 if __name__ == '__main__':


### PR DESCRIPTION
This solves problems where an array that is the return value of some method call is indexed immediately and a reference to the array is not held, which could result in garbage values for the indexed item. Currently this is turned on for just GridCellCoordsArray, but others can be switched in the future if needed.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's 
     okay to remove the "Fixes #..." below, but be sure to give an even better 
     description of the PR in that case.
     
     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #297

