### PR TITLE
 wx/lib/mixins/listctrl.py - change to CheckListCtrlMixin.CheckItem()

### DIFF
--- a/wx/lib/mixins/listctrl.py
+++ b/wx/lib/mixins/listctrl.py
@@ -800,12 +800,12 @@ class CheckListCtrlMixin(object):
     def IsChecked(self, index):
         return self.GetItem(index).GetImage() == 1
 
-    def CheckItem(self, index, check = True):
+    def CheckItem(self, index, check=True):
         img_idx = self.GetItem(index).GetImage()
-        if img_idx == 0 and check is True:
+        if img_idx == 0 and check:
             self.SetItemImage(index, 1)
             self.OnCheckItem(index, True)
-        elif img_idx == 1 and check is False:
+        elif img_idx == 1 and not check:
             self.SetItemImage(index, 0)
             self.OnCheckItem(index, False)
 


### PR DESCRIPTION
As it stands, unless the **check** parameter passed to this public method has the value _True_ or _False_ the intended actions do not occur, defeating the efforts of old fogeys like myself who still tend to use 0 and 1 as boolean constants. The changes are in line with the consensus (I think) of the recent interminable thread on the subject in comp.lang.python.
