### PR TITLE
Fix MSys2/mingw32 build error caused by typo in buildtools/config.py

### DIFF
--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -198,7 +198,7 @@ class Configuration(object):
 
         #---------------------------------------
         # Posix (wxGTK, wxMac or mingw32) settings
-        elif os.name == 'posix' or COMPILER == 'mingw32':
+        elif os.name == 'posix' or self.COMPILER == 'mingw32':
             self.Verify_WX_CONFIG()
             self.includes += ['include']
             self.defines = [ #('NDEBUG',),  # using a 1-tuple makes it do an undef


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's 
     okay to remove the "Fixes #..." below, but be sure to give an even better 
     description of the PR in that case.
     
     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #643

