### PR TITLE
Replace deprecated PIL.Image.tostring()

### DIFF
--- a/wx/lib/agw/rulerctrl.py
+++ b/wx/lib/agw/rulerctrl.py
@@ -257,7 +257,7 @@ def ConvertWXToPIL(bmp):
 
     width = bmp.GetWidth()
     height = bmp.GetHeight()
-    img = Image.fromstring("RGBA", (width, height), bmp.GetData())
+    img = Image.frombytes("RGBA", (width, height), bmp.GetData())
 
     return img
 
@@ -276,12 +276,12 @@ def ConvertPILToWX(pil, alpha=True):
 
     if alpha:
         image = wx.Image(*pil.size)
-        image.SetData(pil.convert("RGB").tostring())
-        image.SetAlpha(pil.convert("RGBA").tostring()[3::4])
+        image.SetData(pil.convert("RGB").tobytes())
+        image.SetAlpha(pil.convert("RGBA").tobytes()[3::4])
     else:
         image = wx.Image(pil.size[0], pil.size[1])
         new_image = pil.convert('RGB')
-        data = new_image.tostring()
+        data = new_image.tobytes()
         image.SetData(data)
 
     return image

--- a/wx/lib/agw/shapedbutton.py
+++ b/wx/lib/agw/shapedbutton.py
@@ -909,7 +909,7 @@ class SButton(wx.Window):
 
         width = bmp.GetWidth()
         height = bmp.GetHeight()
-        img = Image.fromstring("RGBA", (width, height), bmp.GetData())
+        img = Image.frombytes("RGBA", (width, height), bmp.GetData())
 
         return img
 
@@ -925,12 +925,12 @@ class SButton(wx.Window):
 
         if alpha:
             image = wx.Image(*pil.size)
-            image.SetData(pil.convert("RGB").tostring())
-            image.SetAlpha(pil.convert("RGBA").tostring()[3::4])
+            image.SetData(pil.convert("RGB").tobytes())
+            image.SetAlpha(pil.convert("RGBA").tobytes()[3::4])
         else:
             image = wx.Image(pil.size[0], pil.size[1])
             new_image = pil.convert('RGB')
-            data = new_image.tostring()
+            data = new_image.tobytes()
             image.SetData(data)
 
         return image

--- a/wx/lib/agw/thumbnailctrl.py
+++ b/wx/lib/agw/thumbnailctrl.py
@@ -484,11 +484,11 @@ class PILImageHandler(object):
         pil.thumbnail(thumbnailsize)
         img = wx.Image(pil.size[0], pil.size[1])
 
-        img.SetData(pil.convert("RGB").tostring())
+        img.SetData(pil.convert("RGB").tobytes())
 
         alpha = False
         if "A" in pil.getbands():
-            img.SetAlpha(pil.convert("RGBA").tostring()[3::4])
+            img.SetAlpha(pil.convert("RGBA").tobytes()[3::4])
             alpha = True
 
         return img, originalsize, alpha
@@ -509,7 +509,7 @@ class PILImageHandler(object):
         pil.fromstring(img.GetData())
         enh = ImageEnhance.Brightness(pil)
         enh = enh.enhance(1.5)
-        img.SetData(enh.convert('RGB').tostring())
+        img.SetData(enh.convert('RGB').tobytes())
         return img
 
 
@@ -2457,7 +2457,7 @@ class ScrolledThumbnail(wx.ScrolledWindow):
                 fil = opj(thumb.GetFullFileName())
                 pil = Image.open(fil).rotate(newangle)
                 img = wx.Image(pil.size[0], pil.size[1])
-                img.SetData(pil.convert('RGB').tostring())
+                img.SetData(pil.convert('RGB').tobytes())
                 thumb.SetRotation(newangle*pi/180)
             else:
                 img = thumb._threadedimage

--- a/wx/lib/agw/thumbnailctrl.py
+++ b/wx/lib/agw/thumbnailctrl.py
@@ -506,7 +506,7 @@ class PILImageHandler(object):
         import PIL.ImageEnhance as ImageEnhance
 
         pil = Image.new('RGB', (img.GetWidth(), img.GetHeight()))
-        pil.fromstring(img.GetData())
+        pil.frombytes(img.GetData())
         enh = ImageEnhance.Brightness(pil)
         enh = enh.enhance(1.5)
         img.SetData(enh.convert('RGB').tobytes())


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes `NotImplementedError` raised when using `wx.lib.agw.thumbnailctrl.PILImageHandler`.

