### PR TITLE
Fix wx.TextCompleterSimple.GetCompletions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,9 @@ Changes in this release include the following:
 * Ensure that the page exists in book controls GetPage and RemovePage methods.
   At least one of the wx ports do not do this. (#830)
 
+* Change wx.TextCompleterSimple.GetCompletions to send the list of strings
+  as a return value, rather than a parameter that gets filled. (#836)
+
 
 
 

--- a/etg/textcompleter.py
+++ b/etg/textcompleter.py
@@ -42,8 +42,9 @@ def run():
     c.copyFromClass(tc, 'Start')
     c.copyFromClass(tc, 'GetNext')
 
-    # TODO: Change GetCompletions to return the wxArrayString instead of
-    # passing it as a parameter?
+    # Change GetCompletions to return the wxArrayString instead of passing it
+    # as a parameter
+    c.find('GetCompletions.res').out = True
 
 
     #-----------------------------------------------------------------

--- a/unittests/test_textcompleter.py
+++ b/unittests/test_textcompleter.py
@@ -27,9 +27,11 @@ class testcompleter_Tests(wtc.WidgetTestCase):
         class MyTextCompleterSimple(wx.TextCompleterSimple):
             def __init__(self):
                 wx.TextCompleterSimple.__init__(self)
-            def GetCompletions(self, prefix, res):
+            def GetCompletions(self, prefix):
+                res = []
                 res.append("one")
                 res.append("two")
+                return res
         t = wx.TextCtrl(self.frame)
         t.AutoComplete(MyTextCompleterSimple())
 


### PR DESCRIPTION
Change wx.TextCompleterSimple.GetCompletions to send the list of strings as a return value, rather than a parameter that gets filled.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #836

