### PR TITLE
Fix example of using UltimateListCtrl in docstring

### DIFF
--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -91,23 +91,23 @@ Usage example::
 
     class MyFrame(wx.Frame):
 
-        def __init__(self):
+        def __init__(self, parent):
 
             wx.Frame.__init__(self, parent, -1, "UltimateListCtrl Demo")
 
-            list = ULC.UltimateListCtrl(self, wx.ID_ANY, agwStyle=wx.LC_REPORT | wx.LC_VRULES | wx.LC_HRULES | wx.LC_SINGLE_SEL)
+            list = ULC.UltimateListCtrl(self, wx.ID_ANY, agwStyle=ULC.ULC_REPORT | ULC.ULC_VRULES | ULC.ULC_HRULES | ULC.ULC_SINGLE_SEL | ULC.ULC_HAS_VARIABLE_ROW_HEIGHT)
 
             list.InsertColumn(0, "Column 1")
             list.InsertColumn(1, "Column 2")
 
-            index = list.InsertStringItem(sys.maxint, "Item 1")
+            index = list.InsertStringItem(sys.maxsize, "Item 1")
             list.SetStringItem(index, 1, "Sub-item 1")
 
-            index = list.InsertStringItem(sys.maxint, "Item 2")
+            index = list.InsertStringItem(sys.maxsize, "Item 2")
             list.SetStringItem(index, 1, "Sub-item 2")
 
             choice = wx.Choice(list, -1, choices=["one", "two"])
-            index = list.InsertStringItem(sys.maxint, "A widget")
+            index = list.InsertStringItem(sys.maxsize, "A widget")
 
             list.SetItemWindow(index, 1, choice, expand=True)
 
@@ -116,16 +116,16 @@ Usage example::
             self.SetSizer(sizer)
 
 
-    # our normal wxApp-derived class, as usual
+# our normal wxApp-derived class, as usual
 
-    app = wx.App(0)
+    if __name__ == "__main__":
+        app = wx.App(0)
 
-    frame = MyFrame(None)
-    app.SetTopWindow(frame)
-    frame.Show()
+        frame = MyFrame(None)
+        app.SetTopWindow(frame)
+        frame.Show()
 
-    app.MainLoop()
-
+        app.MainLoop()
 
 
 Window Styles


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Add parent parameter to `__init__`. 
Add `ULC_HAS_VARIABLE_ROW_HEIGHT` style. 
Replace wx... styles to wx.lib.agw.ultimatelistctrl... styles. 
Replace `sys.maxint` to `sys.maxsize`.

Old example don't work in Python 3.6.

