### PR TITLE
Fixed bug with image in floatcanvas incorrectly getting rescaled to zero width and height during frame resize.

### DIFF
--- a/wx/lib/floatcanvas/FCObjects.py
+++ b/wx/lib/floatcanvas/FCObjects.py
@@ -2333,7 +2333,7 @@ class ScaledBitmap2(TextObjectMixin, DrawObject, ):
             Hb = BBbitmap[1,1] - Yb
 
         FullHeight = ScaleWorldToPixel(self.Height)[0]
-        scale = FullHeight / self.bmpWH[1]
+        scale = float(FullHeight) / float(self.bmpWH[1])
         Ws = int(scale * Wb + 0.5) # add the 0.5 to  round
         Hs = int(scale * Hb + 0.5)
         if (self.ScaledBitmap is None) or (self.ScaledBitmap[0] != (Xb, Yb, Wb, Hb, Ws, Ws) ):


### PR DESCRIPTION
Rescaling a frame with a NavCanvas holding a FloatCanvas.ScaledBitmap2 image may trigger a wx._core.wxAssertionError in wxImage::Scale(). This pull request fixes this bug. The comment in commit 6d24a91 describes the bug and the trivial fix in detail.
