### PR TITLE
Fix building with SIP 4.19.14

### DIFF
--- a/etg/config.py
+++ b/etg/config.py
@@ -179,7 +179,7 @@ def run():
     c.find('wxFileConfig').findOverload('wxInputStream').find('conv').ignore()
     ctor = c.find('wxFileConfig').findOverload('wxString').find('conv').ignore()
     #ctor.items.remove(ctor.find('conv'))
-    ctor = c.find('Save').find('conv').ignore()
+    c.find('Save').ignore()
     c.find('GetGlobalFile').ignore()
     c.find('GetLocalFile').ignore()
 
@@ -187,6 +187,14 @@ def run():
     c.find('GetNextGroup').ignore()
     c.find('GetFirstEntry').ignore()
     c.find('GetNextEntry').ignore()
+
+    c.addCppMethod('bool', 'Save', '(wxOutputStream& os)', doc=c.find('Save').briefDoc, body="""\
+        #if wxUSE_STREAMS
+            return self->Save(*os);
+        #else
+            wxPyRaiseNotImplemented();
+        #endif
+        """)
 
 
 

--- a/etg/printfw.py
+++ b/etg/printfw.py
@@ -61,7 +61,6 @@ def run():
     c.find('CreateCanvas').isVirtual = True
     c.find('CreateControlBar').isVirtual = True
     c.find('Initialize').isVirtual = True
-    c.find('InitializeWithModality').isVirtual = True
 
 
 

--- a/etg/renderer.py
+++ b/etg/renderer.py
@@ -43,23 +43,27 @@ def run():
     c.find('GetGeneric').mustHaveApp()
     c.find('GetDefault').mustHaveApp()
     c.find('Set').mustHaveApp()
+    c.find('DrawTitleBarBitmap').ignore()
+    draw_tb_bmp_doc = c.find('DrawTitleBarBitmap').briefDoc
+
+
+    c = module.find('wxDelegateRendererNative')
+    c.mustHaveApp()
+    c.addPrivateCopyCtor()
 
 
     #virtual void DrawTitleBarBitmap(wxWindow *win,
     #                                wxDC& dc,
     #                                const wxRect& rect,
     #                                wxTitleBarButton button,
-    #                                int flags = 0) = 0;
-    c.find('DrawTitleBarBitmap').setCppCode("""\
+    #                                int flags = 0);
+    c.addCppMethod('void', 'DrawTitleBarBitmap', '(wxWindow* win, wxDC& dc, const wxRect& rect, wxTitleBarButton button, int flags = 0)', doc=draw_tb_bmp_doc, body="""\
     #ifdef wxHAS_DRAW_TITLE_BAR_BITMAP
         self->DrawTitleBarBitmap(win, *dc, *rect, button, flags);
+    #else
+        wxPyRaiseNotImplemented();
     #endif
     """)
-
-
-    c = module.find('wxDelegateRendererNative')
-    c.mustHaveApp()
-    c.addPrivateCopyCtor()
 
 
     #-----------------------------------------------------------------

--- a/etg/statbox.py
+++ b/etg/statbox.py
@@ -41,7 +41,7 @@ def run():
 
     # This is intentionally not documented, but I think it would be handy to
     # use from wxPython.
-    meth = MethodDef(name='GetBordersForSizer', isVirtual=True, type='void', protection='public',
+    meth = MethodDef(name='GetBordersForSizer', isConst=True, isVirtual=True, type='void', protection='public',
                      briefDoc="Returns extra space that may be needed for borders within a StaticBox.",
                      items=[ParamDef(name='borderTop', type='int*', out=True),
                             ParamDef(name='borderOther', type='int*', out=True),


### PR DESCRIPTION
This commit fixes building Phoenix with SIP 4.19.14.  One of the main changes
in this release was to add SIP_OVERRIDE, which adds the C++ override keyword
to method declarations that are intended to override the C++ class that SIP
is wrapping.  Unfortunately, this exposed a few bugs which caused compile
errors.  Most of the fixes are to the interface headers.  The two trickier
fixes were to wxFileConfig and wxRendererNative.

For wxFileConfig, the Save method's second parameter, 'conv', had been ignored.
This caused the override check to fail.  This was resolved by ignoring the
auto-generated Save() and adding a manually generated one without the second
parameter.

For wxRendererNative, the DrawTitleBarBitmap method is actually pure virtual
in the subclass, so the fix was to ignore it there.  In the subclass
wxDelegateRendererNative, it is concrete, but only on certain platforms.  This
was fixed in a similar way by adding a manually generated method that will
do the right thing on the platforms that support it.

There is one other fix required for SIP 4.19.14: SIP has now added its own
wrapper for size_t, so it required removing the one in wacky_ints.  This change
was omitted for now because it should probably wait until Phoenix officially
moves to 4.19.14.
