### PR TITLE
Fix building with Python 3.8 on Linux

### DIFF
--- a/wscript
+++ b/wscript
@@ -99,7 +99,7 @@ def configure(conf):
         # TODO: Check if it can/should be used on other platforms too.
         conf.my_check_python_headers()
     else:
-        conf.check_python_headers()
+        conf.check_python_headers(features='pyext')
 
     # fetch and save the debug options
     conf.env.debug = conf.options.debug


### PR DESCRIPTION
In Python 3.8, running "python3-config --libs" no longer returns the python
library itself.  This causes Waf's pyembed check to fail as it can't resolve
references to methods in the python library.  There is discussion[1] ongoing
about adding an "embed" mode to python3-config, but at the moment it is not
implemented.  We can work around this, however, in wxPython, by invoking Waf's
check_python_headers() with just the "pyext" feature as "pyembed" isn't needed
in wxPython (as far as I can tell).

[1] https://bugs.python.org/issue36721