### PR TITLE
Missing tool_id parameter in AddToggleTool

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -86,6 +86,9 @@ Changes in this release include the following:
 
 * Fix TypeError in wx.lib.throbber. (#924)
 
+* Fix missing parameter tool_id in
+  wx.lib.agw.ribbon.toolbar.RibbonToolBar.AddToggleTool. (#947)
+
 
 
 

--- a/wx/lib/agw/ribbon/toolbar.py
+++ b/wx/lib/agw/ribbon/toolbar.py
@@ -297,7 +297,7 @@ class RibbonToolBar(RibbonControl):
         return self.InsertTool(pos, tool_id, bitmap, wx.NullBitmap, help_string, RIBBON_BUTTON_HYBRID, None)
 
 
-    def AddToggleTool(self, bitmap, help_string=""):
+    def AddToggleTool(self, tool_id, bitmap, help_string=""):
         """
         Add a toggle tool to the tool bar (simple version).
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #947 

