### PR TITLE
Override SetForegroundColour and SetBackgroundColour in MaskedEditMixin

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -107,6 +107,9 @@ Changes in this release include the following:
   
 * Fix a bug in calculating whether a tool fits into the AuiToolBar. (#863)
 
+* Override SetForegroundColour and SetBackgroundColour in MaskedEditMixin (#808)
+
+
 
 
 4.0.1 "Lemonade"

--- a/wx/lib/masked/maskededit.py
+++ b/wx/lib/masked/maskededit.py
@@ -3229,6 +3229,13 @@ class MaskedEditMixin:
 ####        dbg(indent=0)
         return self._fields[self._lookupField[pos]]
 
+    def SetForegroundColour(self, colour):
+        super(MaskedEditMixin, self).SetForegroundColour(colour)
+        self._foregroundColour = colour
+
+    def SetBackgroundColour(self, colour):
+        super(MaskedEditMixin, self).SetBackgroundColour(colour)
+        self._validBackgroundColour = colour
 
     def ClearValue(self):
         """ Blanks the current control value by replacing it with the default value."""


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #808

