### PR TITLE
Fix GraphicsContext created from AutoBufferedPaintDC

### DIFF
--- a/etg/graphics.py
+++ b/etg/graphics.py
@@ -73,7 +73,7 @@ def run():
         pyArgsString='(autoPaintDC) -> GraphicsContext',
         isStatic=True,
         body="""\
-            return wxGraphicsContext::Create(autoPaintDC);
+            return wxGraphicsContext::Create(*autoPaintDC);
             """)
 
     m = c.find('Create').findOverload('wxEnhMetaFileDC')


### PR DESCRIPTION
Dereference the dc pointer, otherwise the void* overload will be called which apparently fails silently.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #944

