### PR TITLE
Fixes #1235: CustomTreeCtrl edit label remains stuck forever

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -46,6 +46,8 @@ Other changes in this release:
 * Switch to using a wx.Overlay in the Widget Inspection Tool to highlight
   widgets when running on a GTK3 port.
 
+* Fixed issue in wx.lib.agw.customtreectrl where label editor could remain
+  stuck forever (#1235).
 
 
 4.0.6 "Applesauce"

--- a/wx/lib/agw/customtreectrl.py
+++ b/wx/lib/agw/customtreectrl.py
@@ -7733,8 +7733,9 @@ class CustomTreeCtrl(wx.ScrolledWindow):
         if self._editCtrl != None and item != self._editCtrl.item():
             self._editCtrl.StopEditing()
 
-        self._editCtrl = TreeTextCtrl(self, item=item)
-        self._editCtrl.SetFocus()
+        if self._editCtrl is None:
+            self._editCtrl = TreeTextCtrl(self, item=item)
+            self._editCtrl.SetFocus()
 
 
     def GetEditControl(self):


### PR DESCRIPTION
I added a condition to check that an edit control doesn't already exist.
For more info you can read [cbeytas's explanation](https://github.com/wxWidgets/Phoenix/issues/1235#issuecomment-496777121) about the issue.