### PR TITLE
Use a wx.Overlay in WIT on GTK3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -43,6 +43,8 @@ Other changes in this release:
   possible; key navigation now sets the date and fires the EVT_CALENDAR event; 
   setter APIs now set the date correctly (#1230).
 
+* Switch to using a wx.Overlay in the Widget Inspection Tool to highlight
+  widgets when running on a GTK3 port.
 
 
 

--- a/wx/lib/inspection.py
+++ b/wx/lib/inspection.py
@@ -823,7 +823,7 @@ class _InspectionHighlighter(object):
     highlightTime = 3000   # how long to display the highlights
 
                            # how to draw it
-    useOverlay = 'wxMac' in wx.PlatformInfo
+    useOverlay = 'wxMac' in wx.PlatformInfo or 'gtk3' in wx.PlatformInfo
 
 
     def __init__(self):


### PR DESCRIPTION

Use an overlay to highlight widgets in the Widget Inspection Tool when running on GTK3