### PR TITLE
Update AuiToolBar orientation in AuiManager.DoUpdate

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,7 +33,9 @@ Changes in this release include the following:
 * Switch wx.lib.plot to issue deprecation warnings with PlotPendingDeprecation
   so it doesn't have to enable all warnings to get them to be shown by default.
   (#902)
-  
+
+* Fix an issue in wx.lib.agw.aui.AuiManager where the orientation of
+  an AuiToolBar would not be updated when calling LoadPerspective.
 
 
 

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -6530,7 +6530,7 @@ class AuiManager(wx.EvtHandler):
             else:
 
                 if p.IsToolbar():
-#                    self.SwitchToolBarOrientation(p)
+                    self.SwitchToolBarOrientation(p)
                     p.best_size = p.window.GetBestSize()
 
                 if p.window and not p.IsNotebookPage() and p.window.IsShown() != p.IsShown():


### PR DESCRIPTION
AuiManager.DoUpdate doesn't update the orientation of AuiToolBar.
This means that if the orientation of the dock for the toolbar changes
when using LoadPerspective the orientation of the toolbar will be
wrong.

The line that calls SwitchToolBarOrientation() in DoUpdate of was
commented out when framemanager.py was imported into git way back in
2012 and is still updated today.  Removing the comment makes the above
scenario work properly.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #917
