### PR TITLE
Add missing methods in wx.ListBox

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -151,6 +151,9 @@ Changes in this release include the following:
   anymore plastered right in the middle of the screen and can't be worked with
   easily and ESC now cancels the popup with a proper returnId. (#1096)
 
+* Added missing methods in wx.ListBox, SetItemForegroundColour,
+  SetItemBackgroundColour and SetItemFont. (#1095)
+
 
 
 

--- a/demo/ListBox.py
+++ b/demo/ListBox.py
@@ -77,7 +77,7 @@ class TestListBox(wx.Panel):
 
         wx.StaticText(self, -1, "This example uses the wx.ListBox control.", (45, 10))
         wx.StaticText(self, -1, "Select one:", (15, 50))
-        self.lb1 = wx.ListBox(self, 60, (100, 50), (90, 120), sampleList, wx.LB_SINGLE)
+        self.lb1 = wx.ListBox(self, 60, (100, 50), (90, 120), sampleList, wx.LB_SINGLE|wx.LB_OWNERDRAW)
         self.Bind(wx.EVT_LISTBOX, self.EvtListBox, self.lb1)
         self.Bind(wx.EVT_LISTBOX_DCLICK, self.EvtListBoxDClick, self.lb1)
         self.lb1.Bind(wx.EVT_RIGHT_UP, self.EvtRightButton)
@@ -85,6 +85,9 @@ class TestListBox(wx.Panel):
         self.lb1.Append("with data", "This one has data");
         self.lb1.SetClientData(2, "This one has data");
 
+        # These only work on Windows
+        self.lb1.SetItemBackgroundColour(1, "green")
+        self.lb1.SetItemForegroundColour(2, "red")
 
         wx.StaticText(self, -1, "Select many:", (220, 50))
         self.lb2 = wx.ListBox(self, 70, (320, 50), (90, 120), sampleList, wx.LB_EXTENDED)

--- a/etg/listbox.py
+++ b/etg/listbox.py
@@ -33,6 +33,8 @@ def run():
     # customizing the generated code and docstrings.
 
     c = module.find('wxListBox')
+    assert isinstance(c, etgtools.ClassDef)
+
     c.find('wxListBox').findOverload('wxString choices').ignore()
     c.find('wxListBox').findOverload('wxArrayString').find('choices').default = 'wxArrayString()'
 
@@ -55,8 +57,41 @@ def run():
 
     c.find('InsertItems').findOverload('wxString *items').ignore()
 
-    tools.fixWindowClass(c)
+    c.addCppMethod('void', 'SetItemForegroundColour', '(int item, const wxColour& c)',
+        doc="""\
+            Set the foreground colour of an item in the ListBox.
+            Only valid on MSW and if the ``wx.LB_OWNERDRAW`` flag is set.""",
+        body="""\
+            #ifdef __WXMSW__
+                 if (self->GetWindowStyle() & wxLB_OWNERDRAW)
+                     self->GetItem(item)->SetTextColour(c);
+            #endif
+            """)
 
+    c.addCppMethod('void', 'SetItemBackgroundColour', '(int item, const wxColour& c)',
+        doc="""\
+            Set the background colour of an item in the ListBox.
+            Only valid on MSW and if the ``wx.LB_OWNERDRAW`` flag is set.""",
+        body="""\
+            #ifdef __WXMSW__
+                 if (self->GetWindowStyle() & wxLB_OWNERDRAW)
+                     self->GetItem(item)->SetBackgroundColour(c);
+            #endif
+            """)
+
+    c.addCppMethod('void', 'SetItemFont', '(int item, const wxColour& c)',
+        doc="""\
+            Set the font of an item in the ListBox.
+            Only valid on MSW and if the ``wx.LB_OWNERDRAW`` flag is set.""",
+        body="""\
+            #ifdef __WXMSW__
+                 if (self->GetWindowStyle() & wxLB_OWNERDRAW)
+                     self->GetItem(item)->SetFont(f);
+            #endif
+            """)
+
+
+    tools.fixWindowClass(c)
     module.addGlobalStr('wxListBoxNameStr', c)
 
     #-----------------------------------------------------------------

--- a/etg/listbox.py
+++ b/etg/listbox.py
@@ -57,36 +57,36 @@ def run():
 
     c.find('InsertItems').findOverload('wxString *items').ignore()
 
-    c.addCppMethod('void', 'SetItemForegroundColour', '(int item, const wxColour& c)',
+    c.addCppMethod('void', 'SetItemForegroundColour', '(int item, const wxColour* c)',
         doc="""\
             Set the foreground colour of an item in the ListBox.
             Only valid on MSW and if the ``wx.LB_OWNERDRAW`` flag is set.""",
         body="""\
             #ifdef __WXMSW__
                  if (self->GetWindowStyle() & wxLB_OWNERDRAW)
-                     self->GetItem(item)->SetTextColour(c);
+                     self->GetItem(item)->SetTextColour(*c);
             #endif
             """)
 
-    c.addCppMethod('void', 'SetItemBackgroundColour', '(int item, const wxColour& c)',
+    c.addCppMethod('void', 'SetItemBackgroundColour', '(int item, const wxColour* c)',
         doc="""\
             Set the background colour of an item in the ListBox.
             Only valid on MSW and if the ``wx.LB_OWNERDRAW`` flag is set.""",
         body="""\
             #ifdef __WXMSW__
                  if (self->GetWindowStyle() & wxLB_OWNERDRAW)
-                     self->GetItem(item)->SetBackgroundColour(c);
+                     self->GetItem(item)->SetBackgroundColour(*c);
             #endif
             """)
 
-    c.addCppMethod('void', 'SetItemFont', '(int item, const wxColour& c)',
+    c.addCppMethod('void', 'SetItemFont', '(int item, const wxFont* f)',
         doc="""\
             Set the font of an item in the ListBox.
             Only valid on MSW and if the ``wx.LB_OWNERDRAW`` flag is set.""",
         body="""\
             #ifdef __WXMSW__
                  if (self->GetWindowStyle() & wxLB_OWNERDRAW)
-                     self->GetItem(item)->SetFont(f);
+                     self->GetItem(item)->SetFont(*f);
             #endif
             """)
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Added missing methods in wx.ListBox, SetItemForegroundColour, SetItemBackgroundColour and SetItemFont.

Fixes #1095

