### PR TITLE
Remove pathlib2 as a build-time dependency for Python 3

### DIFF
--- a/build.py
+++ b/build.py
@@ -27,7 +27,10 @@ import tarfile
 import tempfile
 import datetime
 
-import pathlib2
+try:
+	import pathlib
+except ImportError:
+	import pathlib2 as pathlib
 
 from distutils.dep_util import newer, newer_group
 from buildtools.config  import Config, msg, opj, posixjoin, loadETG, etg2sip, findCmd, \
@@ -1183,7 +1186,7 @@ def cmd_sip(options, args):
 def cmd_touch(options, args):
     cmdTimer = CommandTimer('touch')
     pwd = pushDir(phoenixDir())
-    etg = pathlib2.Path('etg')
+    etg = pathlib.Path('etg')
     for item in etg.glob('*.py'):
         item.touch()
 


### PR DESCRIPTION
Built-in pathlib has provided the required touch() function since it was
introduced in Python 3.4:
https://docs.python.org/release/3.4.0/library/pathlib.html#pathlib.Path.touch

Fall back to pathlib2 for earlier versions of Python.

---

I've only tested this on Python 3.7.
