### PR TITLE
Fix comparing TreeListItem __eq__ and __ne__

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -51,6 +51,12 @@ Changes in this release include the following:
 * Fixed wx.richtext.RichTextBuffer.GetExtWildcard to return a tuple of 2
   values, as was done in Classic. (#594)
 
+* Various fixes in UltimateListCtrl, HyperTreeList and CheckListCtrlMixin. 
+  (#592, #349, #612)
+
+
+
+
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -54,6 +54,8 @@ Changes in this release include the following:
 * Various fixes in UltimateListCtrl, HyperTreeList and CheckListCtrlMixin. 
   (#592, #349, #612)
 
+* Fix comparing DataViewItem and TreeListItem objects with None. (#595)
+
 
 
 

--- a/etg/treelist.py
+++ b/etg/treelist.py
@@ -51,9 +51,10 @@ def run():
         return (long)self->GetID();
         """)
 
-    c.addCppMethod('bool', '__eq__', '(wxTreeListItem* other)', "return (self->GetID() == other->GetID());")
-    c.addCppMethod('bool', '__ne__', '(wxTreeListItem* other)', "return (self->GetID() != other->GetID());")
-
+    c.addCppMethod('bool', '__eq__', '(wxTreeListItem* other)',
+                   "return other ? (self->GetID() == other->GetID()) : false;")
+    c.addCppMethod('bool', '__ne__', '(wxTreeListItem* other)',
+                   "return other ? (self->GetID() != other->GetID()) : true;")
 
     #-----------------------------------------------------------------
     c = module.find('wxTreeListItemComparator')


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's 
     okay to remove the "Fixes #..." below, but be sure to give an even better 
     description of the PR in that case.
     
     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #595

