### PR TITLE
Return original AGW window style in AuiToolBar.GetAGWWindowStyleFlag.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -109,6 +109,7 @@ Changes in this release include the following:
 
 * Override SetForegroundColour and SetBackgroundColour in MaskedEditMixin (#808)
 
+* Return original AGW window style in AuiToolBar.GetAGWWindowStyleFlag. (#870)
 
 
 

--- a/wx/lib/agw/aui/auibar.py
+++ b/wx/lib/agw/aui/auibar.py
@@ -1706,7 +1706,7 @@ class AuiToolBar(wx.Control):
         :see: :meth:`SetAGWWindowStyleFlag` for an explanation of various AGW-specific style.
         """
 
-        return self._agwStyle
+        return self._originalStyle
 
 
     def SetArtProvider(self, art):


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #870 

