### PR TITLE
Fix a bug in calculating whether a tool fits into the AuiToolBar.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -102,6 +102,7 @@ Changes in this release include the following:
 * Detach wxControl in AuiToolbar from current sizer before attach to a new
   one. (#843)
 
+* Fix a bug in calculating whether a tool fits into the AuiToolBar. (#863)
 
 
 

--- a/wx/lib/agw/aui/auibar.py
+++ b/wx/lib/agw/aui/auibar.py
@@ -2935,11 +2935,12 @@ class AuiToolBar(wx.Control):
 
         cli_w, cli_h = self.GetClientSize()
         rect = self._items[tool_id].sizer_item.GetRect()
+        dropdown_size = self._art.GetElementSize(AUI_TBART_OVERFLOW_SIZE)
 
         if self._agwStyle & AUI_TB_VERTICAL:
             # take the dropdown size into account
             if self._overflow_visible:
-                cli_h -= self._overflow_sizer_item.GetSize().y
+                cli_h -= dropdown_size
 
             if rect.y+rect.height < cli_h:
                 return True
@@ -2948,7 +2949,7 @@ class AuiToolBar(wx.Control):
 
             # take the dropdown size into account
             if self._overflow_visible:
-                cli_w -= self._overflow_sizer_item.GetSize().x
+                cli_w -= dropdown_size
 
             if rect.x+rect.width < cli_w:
                 return True


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #863

