### PR TITLE
Transfer ownership of clientData objects in wx.dataview.DataViewTreeCtrl

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -93,6 +93,9 @@ Changes in this release include the following:
 
 * Fix a bug in setting AuiDockingGuide size. (#727)
 
+* Fixed crashing bug when using client data with items in
+  wx.dataview.DataViewTreeCtrl. (#856)
+
 
 
 

--- a/etg/dataview.py
+++ b/etg/dataview.py
@@ -11,7 +11,7 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
-from etgtools import PyFunctionDef, PyCodeDef, PyPropertyDef
+from etgtools import PyFunctionDef, ParamDef
 
 PACKAGE   = "wx"
 MODULE    = "_dataview"
@@ -525,14 +525,20 @@ def run():
 
 
     #-----------------------------------------------------------------
+    def _setClientDataTrasfer(klass):
+        for item in klass.allItems():
+            if isinstance(item, ParamDef) and item.type == 'wxClientData *':
+                item.transfer = True
+
     c = module.find('wxDataViewTreeCtrl')
     tools.fixWindowClass(c)
+    _setClientDataTrasfer(c)
     c.find('GetStore').overloads = []
-
 
     c = module.find('wxDataViewTreeStore')
     c.addAutoProperties()
     tools.fixRefCountedClass(c)
+    _setClientDataTrasfer(c)
 
 
     #-----------------------------------------------------------------


### PR DESCRIPTION
Fixes #856

