### PR TITLE
Update FCObjects.py

### DIFF
--- a/wx/lib/floatcanvas/FCObjects.py
+++ b/wx/lib/floatcanvas/FCObjects.py
@@ -2135,6 +2135,8 @@ class ScaledBitmap(TextObjectMixin, DrawObject):
             self.Image = Bitmap.ConvertToImage()
         elif type(Bitmap) == wx.Image:
             self.Image = Bitmap
+        else:
+            raise ValueError("'Bitmap' must be a wx.Bitmap or wx.Image object not %s" % type(Bitmap))
 
         self.XY = XY
         self.Height = Height


### PR DESCRIPTION
If something other than a wx.Bitmap or wx.Image is passed to the ScaledBitmap an AttributeError is raised because the Image attribute is never set. The proposed change will raise a more helpful ValueError instead

