### PR TITLE
Don't try to compare Colours in SortForDisplay.

### DIFF
--- a/wx/lib/agw/pygauge.py
+++ b/wx/lib/agw/pygauge.py
@@ -505,12 +505,12 @@ class PyGauge(wx.Window):
         """ Internal method which sorts things so we draw the longest bar first. """
 
         if self.GetBarGradient():
-            tmp = sorted(zip(self._value,self._barGradient)); tmp.reverse()
+            tmp = sorted(zip(self._value,self._barGradient), key=lambda x: x[0]); tmp.reverse()
             a, b = list(zip(*tmp))
             self._valueSorted       = list(a)
             self._barGradientSorted = list(b)
         else:
-            tmp = sorted(zip(self._value,self._barColour)); tmp.reverse()
+            tmp = sorted(zip(self._value,self._barColour), key=lambda x: x[0]); tmp.reverse()
             a, b = list(zip(*tmp))
             self._valueSorted     = list(a)
             self._barColourSorted = list(b)


### PR DESCRIPTION
Specifying a key to sort only by the first element prevents
```
TypeError: '<' not supported between instances of 'Colour' and 'Colour'
```
in SortForDisplay.

If any two elements of self._value are equal, sorted tries to sort by the next element in the zipped tuples, which are Colours that can not be compared.

I don't think this issue has been reported.