### PR TITLE
Fix wx/tools/pywxrc for py2/3 compatibility. Refs 1156.

### DIFF
--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -33,7 +33,7 @@ Usage: python pywxrc.py -h
 
 import sys, os, getopt, glob, re
 import xml.dom.minidom as minidom
-from six import print_
+from six import print_, byte2int
 
 #----------------------------------------------------------------------
 
@@ -295,22 +295,23 @@ class XmlResourceCompiler:
         # later when they try to run the program.
         if subclasses:
             subclasses = self.ReplaceBlocks(u"\n".join(subclasses))
-            print_(subclasses.encode("UTF-8"), file=outputFile)
+            print_(subclasses, file=outputFile)
         if classes:
             classes = self.ReplaceBlocks(u"\n".join(classes))
-            print_(classes.encode("UTF-8"), file=outputFile)
+            print_(classes, file=outputFile)
 
         print_(self.templates.INIT_RESOURE_HEADER, file=outputFile)
         if embedResources:
             print_(self.templates.PREPARE_MEMFS, file=outputFile)
         resources = u"\n".join(resources)
-        print_(resources.encode("UTF-8"), file=outputFile)
+        print_(resources, file=outputFile)
 
         if generateGetText:
-            # These have already been converted to utf-8...
-            gettextStrings = ['    _("%s")' % s for s in gettextStrings]
-            gettextStrings = "\n".join(gettextStrings)
-            print_(self.templates.GETTEXT_DUMMY_FUNC % gettextStrings, file=outputFile)
+            # gettextStrings is a list of unicode strings as returned by ConvertText
+            conversions = [u'    _("%s")' % s for s in gettextStrings]
+            conversion_block = u"\n".join(conversions)
+            conversion_func = self.templates.GETTEXT_DUMMY_FUNC % conversion_block
+            print_(conversion_func, file=outputFile)
 
     #-------------------------------------------------------------------
 
@@ -324,6 +325,7 @@ class XmlResourceCompiler:
             resourceDocument = minidom.parse(inFile)
             resource = resourceDocument.firstChild
             strings = self.FindStringsInNode(resource)
+            # strings is a list of unicode strings as returned by ConvertText
             strings = ['_("%s");' % s for s in strings]
             print_("\n".join(strings), file=outputFile)
 
@@ -629,27 +631,27 @@ class XmlResourceCompiler:
         fileLen = len(buffer)
 
         linelng = 0
-        for i in xrange(fileLen):
-            s = buffer[i]
-            c = ord(s)
-            if s == '\n':
+        for i in range(len(buffer)):
+            s = buffer[i:i+1]
+            c = byte2int(s)
+            if s == b'\n':
                 tmp = s
                 linelng = 0
-            elif c < 32 or c > 127 or s == "'":
-                tmp = "\\x%02x" % c
-            elif s == "\\":
-                tmp = "\\\\"
+            elif c < 32 or c > 127 or s == b"'":
+                tmp = b"\\x%02x" % c
+            elif s == b"\\":
+                tmp = b"\\\\"
             else:
                 tmp = s
 
             if linelng > 70:
                 linelng = 0
-                outputList.append("\\\n")
+                outputList.append(b"\\\n")
 
             outputList.append(tmp)
             linelng += len(tmp)
 
-        return "".join(outputList)
+        return (b"".join(outputList)).decode('utf-8')
 
     #-------------------------------------------------------------------
 
@@ -758,6 +760,17 @@ class XmlResourceCompiler:
     #-------------------------------------------------------------------
 
     def ConvertText(self, st):
+        """
+        Encode special characters as escaped C/Python string characters.
+
+            \n => \\n
+            \r => \\r
+            \t => \\t
+            \ => \\
+            " => \"
+
+        Returns result as string, which is bytes in py2 or unicode in py3.
+        """
         st2 = ""
         dt = list(st)
 
@@ -789,7 +802,7 @@ class XmlResourceCompiler:
             else:
                 st2 += dt[i]
 
-        return st2.encode("UTF-8")
+        return st2
 
     #-------------------------------------------------------------------
 


### PR DESCRIPTION
Produce byte compatible output from python 2 and 3 versions of pywxrc.  

Run with wxWidgets example resource file with embedded gif files.  Includes the gettext translation:
```sh
python wx/tools/pywxrc.py -o - -p -g -e ext/wxWidgets/samples/xrc/rc/resource.xrc > out_stdout.py
python wx/tools/pywxrc.py -o out_file.py -p -g -e ext/wxWidgets/samples/xrc/rc/resource.xrc
```

Fixes #1156.

