### PR TITLE
Added missing setters for the wheel-related properties in wx.MouseEvent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,8 @@ Pip:    ``pip install wxPython==4.0.5``
 Changes in this release include the following:
 
 
+* Added missing setters for the wheel-related properties in wx.MouseEvent. 
+  (#1140)
 
 
 

--- a/etg/event.py
+++ b/etg/event.py
@@ -413,10 +413,27 @@ def run():
     #---------------------------------------
     # wxMouseEvent
     c = module.find('wxMouseEvent')
-    c.addProperty('LinesPerAction GetLinesPerAction')
-    c.addProperty('LogicalPosition GetLogicalPosition')
-    c.addProperty('WheelDelta GetWheelDelta')
-    c.addProperty('WheelRotation GetWheelRotation')
+
+    c.addCppMethod('void', 'SetWheelAxis', '(wxMouseWheelAxis wheelAxis)',
+        body="self->m_wheelAxis = wheelAxis;")
+
+    c.addCppMethod('void', 'SetWheelRotation', '(int wheelRotation)',
+        body="self->m_wheelRotation = wheelRotation;")
+
+    c.addCppMethod('void', 'SetWheelDelta', '(int wheelDelta)',
+        body="self->m_wheelDelta = wheelDelta;")
+
+    c.addCppMethod('void', 'SetLinesPerAction', '(int linesPerAction)',
+        body="self->m_linesPerAction = linesPerAction;")
+
+    c.addCppMethod('void', 'SetColumnsPerAction', '(int columnsPerAction)',
+        body="self->m_columnsPerAction = columnsPerAction;")
+
+    c.addProperty('WheelAxis GetWheelAxis SetWheelAxis')
+    c.addProperty('WheelRotation GetWheelRotation SetWheelRotation')
+    c.addProperty('WheelDelta GetWheelDelta SetWheelDelta')
+    c.addProperty('LinesPerAction GetLinesPerAction SetLinesPerAction')
+    c.addProperty('ColumnsPerAction GetColumnsPerAction SetColumnsPerAction')
 
     #---------------------------------------
     # wxSetCursorEvent


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1140 

