### PR TITLE
Fix a bug in setting AuiDockingGuide size.

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -2263,9 +2263,9 @@ class AuiSingleDockingGuide(AuiDockingGuide):
             else:
                 self.SetGuideShape()
 
-            self.SetSize(self.region.GetBox().GetSize())
+            self.SetClientSize(self.region.GetBox().GetSize())
         else:
-            self.SetSize((sizeX, sizeY))
+            self.SetClientSize((sizeX, sizeY))
 
         self.rect = wx.Rect(0, 0, sizeX, sizeY)
 
@@ -2414,7 +2414,7 @@ class AuiCenterDockingGuide(AuiDockingGuide):
         else:
             self.SetGuideShape()
 
-        self.SetSize(self.region.GetBox().GetSize())
+        self.SetClientSize(self.region.GetBox().GetSize())
 
         self.Bind(wx.EVT_ERASE_BACKGROUND, self.OnEraseBackground)
         self.Bind(wx.EVT_PAINT, self.OnPaint)


### PR DESCRIPTION
Set the client size to be the guide size. Otherwise, it is not shown correctly
on Linux.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #727

