### PR TITLE
Copy methods from wxGenericProgressDialog to wxProgressDialog.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -106,7 +106,8 @@ Changes in this release include the following:
 
 * Fix displaying '&' in the label of wx.RadioBox on GTK. (#39)
 
-
+* Fix problems of the wrong C++ method being called in wx.ProgressDialog on MS
+  Windows. (#701)
 
 
 

--- a/etg/progdlg.py
+++ b/etg/progdlg.py
@@ -9,6 +9,7 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
+import copy
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -34,7 +35,7 @@ def run():
 
     module.addHeaderCode("#include <wx/progdlg.h>")
 
-    c = module.find('wxGenericProgressDialog')
+    c = gpd = module.find('wxGenericProgressDialog')
     assert isinstance(c, etgtools.ClassDef)
 
     tools.fixWindowClass(c)#, False)
@@ -46,6 +47,18 @@ def run():
 
     c = module.find('wxProgressDialog')
     tools.fixWindowClass(c)
+
+    # Copy methods from the generic to the native class. This is needed
+    # because none of the methods are declared in the interface files, and
+    # since on MSW some non-virtual methods are reimplemented in
+    # wxProgressDialogs they will not be called if SIP doesn't know about
+    # them. We'll copy all of them and let the C++ compiler sort things out.
+    for item in gpd:
+        if (isinstance(item, etgtools.MethodDef) and
+                not item.isCtor and
+                not item.isDtor):
+            c.addItem(copy.deepcopy(item))
+
 
     #-----------------------------------------------------------------
     tools.doCommonTweaks(module)


### PR DESCRIPTION
This is needed because some of the methods are non-virtual, and they are reimplemented in the MSW version of wxProgressDialog. In order for those methods to be called they need to have wrappers generated.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #701

