### PR TITLE
Fix dataview test on Python 2

### DIFF
--- a/unittests/test_dataview.py
+++ b/unittests/test_dataview.py
@@ -1,7 +1,6 @@
 import unittest
 from unittests import wtc
 import wx
-import six
 import wx.dataview as dv
 import os
 import sys
@@ -45,10 +44,6 @@ class dataview_Tests(wtc.WidgetTestCase):
 
     def test_dataviewItem7(self):
         n = sys.maxsize
-        if six.PY3:
-            assert type(n) is int
-        else:
-            assert type(n) is long
         dvi = dv.DataViewItem(n)
         self.assertTrue(dvi)
         self.assertTrue(int(dvi.GetID()) == n)


### PR DESCRIPTION
sys.maxsize isn't a long on Py2, it's an int.  So just remove this assert.
