### PR TITLE
10.13 OS X SDK fix

### DIFF
--- a/buildtools/build_wxwidgets.py
+++ b/buildtools/build_wxwidgets.py
@@ -293,8 +293,7 @@ def main(wxDir, args):
                             ]
 
         if sys.platform.startswith("darwin"):
-            #wxpy_configure_opts.append("--enable-monolithic")
-            pass
+            wxpy_configure_opts.append("--with-macosx-version-min=10.6")
         else:
             wxpy_configure_opts.append("--with-sdl")
 


### PR DESCRIPTION
Make the min supported OS X version 10.6 to fix compilation issues with the OS X 10.13 SDK. The headers require weak-linking macro support that only exists on 10.6+.