### PR TITLE
Small fixes to pywxrc

### DIFF
--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -856,7 +856,6 @@ def main(args=None):
     if not args:
         args = sys.argv[1:]
 
-    resourceFilename = ""
     outputFilename = None
     embedResources = False
     generateGetText = False
@@ -931,7 +930,7 @@ def main(args=None):
         print_("%s." % str(exc), file=sys.stderr)
     else:
         if outputFilename != "-":
-            print_("Resources written to %s." % outputFilename, file=outputFilename)
+            print_("Resources written to %s." % outputFilename, file=sys.stderr)
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -396,7 +396,10 @@ class XmlResourceCompiler:
                 if widgetClass == "MenuItem":
                     outputList.append(self.templates.MENUBAR_MENUITEM_VAR % locals())
                 elif widgetClass == "Menu":
-                    label = widget.getElementsByTagName("label")[0]
+                    for e in widget.childNodes:
+                        if e.nodeType == e.ELEMENT_NODE and e.tagName == "label":
+                            label = e
+                            break
                     label = label.childNodes[0].data
                     outputList.append(self.templates.MENUBAR_MENU_VAR % locals())
                 else:
@@ -420,7 +423,10 @@ class XmlResourceCompiler:
                 if widgetClass == "MenuItem":
                     outputList.append(self.templates.MENU_MENUITEM_VAR % locals())
                 elif widgetClass == "Menu":
-                    label = widget.getElementsByTagName("label")[0]
+                    for e in widget.childNodes:
+                        if e.nodeType == e.ELEMENT_NODE and e.tagName == "label":
+                            label = e
+                            break
                     label = label.childNodes[0].data
                     outputList.append(self.templates.MENU_MENU_VAR % locals())
                 else:
@@ -465,22 +471,26 @@ class XmlResourceCompiler:
             widgetName = widget.getAttribute("name")
             if widgetName != "" and widgetClass != "":
                 vars.append(widgetName)
-                if widgetClass not in \
-                       ['tool', 'unknown', 'notebookpage', 'separator',
-                        'sizeritem', 'Menu', 'MenuBar', 'MenuItem']:
-                    outputList.append(self.templates.CREATE_WIDGET_VAR % locals())
-                elif widgetClass == "MenuBar":
+                if widgetClass == "MenuBar":
                     outputList.append(self.templates.FRAME_MENUBAR_VAR % locals())
                 elif widgetClass == "MenuItem":
                     outputList.append(self.templates.FRAME_MENUBAR_MENUITEM_VAR % locals())
                 elif widgetClass == "Menu":
-                    label = widget.getElementsByTagName("label")[0]
+                    # Only look directly under for the "label"
+                    for e in widget.childNodes:
+                        if e.nodeType == e.ELEMENT_NODE and e.tagName == "label":
+                            label = e
+                            break
                     label = label.childNodes[0].data
                     outputList.append(self.templates.FRAME_MENUBAR_MENU_VAR % locals())
-                elif widgetClass == "ToolBar":
-                    outputList.append(self.templates.FRAME_TOOLBAR_VAR % locals())
+#                 elif widgetClass == "ToolBar":
+#                     outputList.append(self.templates.FRAME_TOOLBAR_VAR % locals())
                 elif widgetClass == "tool":
                     outputList.append(self.templates.FRAME_TOOLBAR_TOOL_VAR % locals())
+                elif widgetClass in ('unknown', 'notebookpage', 'separator', 'sizeritem'):
+                    pass
+                else:
+                    outputList.append(self.templates.CREATE_WIDGET_VAR % locals())
 
         return outputList
 

--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -73,7 +73,6 @@ class xrc%(windowName)s(wx.%(windowClass)s):
 #!XRCED:end-block:xrc%(windowName)s.PreCreate
 
     def __init__(self, parent):
-        # Two stage creation (see http://wiki.wxpython.org/index.cgi/TwoStageCreation)
         wx.%(windowClass)s.__init__(self)
         self.PreCreate()
         get_resources().Load%(windowClass)s(self, parent, "%(windowName)s")
@@ -84,7 +83,6 @@ class xrc%(windowName)s(wx.%(windowClass)s):
     SUBCLASS_HEADER = """\
 class %(subclass)s(wx.%(windowClass)s):
     def __init__(self):
-        # Two stage creation (see http://wiki.wxpython.org/index.cgi/TwoStageCreation)
         wx.%(windowClass)s.__init__(self)
         self.Bind(wx.EVT_WINDOW_CREATE, self.OnCreate)
 


### PR DESCRIPTION
While migrating an application from wxPython 3 to wxPython 4, we've encountered small issues in pywxrc. This fixes most of them:
 * Incorrect comment about 2 stage creation
 * Menu with variable name failed to be found (if <label> is defined after the sub-menus)
 * Success message failed to be shown.