### PR TITLE
Phoenix compatibility in pywxrc

### DIFF
--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -213,7 +213,7 @@ class xrc%(windowName)s(wx.%(windowClass)s):
 
 def __init_resources():
     global __res
-    __res = xrc.EmptyXmlResource()
+    __res = xrc.XmlResource()
 """
 
     LOAD_RES_FILE = """\

--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -62,7 +62,7 @@ def get_resources():
     CLASS_HEADER = """\
 class xrc%(windowName)s(wx.%(windowClass)s):
 #!XRCED:begin-block:xrc%(windowName)s.PreCreate
-    def PreCreate(self, pre):
+    def PreCreate(self):
         \"\"\" This function is called during the class's initialization.
 
         Override it for custom setup before the window is created usually to
@@ -75,7 +75,7 @@ class xrc%(windowName)s(wx.%(windowClass)s):
     def __init__(self, parent):
         # Two stage creation (see http://wiki.wxpython.org/index.cgi/TwoStageCreation)
         wx.%(windowClass)s.__init__(self)
-        self.PreCreate(self)
+        self.PreCreate()
         get_resources().Load%(windowClass)s(self, parent, "%(windowName)s")
 
         # Define variables for the controls, bind event handlers

--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -74,10 +74,9 @@ class xrc%(windowName)s(wx.%(windowClass)s):
 
     def __init__(self, parent):
         # Two stage creation (see http://wiki.wxpython.org/index.cgi/TwoStageCreation)
-        pre = wx.Pre%(windowClass)s()
-        self.PreCreate(pre)
-        get_resources().LoadOn%(windowClass)s(pre, parent, "%(windowName)s")
-        self.PostCreate(pre)
+        wx.%(windowClass)s.__init__(self)
+        self.PreCreate(self)
+        get_resources().Load%(windowClass)s(self, parent, "%(windowName)s")
 
         # Define variables for the controls, bind event handlers
 """
@@ -86,8 +85,7 @@ class xrc%(windowName)s(wx.%(windowClass)s):
 class %(subclass)s(wx.%(windowClass)s):
     def __init__(self):
         # Two stage creation (see http://wiki.wxpython.org/index.cgi/TwoStageCreation)
-        pre = wx.Pre%(windowClass)s()
-        self.PostCreate(pre)
+        wx.%(windowClass)s.__init__(self)
         self.Bind(wx.EVT_WINDOW_CREATE, self.OnCreate)
 
 #!XRCED:begin-block:%(subclass)s._PostInit


### PR DESCRIPTION
These changes should make pywxrc's generated python output actually work with the Phoenix version.  Tested with the pywxrc_demo files from https://wiki.wxpython.org/pywxrc.

As those demo files do not leverage every code path in pywxrc, there are probably more changes needed to fix other migration issues.