### PR TITLE
Explicitly zero-terminate the array used for the GLCanvas attribute list.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,8 @@ Changes in this release include the following:
   disappearing in 4.1 so it's important to ensure they are deprecated at
   runtime too instead of just in the docs. (#749)
 
+* Ensure that the attribute list given to the GLCanvas constructor is
+  zero-terminated like it was in Classic. (#770)
 
 
 

--- a/etg/_glcanvas.py
+++ b/etg/_glcanvas.py
@@ -88,8 +88,10 @@ def run():
         pyArgsString="(parent, id=wx.ID_ANY, attribList=None, pos=wx.DefaultPosition, size=wx.DefaultSize, style=0, name='GLCanvas', palette=wx.NullPalette)",
         body="""\
             const int* attribPtr = NULL;
-            if (attribList)
+            if (attribList) {
+                attribList->push_back(0); // ensure it is zero-terminated
                 attribPtr = &attribList->front();
+            }
             sipCpp = new sipwxGLCanvas(parent, id, attribPtr, *pos, *size, style, *name, *palette);
             """,
         noDerivedCtor=False,
@@ -100,8 +102,10 @@ def run():
     m.find('attribList').type = 'wxArrayInt*'
     m.setCppCode_sip("""\
         const int* attribPtr = NULL;
-        if (attribList)
+        if (attribList) {
+            attribList->push_back(0); // ensure it is zero-terminated
             attribPtr = &attribList->front();
+        }
         sipRes = wxGLCanvas::IsDisplaySupported(attribPtr);
         """)
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #770

