### PR TITLE
Modified build.py to not produce usage() output when specifying python version or python path (XOR)

### DIFF
--- a/build.py
+++ b/build.py
@@ -165,7 +165,7 @@ def main(args):
     if not os.path.exists(wxpydir):
         os.makedirs(wxpydir)
 
-    if not args or 'help' in args or '--help' in args or '-h' in args:
+    if not havePyVer ^ havePyPath or 'help' in args or '--help' in args or '-h' in args:
         usage()
         sys.exit(1)
 
@@ -214,6 +214,8 @@ def setPythonVersion(args):
     global PYSHORTVER
     global PYTHON
     global PYTHON_ARCH
+    global havePyVer
+    global havePyPath
 
     havePyVer = False
     havePyPath = False


### PR DESCRIPTION
Made havePyVer and havePyPath in the setPythonVersion function global, and modified the if statement in main to check if either one of these variables were set. It seemed that 'if not args' within that statement was redundant and negated the xor check, so removed.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #805

