### PR TITLE
Fix GetExtWildcard to return the output arg

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,6 +48,9 @@ Changes in this release include the following:
   pass a value that is larger than what will fit in that type of integer then
   an OverflowError exception will be raised.
 
+* Fixed wx.richtext.RichTextBuffer.GetExtWildcard to return a tuple of 2
+  values, as was done in Classic. (#594)
+
 
 
 

--- a/etg/richtextbuffer.py
+++ b/etg/richtextbuffer.py
@@ -354,6 +354,30 @@ def run():
 
     c.find('FindHandlerFilenameOrType').pyName = 'FindHandlerByFilename'
 
+    c.find('GetExtWildcard').ignore()
+    c.addCppMethod('PyObject*', 'GetExtWildcard', '(bool combine=false, bool save=false)',
+        doc="""\
+            Gets a wildcard string for the file dialog based on all the currently
+            loaded richtext file handlers, and a list that can be used to map
+            those filter types to the file handler type.""",
+        body="""\
+            wxString wildcards;
+            wxArrayInt types;
+            wildcards = wxRichTextBuffer::GetExtWildcard(combine, save, &types);
+
+            wxPyThreadBlocker blocker;
+            PyObject* list = PyList_New(0);
+            for (size_t i=0; i < types.GetCount(); i++) {
+                PyObject* number = wxPyInt_FromLong(types[i]);
+                PyList_Append(list, number);
+                Py_DECREF(number);
+            }
+            PyObject* tup = PyTuple_New(2);
+            PyTuple_SET_ITEM(tup, 0, wx2PyString(wildcards));
+            PyTuple_SET_ITEM(tup, 1, list);
+            return tup;
+            """,
+        isStatic=True)
 
     #-------------------------------------------------------
     c = module.find('wxRichTextTable')


### PR DESCRIPTION
Fix GetExtWildcard to return the output arg in a tuple with the return value, like in Classic.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's 
     okay to remove the "Fixes #..." below, but be sure to give an even better 
     description of the PR in that case.
     
     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #594

