### PR TITLE
Fix hhctrl crash in 64-bit MSW builds

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,8 +8,9 @@
 wxPython Changelog
 ==================
 
-4.0.4 ""
---------
+
+4.0.4 "What? It's 2019 already?"
+--------------------------------
 * (not yet released)
 
 PyPI:   https://pypi.org/project/wxPython/4.0.4
@@ -153,6 +154,8 @@ Changes in this release include the following:
 
 * Added missing methods in wx.ListBox, SetItemForegroundColour,
   SetItemBackgroundColour and SetItemFont. (#1095)
+
+* Backported a fix in wxWidgets that avoids crashing in hhctrl.ocx (#1104)
 
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -155,7 +155,8 @@ Changes in this release include the following:
 * Added missing methods in wx.ListBox, SetItemForegroundColour,
   SetItemBackgroundColour and SetItemFont. (#1095)
 
-* Backported a fix in wxWidgets that avoids crashing in hhctrl.ocx (#1104)
+* Backported a fix in wxWidgets that avoids crashing in hhctrl.ocx when using
+  context sensitive help in 64-bit builds on Windows. (#1104)
 
 
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1104

