### PR TITLE
Fix TypeError in samples/hello.py

### DIFF
--- a/samples/simple/hello.py
+++ b/samples/simple/hello.py
@@ -15,7 +15,7 @@ st = wx.StaticText(pnl, pos=(15,40),
 st.SetFont(wx.FFont(10, wx.FONTFAMILY_SWISS, wx.FONTFLAG_BOLD))
 
 bmp = wx.Bitmap(os.path.join(os.path.dirname(__file__), 'phoenix_main.png'))
-sb = wx.StaticBitmap(pnl, label=bmp, pos=(15,85))
+sb = wx.StaticBitmap(pnl, bitmap=bmp, pos=(15,85))
 
 frm.Show()
 app.MainLoop()


### PR DESCRIPTION
The call to wx.StaticBitmap in hello.py produces a TypeError. The argument should be 'bitmap=bmp' not 'label=bmp'

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's 
     okay to remove the "Fixes #..." below, but be sure to give an even better 
     description of the PR in that case.
     
     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #NNNN

