### PR TITLE
Don't use string exceptions

### DIFF
--- a/demo/agw/FoldPanelBar.py
+++ b/demo/agw/FoldPanelBar.py
@@ -501,7 +501,7 @@ class Extended(wx.Frame):
             style.SetCaptionStyle(fpb.CAPTIONBAR_FILLED_RECTANGLE)
 
         else:
-            raise "ERROR: Undefined Style Selected For CaptionBar: " + repr(eventid)
+            raise ValueError("Undefined Style Selected For CaptionBar: " + repr(eventid))
 
         col1 = wx.Colour(self._rslider1.GetValue(), self._gslider1.GetValue(),
                          self._bslider1.GetValue())

--- a/wx/lib/ogl/basic.py
+++ b/wx/lib/ogl/basic.py
@@ -2051,7 +2051,7 @@ class Shape(ShapeEvtHandler):
             shoulder1[1] = neck[1] - totalBranchLength / 2.0
             shoulder2[1] = neck[1] + totalBranchLength / 2.0
         else:
-            raise "Unrecognised attachment point in GetBranchingAttachmentInfo"
+            raise ValueError("Unrecognised attachment point in GetBranchingAttachmentInfo")
         return root, neck, shoulder1, shoulder2
 
     def GetBranchingAttachmentPoint(self, attachment, n):
@@ -2093,7 +2093,7 @@ class Shape(ShapeEvtHandler):
             stemPt[0] = neck[0]
             stemPt[1] = pt[1]
         else:
-            raise "Unrecognised attachment point in GetBranchingAttachmentPoint"
+            raise ValueError("Unrecognised attachment point in GetBranchingAttachmentPoint")
 
         return pt, stemPt
 
@@ -2140,7 +2140,7 @@ class Shape(ShapeEvtHandler):
             root[0] = self.GetX() - width / 2.0
             root[1] = self.GetY()
         else:
-            raise "Unrecognised attachment point in GetBranchingAttachmentRoot"
+            raise ValueError("Unrecognised attachment point in GetBranchingAttachmentRoot")
 
         return root
 


### PR DESCRIPTION
This is mostly untested. Sorry!

[String exceptions have been removed in Python 2.6](https://docs.python.org/2/whatsnew/2.6.html#deprecations-and-removals).
Attempting to raise them causes `TypeError`.

These bugs were found using [pydiatra](https://github.com/jwilk/pydiatra).