### PR TITLE
Change winid parameter in wx.ScrolledWindow to id, for consistency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -67,6 +67,9 @@ Changes in this release include the following:
 
 * Fix wxGet to be able to use pip v10. (#817)
 
+* Change winid parameter in wx.ScrolledWindow to id, for consistency. (#816)
+
+
 
 
 

--- a/etg/scrolwin.py
+++ b/etg/scrolwin.py
@@ -116,7 +116,7 @@ def run():
                 overloads=[
                     MethodDef(name='wxScrolledWindow', isCtor=True, items=[
                         ParamDef(name='parent', type='wxWindow*'),
-                        ParamDef(name='winid', type='wxWindowID', default='wxID_ANY'),
+                        ParamDef(name='id', type='wxWindowID', default='wxID_ANY'),
                         ParamDef(name='pos', type='const wxPoint&', default='wxDefaultPosition'),
                         ParamDef(name='size', type='const wxSize&', default='wxDefaultSize'),
                         ParamDef(name='style', type='long', default='wxScrolledWindowStyle'),


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #816

