### PR TITLE
Fix our wxEvtHandler::Disconnect replacement

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -64,6 +64,9 @@ Changes in this release include the following:
 * The wx.MessageDialog methods which take ButtonLabel parameters are now able
   to accept either strings or stock IDs. (#607, #276)
 
+* Fix wx.EvtHandler.Unbind to work correctly when specifying the handler and
+  it is a bound method. (#624)
+
 
 
 

--- a/etg/event.py
+++ b/etg/event.py
@@ -128,7 +128,7 @@ def run():
                 body="""\
                     success = 0
                     for et in self.evtType:
-                        success += target.Disconnect(id1, id2, et, handler)
+                        success += int(target.Disconnect(id1, id2, et, handler))
                     return success != 0
                     """),
 
@@ -196,8 +196,7 @@ def run():
         body="""\
             if (PyCallable_Check(func)) {
                 self->Connect(id, lastId, eventType,
-                              (wxObjectEventFunction)(wxEventFunction)
-                              &wxPyCallback::EventThunker,
+                              (wxObjectEventFunction)&wxPyCallback::EventThunker,
                               new wxPyCallback(func));
             }
             else if (func == Py_None) {
@@ -219,7 +218,7 @@ def run():
         body="""\
             if (func && func != Py_None) {
                 // Find the current matching binder that has this function
-                // pointer and dissconnect that one.  Unfortuneatly since we
+                // pointer and disconnect that one.  Unfortunately since we
                 // wrapped the PyObject function pointer in another object we
                 // have to do the searching ourselves...
                 wxList::compatibility_iterator node = self->GetDynamicEventTable()->GetFirst();
@@ -229,12 +228,15 @@ def run():
                     if ((entry->m_id == id) &&
                         ((entry->m_lastId == lastId) || (lastId == wxID_ANY)) &&
                         ((entry->m_eventType == eventType) || (eventType == wxEVT_NULL)) &&
-                        // FIXME?
-                        //((entry->m_fn->IsMatching((wxObjectEventFunction)(wxEventFunction)&wxPyCallback::EventThunker))) &&
+                        entry->m_fn->IsMatching(wxObjectEventFunctor((wxObjectEventFunction)&wxPyCallback::EventThunker, NULL)) &&
                         (entry->m_callbackUserData != NULL))
                     {
+                        wxPyThreadBlocker block;
                         wxPyCallback *cb = (wxPyCallback*)entry->m_callbackUserData;
-                        if (cb->m_func == func) {
+                        // NOTE: Just comparing PyObject pointers is not enough, as bound 
+                        // methods can result in different PyObjects each time obj.Method 
+                        // is evaluated. (!!!)
+                        if (PyObject_RichCompareBool(cb->m_func, func, Py_EQ) == 1) {
                             delete cb;
                             self->GetDynamicEventTable()->Erase(node);
                             delete entry;
@@ -247,8 +249,7 @@ def run():
             }
             else {
                 return self->Disconnect(id, lastId, eventType,
-                                        (wxObjectEventFunction)
-                                        &wxPyCallback::EventThunker);
+                                        (wxObjectEventFunction)&wxPyCallback::EventThunker);
             }
         """)
 


### PR DESCRIPTION
 * Fix C++ compare of the handler functor
 * Use PyObject_RichCompare to check for matching python handlers

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's 
     okay to remove the "Fixes #..." below, but be sure to give an even better 
     description of the PR in that case.
     
     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #624 

