### PR TITLE
Fix to allow '=' char in caption or name of AUI pane

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -5332,7 +5332,7 @@ class AuiManager(wx.EvtHandler):
         options = pane_part.split(";")
         for items in options:
 
-            val_name, value = items.split("=")
+            val_name, value = items.split("=", 1)
             val_name = val_name.strip()
 
             if val_name == "name":


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's 
     okay to remove the "Fixes #..." below, but be sure to give an even better 
     description of the PR in that case.
     
     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #660 

