### PR TITLE
Ensure the sequence attribute is a list by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -55,6 +55,9 @@ Changes in this release include the following:
 
 * Improve calltip stability in pyshell. (#941)
 
+* Fix TypeError in wx.lib.throbber. (#924)
+
+
 
 
 4.0.3 "The show must go on. (Die show-stoppers! Die!)"

--- a/demo/Throbber.py
+++ b/demo/Throbber.py
@@ -46,10 +46,7 @@ class TestPanel(wx.Panel):
             throb.Throbber(self, -1, images, frameDelay = 0.1, reverse = True)
 
         seq = self.throbbers['autoreverse']['throbber'].sequence
-        if isinstance(seq, range):
-            seq = list(seq).append(0)
-        else:
-            seq.append(0)
+        seq.append(0)
 
         self.throbbers['label']['throbber'] = \
             throb.Throbber(self, -1, images, frameDelay = 0.1, label = 'Label')

--- a/wx/lib/throbber.py
+++ b/wx/lib/throbber.py
@@ -333,7 +333,7 @@ class Throbber(wx.Panel):
             #FIXME: need to make sure values are within range!!!
             self.sequence = sequence
         else:
-            self.sequence = range(self.frames)
+            self.sequence = list(range(self.frames))
 
         if running:
             self.Start()


### PR DESCRIPTION
Ensure the sequence attribute is a list by default, not a range, so i…t can be appended to.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #924

