### PR TITLE
Ensure colours set in TreeItemAttr are instances of wx.Colour

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -126,6 +126,10 @@ Changes in this release include the following:
 
 * Performance update for `wx.lib.agw.customtreectrl` (#1049)
 
+* Ensure that colours set in wx.lib.agw.customtreectrl.TreeItemAttr are
+  instances of wx.Colour. (#1032)
+
+  
 
 
 4.0.3 "The show must go on. (Die show-stoppers! Die!)"

--- a/wx/lib/agw/customtreectrl.py
+++ b/wx/lib/agw/customtreectrl.py
@@ -857,7 +857,7 @@ class TreeItemAttr(object):
         :param `colText`: an instance of :class:`wx.Colour`.
         """
 
-        self._colText = colText
+        self._colText = wx.Colour(colText)
 
 
     def SetBackgroundColour(self, colBack):
@@ -867,7 +867,7 @@ class TreeItemAttr(object):
         :param `colBack`: an instance of :class:`wx.Colour`.
         """
 
-        self._colBack = colBack
+        self._colBack = wx.Colour(colBack)
 
 
     def SetBorderColour(self, colBorder):
@@ -879,7 +879,7 @@ class TreeItemAttr(object):
         .. versionadded:: 0.9.6
         """
 
-        self._colBorder = colBorder
+        self._colBorder = wx.Colour(colBorder)
 
 
     def SetFont(self, font):

--- a/wx/lib/agw/hypertreelist.py
+++ b/wx/lib/agw/hypertreelist.py
@@ -2366,7 +2366,7 @@ class TreeListMainWindow(CustomTreeCtrl):
 # operations
 # ----------------------------------------------------------------------------
 
-    def DoInsertItem(self, parent, previous, text, ct_type=0, wnd=None, image=-1, selImage=-1, data=None, separator=False):
+    def DoInsertItem(self, parent, previous, text, ct_type=0, wnd=None, image=-1, selImage=-1, data=None, *ignored_args):
         """
         Actually inserts an item in the tree.
 
@@ -2383,7 +2383,7 @@ class TreeListMainWindow(CustomTreeCtrl):
          use for the item in selected state; if `image` > -1 and `selImage` is -1, the
          same image is used for both selected and unselected items;
         :param `data`: associate the given Python object `data` with the item.
-        :param `separator`: unused at the moment, this parameter is present to comply with
+        :param `ignored_args`: unused at the moment, this parameter is present to comply with
          :meth:`CustomTreeCtrl.DoInsertItem() <lib.agw.customtreectrl.CustomTreeCtrl.DoInsertItem>` changed API.
         """
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1032

