### PR TITLE
Fixes #904, pip install for custom built python, documentation add, prepare for waf 2.0.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -370,6 +370,8 @@ installed, if they are available. For example:
 * libwebkit2gtk-4.0-dev
 * libsdl2-dev
 
+If You use a custom built python in a non standard location, You need to
+compile python with the --enable-shared option.
 
 **Mac OSX**
 
@@ -413,4 +415,3 @@ once per day, on any day that has had a commit to the master branch.
 
 .. image:: docs/phoenix-fire-md.png
    :width: 100%
-

--- a/build.py
+++ b/build.py
@@ -85,6 +85,9 @@ sipMD5 = {
 
 wafCurrentVersion = '2.0.7'
 wafMD5 = '48ac1250bcccd0674cf461937875ce9a'
+# enable this as soon as waf-2.0.8.bz2 is uploaded to https://wxpython.org/tools
+# wafCurrentVersion = '2.0.8'
+# wafMD5 = 'e1df61f724cc50efedbde867026ce4e3'
 
 doxygenCurrentVersion = '1.8.8'
 doxygenMD5 = {

--- a/wscript
+++ b/wscript
@@ -314,7 +314,7 @@ def configure(conf):
         # speicifc Python instance instead of the one that is loading the
         # wxPython extension modules. That's okay for PYEMBED but not for PYEXT
         # configs.  
-        if isDarwin:
+        if not isWindows:
             conf.env.LIBPATH_PYEXT = []
             conf.env.LIB_PYEXT = []
 


### PR DESCRIPTION
Fixes #904

- readme.rst : hint for custom python build to use --option-shared
- wscript : correction to be able to compile for custom built python on linux (correct WAF parameters),
see issue https://github.com/wxWidgets/Phoenix/issues/904
- build.py : prepared for waf 2.0.8
