### PR TITLE
Various fixes in wx.lib.calendar

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,9 @@ Other changes in this release:
   with warnings enabled so you can see which class, method or function calls
   you need to change.
 
+* Bug fixes in wx.lib.calendar: key navigation across month boundaries is now 
+  possible; key navigation now sets the date and fires the EVT_CALENDAR event; 
+  setter APIs now set the date correctly (#1230).
 
 
 4.0.5 "St. Helens Day"

--- a/unittests/test_lib_calendar.py
+++ b/unittests/test_lib_calendar.py
@@ -20,6 +20,21 @@ class lib_calendar_Tests(wtc.WidgetTestCase):
         acal.SetYear(2014)
         acal.SetMonth(1)
         acal.SetDayValue(31)
+        self.assertEqual(acal.GetDate(), (31, 1, 2014))
+        self.assertEqual(acal.SetDate(29, 2, 2020), (29, 2, 2020))
+        self.assertEqual(acal.SetDate(29, 2, 2019), (28, 2, 2019))
+        with self.assertRaises(ValueError):
+            acal.SetDate(29, 13, 2019)
+
+    def test_lib_calendar_CalendarMoveDate(self):
+        pnl = wx.Panel(self.frame)
+
+        acal = cal.Calendar(pnl)
+        acal.SetDate(31, 1, 2020)
+        self.assertEqual(acal.IncMonth(), (29, 2, 2020))
+        self.assertEqual(acal.IncYear(), (28, 2, 2021))
+        self.assertEqual(acal.DecMonth(), (28, 1, 2021))
+        self.assertEqual(acal.DecYear(), (28, 1, 2020))
 
     def test_lib_calendar_CalenDlgCtor(self):
         dlg = cal.CalenDlg(self.frame, month=1, day=11, year=2014)

--- a/unittests/test_lib_cdate.py
+++ b/unittests/test_lib_cdate.py
@@ -2,7 +2,7 @@ import unittest
 from unittests import wtc
 import wx.lib.CDate as cdate
 import six
-
+import datetime
 
 class lib_cdate_Tests(wtc.WidgetTestCase):
 
@@ -21,16 +21,21 @@ class lib_cdate_Tests(wtc.WidgetTestCase):
         self.assertFalse(l2, msg='Expected a non leap year')
 
     def test_lib_cdate_Julianday(self):
-        bd = cdate.Date(2014, 1, 10)
-        jd = cdate.julianDay(bd.year, bd.month, bd.day)
-
-        self.assertTrue(jd == bd.julian,
-                        msg='Expected them to be equal')
+        for m in range(3, 6):
+            for d in range(10, 20):
+                j = cdate.julianDay(2020, m, d)
+                jy, jm, jd = cdate.FromJulian(j)
+                self.assertEqual((2020, m, d), (jy, jm, jd), 
+                    msg='Julian/Gregorian round-trip failed for 2020-%i-%i' % (m, d))
 
     def test_lib_cdate_Dayofweek(self):
-        jd = cdate.julianDay(2014, 1, 10)
-        dw = cdate.dayOfWeek(jd)
-        self.assertTrue(dw == 4, msg='Expected "4" assuming Monday is 1, got %s' % dw)
+        # this also validates cdate.julianDay, since Date.day_of_week depends on it
+        for m in range(3, 6):
+            for d in range(10, 20):
+                realwd = datetime.date(2020, m, d).weekday()
+                testwd = cdate.Date(2020, m, d).day_of_week
+                self.assertEqual(realwd, testwd, 
+                    msg="Expected weekday to be %i for date 2020-%i-%i, got %i" % (realwd, m, d, testwd))
 
 #---------------------------------------------------------------------------
 

--- a/wx/lib/CDate.py
+++ b/wx/lib/CDate.py
@@ -15,6 +15,7 @@
 #               in a string format, then an error was raised.
 #
 """Date and calendar classes and date utitility methods."""
+from __future__ import division
 import time
 
 # I18N
@@ -43,7 +44,7 @@ def leapdays(y1, y2):
     Return number of leap years in range [y1, y2]
     Assume y1 <= y2 and no funny (non-leap century) years
     """
-    return (y2 + 3) / 4 - (y1 + 3) / 4
+    return (y2 + 3) // 4 - (y1 + 3) // 4
 
 
 def isleap(year):
@@ -75,11 +76,11 @@ def julianDay(year, month, day):
     """
     b = 0
     if month > 12:
-        year = year + month / 12
+        year = year + month // 12
         month = month % 12
     elif month < 1:
         month = -month
-        year = year - month / 12 - 1
+        year = year - month // 12 - 1
         month = 12 - month % 12
     if year > 0:
         yearCorr = 0
@@ -89,8 +90,8 @@ def julianDay(year, month, day):
         year = year - 1
         month = month + 12
     if year * 10000 + month * 100 + day > 15821014:
-        b = 2 - year / 100 + year / 400
-    return (1461 * year - yearCorr) / 4 + 306001 * (month + 1) / 10000 + day + 1720994 + b
+        b = 2 - year // 100 + year // 400
+    return (1461 * year - yearCorr) // 4 + 306001 * (month + 1) // 10000 + day + 1720994 + b
 
 
 def TodayDay():
@@ -122,12 +123,12 @@ def FromJulian(julian):
     if (julian < 2299160):
         b = julian + 1525
     else:
-        alpha = (4 * julian - 7468861) / 146097
-        b = julian + 1526 + alpha - alpha / 4
-    c = (20 * b - 2442) / 7305
-    d = 1461 * c / 4
-    e = 10000 * (b - d) / 306001
-    day = int(b - d - 306001 * e / 10000)
+        alpha = (4 * julian - 7468861) // 146097
+        b = julian + 1526 + alpha - alpha // 4
+    c = (20 * b - 2442) // 7305
+    d = 1461 * c // 4
+    e = 10000 * (b - d) // 306001
+    day = int(b - d - 306001 * e // 10000)
     if e < 14:
         month = int(e - 1)
     else:

--- a/wx/lib/calendar.py
+++ b/wx/lib/calendar.py
@@ -1006,7 +1006,10 @@ class Calendar(wx.Control):
             self.GetParent().GetEventHandler().ProcessEvent(ne)
             event.Skip()
             return
-
+        
+        self.shiftkey = event.ShiftDown()
+        self.ctrlkey = event.ControlDown()
+        self.click = 'KEY'
         delta = None
 
         if key_code == wx.WXK_UP:
@@ -1029,16 +1032,16 @@ class Calendar(wx.Control):
             newDate = curDate + timeSpan
 
             if curDate.GetMonth() == newDate.GetMonth():
-                self.set_day = newDate.GetDay()
+                self.set_day = self.day = newDate.GetDay()
                 key = self.sel_key + delta
                 self.SelectDay(key)
             else:
                 self.month = newDate.GetMonth() + 1
                 self.year = newDate.GetYear()
-                self.set_day = newDate.GetDay()
+                self.set_day = self.day = newDate.GetDay()
                 self.sel_key = None
                 self.Refresh()
-
+            self._EmitCalendarEvent()
         event.Skip()
 
     def SetSize(self, set_size):
@@ -1184,13 +1187,7 @@ class Calendar(wx.Control):
         if self.day == "":
             return None
         else:
-            # Changed 12/1/03 by jmg (see above) to support 2.5 event binding
-            evt = wx.PyCommandEvent(wxEVT_COMMAND_PYCALENDAR_DAY_CLICKED, self.GetId())
-            evt.click, evt.day, evt.month, evt.year = self.click, self.day, self.month, self.year
-            evt.shiftkey = self.shiftkey
-            evt.ctrlkey = self.ctrlkey
-            self.GetEventHandler().ProcessEvent(evt)
-
+            self._EmitCalendarEvent()
             self.set_day = self.day
             return key
 
@@ -1449,6 +1446,13 @@ class Calendar(wx.Control):
             pass
 
         return (cfont, bgcolor)
+
+    def _EmitCalendarEvent(self):
+        evt = wx.PyCommandEvent(wxEVT_COMMAND_PYCALENDAR_DAY_CLICKED, self.GetId())
+        evt.click, evt.day, evt.month, evt.year = self.click, self.day, self.month, self.year
+        evt.shiftkey = self.shiftkey
+        evt.ctrlkey = self.ctrlkey
+        self.GetEventHandler().ProcessEvent(evt)
 
 
 class CalenDlg(wx.Dialog):

--- a/wx/lib/calendar.py
+++ b/wx/lib/calendar.py
@@ -89,7 +89,7 @@ methods and classes.
 import wx
 _ = wx.GetTranslation
 
-import datetime, calendar
+import datetime
 
 CalDays = [6, 0, 1, 2, 3, 4, 5]
 AbrWeekday = {6: _("Sun"), 0: _("Mon"), 1: _("Tue"), 2: _("Wed"), 3: _("Thu"),
@@ -385,9 +385,8 @@ class CalDraw:
         self.month = month
 
         # first day of week (Mon->0), number of days in month
-        dow, dim = calendar.monthrange(year, month)
-        self.dow = dow
-        self.dim = dim
+        self.dow = dow = datetime.date(year, month, 1).weekday()
+        self.dim = dim = wx.DateTime().GetLastMonthDay(month-1, year).GetDay()
 
         if self.cal_type == "NORMAL":
             start_pos = dow + 1
@@ -1417,7 +1416,7 @@ class Calendar(wx.Control):
         """
         try:
             day = self.cal_days[key]
-            day = int(day) + calendar.weekday(self.year, self.month, 1)
+            day = int(day) + wx.DateTime.FromDMY(day, self.month-1, self.year).GetWeekDay()
 
             if day % 7 == 6 or day % 7 == 0:
                 return True

--- a/wx/lib/calendar.py
+++ b/wx/lib/calendar.py
@@ -1037,7 +1037,7 @@ class Calendar(wx.Control):
                 self.year = newDate.GetYear()
                 self.set_day = newDate.GetDay()
                 self.sel_key = None
-                self.DoDrawing(wx.ClientDC(self))
+                self.Refresh()
 
         event.Skip()
 
@@ -1271,8 +1271,6 @@ class Calendar(wx.Control):
         :param `DC`: the :class:`wx.DC` to draw
 
         """
-        DC = wx.PaintDC(self)
-
         try:
             cal = self.caldraw
         except Exception:

--- a/wx/lib/calendar.py
+++ b/wx/lib/calendar.py
@@ -1092,15 +1092,21 @@ class Calendar(wx.Control):
         :param int `day`: the day
         :param int `month`: the month
         :param int `year`: the year
-        :raises: `ValueError` when setting an invalid date.
+        :raises: `ValueError` when setting an invalid month/year
+        :returns: the new date set.
         
         """
-        datetime.date(year, month, day) # let the possible ValueError propagate
+        datetime.date(year, month, 1) # let the possible ValueError propagate
+        try:
+            datetime.date(year, month, day)
+        except ValueError:
+            day = wx.DateTime().GetLastMonthDay(month-1, year).GetDay()
         self.year = year
         self.month = month
         self.set_day = self.day = day
         self.sel_key = None
         self.Refresh()
+        return self.GetDate()
 
     def GetDay(self):
         """

--- a/wx/lib/calendar.py
+++ b/wx/lib/calendar.py
@@ -1022,12 +1022,14 @@ class Calendar(wx.Control):
             delta = 1
         elif key_code == wx.WXK_HOME:
             curDate = wx.DateTime.FromDMY(int(self.cal_days[self.sel_key]), self.month - 1, self.year)
-            newDate = wx.DateTime.Now()
+            curDate.SetHour(12) # leave a margin for the occasional DST crossing
+            newDate = wx.DateTime.Today().SetHour(12)
             ts = newDate - curDate
             delta = ts.GetDays()
 
         if delta is not None:
             curDate = wx.DateTime.FromDMY(int(self.cal_days[self.sel_key]), self.month - 1, self.year)
+            curDate.SetHour(12) # leave a margin for the occasional DST crossing
             timeSpan = wx.TimeSpan.Days(delta)
             newDate = curDate + timeSpan
 

--- a/wx/lib/calendar.py
+++ b/wx/lib/calendar.py
@@ -89,11 +89,16 @@ methods and classes.
 import wx
 _ = wx.GetTranslation
 
-from .CDate import *
+import datetime, calendar
 
 CalDays = [6, 0, 1, 2, 3, 4, 5]
 AbrWeekday = {6: _("Sun"), 0: _("Mon"), 1: _("Tue"), 2: _("Wed"), 3: _("Thu"),
               4: _("Fri"), 5: _("Sat")}
+Month = {0: None,
+         1: _('January'), 2: _('February'), 3: _('March'),
+         4: _('April'), 5: _('May'), 6: _('June'),
+         7: _('July'), 8: _('August'), 9: _('September'),
+         10: _('October'), 11: _('November'), 12: _('December')}
 _MIDSIZE = 180
 
 COLOR_GRID_LINES = "grid_lines"
@@ -379,10 +384,10 @@ class CalDraw:
         self.year = year
         self.month = month
 
-        day = 1
-        t = Date(year, month, day)
-        dow = self.dow = t.day_of_week     # start day in month
-        dim = self.dim = t.days_in_month   # number of days in month
+        # first day of week (Mon->0), number of days in month
+        dow, dim = calendar.monthrange(year, month)
+        self.dow = dow
+        self.dim = dim
 
         if self.cal_type == "NORMAL":
             start_pos = dow + 1
@@ -1058,7 +1063,7 @@ class Calendar(wx.Control):
 
     def SetNow(self):
         """Get the current day."""
-        dt = now()
+        dt = datetime.date.today()
         self.month = dt.month
         self.year = dt.year
         self.day = dt.day
@@ -1393,10 +1398,8 @@ class Calendar(wx.Control):
 
         """
         try:
-            t = Date(self.year, self.month, 1)
-
             day = self.cal_days[key]
-            day = int(day) + t.day_of_week
+            day = int(day) + calendar.weekday(self.year, self.month, 1)
 
             if day % 7 == 6 or day % 7 == 0:
                 return True


### PR DESCRIPTION
Fixes #1230

- wx.lib.calendar does not need wx.lib.CDate anymore. We just use datetime.date and wx.DateTime for all our needs;
- fixed a bug with key navigation across month boundaries;
- key navigation works fine now, setting the date and firing the EVT_CALENDAR;
- setter APIs works fine now, setting the date in a "smart" way (eg, automatically shifting the day when moving to a month with fewer days);
- a lot of fixes to wx.lib.calendar.CalendDlg, to make it work in the updated context;
- wx.lib.CDate should not be needed anymore and can be removed: however it is fixed now (the old py2 division operator caused rounding errors in py3); 
- added/updated tests for both modules.

I tried to be as light-handed as possible, preserving the existing APIs. However there are still many annoyances and inconsistencies... In the long run a more in-depth rewrite would be required I think. 