### PR TITLE
Remove hard-coded sizes from wx.SpinButton and wx.SpinCtrlDouble in demo

### DIFF
--- a/demo/SpinButton.py
+++ b/demo/SpinButton.py
@@ -23,7 +23,7 @@ class TestPanel(wx.Panel):
 
         self.spin = wx.SpinButton(self, -1,
                                   (w, 50),
-                                  (h*2/3, h),
+                                  (-1, -1),
                                   wx.SP_VERTICAL)
         self.spin.SetRange(1, 100)
         self.spin.SetValue(1)

--- a/demo/SpinCtrlDouble.py
+++ b/demo/SpinCtrlDouble.py
@@ -10,7 +10,7 @@ class TestPanel(wx.Panel):
         wx.Panel.__init__(self, parent, -1)
 
         wx.StaticText(self, -1, "wx.SpinCtrlDouble:", pos=(25,25))
-        spin = wx.SpinCtrlDouble(self, value='0.00', pos=(75,50), size=(80,-1),
+        spin = wx.SpinCtrlDouble(self, value='0.00', pos=(75,50),
                                  min=-5.0, max=25.25, inc=0.25)
         spin.SetDigits(2)
 


### PR DESCRIPTION
Fixes #1086 

