### PR TITLE
Enable injecting wxClassInfo macros into the sip generated classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,6 +75,10 @@ Changes in this release include the following:
   since otherwise it would be caught when child windows are destroyed too,
   which causes problems in this case. (#778)
 
+* Fixed a problem where wx.TreeCtrl.OnCompareItems is not being called in
+  derived classes on Windows. This was due to an optimization that wasn't
+  compatible with how the classes are wrapped. (#774)
+
 
 
 

--- a/wx/lib/buttons.py
+++ b/wx/lib/buttons.py
@@ -192,7 +192,7 @@ class GenButton(wx.Control):
         """
         Override this method in a subclass to initialize any other events that
         need to be bound.  Added so :meth:`__init__` doesn't need to be
-        overriden, which is complicated with multiple inheritance.
+        overridden, which is complicated with multiple inheritance.
         """
 
         pass


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #774

