### PR TITLE
Switch deprecation warnings in wx.lib.plot

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,16 @@ Changes in this release include the following:
 
 * Include the MSVC runtime DLLs for Python 3.7 builds too.
 
+* Added a dependency on the Pillow package since it's used in some wx.lib.agw
+  modules. (PR #908)
+
+* Add flag to hide page in wx.lib.agw.aui.notebook. (#895)
+
+* Switch wx.lib.plot to issue deprecation warnings with PlotPendingDeprecation
+  so it doesn't have to enable all warnings to get them to be shown by default.
+  (#902)
+  
+
 
 
 4.0.3 "The show must go on. (Die show-stoppers! Die!)"

--- a/wx/lib/plot/__init__.py
+++ b/wx/lib/plot/__init__.py
@@ -40,6 +40,7 @@ from .polyobjects import PlotPrintout
 
 from .utils import TempStyle
 from .utils import pendingDeprecation
+from .utils import PlotPendingDeprecation
 
 # For backwards compat.
 BoxPlot = PolyBoxPlot

--- a/wx/lib/plot/polyobjects.py
+++ b/wx/lib/plot/polyobjects.py
@@ -36,10 +36,6 @@ from .utils import TempStyle
 from .utils import pairwise
 
 
-# XXX: Comment out this line to disable deprecation warnings
-warnings.simplefilter('default')
-
-
 class PolyPoints(object):
     """
     Base Class for lines and markers.

--- a/wx/lib/plot/utils.py
+++ b/wx/lib/plot/utils.py
@@ -19,6 +19,7 @@ import itertools
 from warnings import warn as _warn
 
 # Third Party
+import wx
 import numpy as np
 
 class PlotPendingDeprecation(wx.wxPyDeprecationWarning):

--- a/wx/lib/plot/utils.py
+++ b/wx/lib/plot/utils.py
@@ -21,6 +21,8 @@ from warnings import warn as _warn
 # Third Party
 import numpy as np
 
+class PlotPendingDeprecation(wx.wxPyDeprecationWarning):
+    pass
 
 class DisplaySide(object):
     """
@@ -252,7 +254,7 @@ def pendingDeprecation(new_func):
     """
     warn_txt = "`{}` is pending deprecation. Please use `{}` instead."
     _warn(warn_txt.format(inspect.stack()[1][3], new_func),
-          PendingDeprecationWarning)
+          PlotPendingDeprecation)
 
 
 def scale_and_shift_point(x, y, scale=1, shift=0):


### PR DESCRIPTION
Switch wx.lib.plot to use a warning class derived from a new wx.wxPyDeprecationWarning so it doesn't need to enable all warnings by default.

Fixes #902

