### PR TITLE
Don't call CleanUpModules when reinitializing wxModules

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -215,6 +215,9 @@ Changes in this release include the following:
   can be handy in the rare cases where something holds on to a DC for too
   long, perhaps unintentionally. (#680)
 
+* Fixed crash due to too aggressive management of wxModules when we load
+  subordinate extensions that have their own wxModules (wx.html, wx.adv, etc.)
+  (#688)
 
 
 

--- a/src/wxpy_api.sip
+++ b/src/wxpy_api.sip
@@ -549,10 +549,22 @@ inline PyObject* i_wxPyMethod_Self(PyObject* method) {
 
 void i_wxPyReinitializeModules() {
     if (i_wxPyCheckForApp(false)) {
-        wxModule::CleanUpModules();
+        // NOTE: We are intentionally NOT calling wxModule::CleanUpModules
+        // here because that could clear some things that will not be reset
+        // when used again, leading to crashes. For example, in
+        // wxMSWDCImpl::DoGradientFillLinear it is saving a pointer to an API
+        // function in a dyn-loaded DLL. When modules are cleaned up then that
+        // DLL will be unloaded, leaving a dangling function pointer.  We'll
+        // likely end up with multiple instances of some things, but that is
+        // better than the alternaive currently.
+        //wxModule::CleanUpModules();
+
         wxModule::RegisterModules();
         wxModule::InitializeModules();
-        wxInitAllImageHandlers();
+
+        // And since we're not calling CleanUpModules there is no longer any
+        // need to re-init the image handlers.
+        //wxInitAllImageHandlers();
     }
 }
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

There is at least one wxModule that can cause later crashes if they are cleaned and then used again later (in this case there's a dangling function pointer to a DLL that has been unloaded) so don't clean them up. This may result in some extra instances of some things but it's better than the alternative.

Fixes #688 

