### PR TITLE
Fixing listctrl (+ TextEditMixin) editor with height -1 in GTK

### DIFF
--- a/wx/lib/mixins/listctrl.py
+++ b/wx/lib/mixins/listctrl.py
@@ -612,7 +612,10 @@ class TextEditMixin:
         y0 = self.GetItemRect(row)[1]
 
         editor = self.editor
-        editor.SetSize(x0-scrolloffset,y0, x1,-1)
+        # It was using -1 as editor height, but it was not showing when in
+        # Linux. So it's calculating text height on the fly
+        height = self.editor.GetTextExtent('M')[1]
+        editor.SetSize(x0-scrolloffset,y0, x1, height)
 
         editor.SetValue(self.GetItem(row, col).GetText())
         editor.Show()


### PR DESCRIPTION
It's not possible to edit a listctrl cell value, because the editor has height -1. It's possible to see this error in the **ListCtrl_edit** from wxPython Demo. In the shell it shows this warning message:

`(demo.py:8618): Gtk-WARNING **: 15:34:15.183: Negative content height -1 (allocation 1, extents 1x1) while allocating gadget (node entry, owner GtkEntry)`

What I'm doing here to fix this error is calculating a text height (using self.editor.GetTextExtent('M')) and using this height values and editor height.




