### PR TITLE
Fix wx.dataview.TreeListCtrl.DeleteAllItems on GTK3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -101,6 +101,9 @@ Changes in this release include the following:
   default style flag you'll need to pass it to the agwStyle parameter instead
   of the style parameter.
 
+* Fix crash when deleting all wx.dataview.TreeListCtrl items with wxGTK3.
+  (#679)
+
 
 
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #679

