### PR TITLE
Attempts to enforce system settings in the demo page panel.

### DIFF
--- a/demo/Main.py
+++ b/demo/Main.py
@@ -372,25 +372,24 @@ def GetCaretPeriod(win = None):
 
     :raises: ValueError if unable to resolve a proper caret blink rate.
     """
+    if '--no-caret-blink' in sys.argv:
+        return 0
+
     try:
         onmsec  = wx.SystemSettings.GetMetric(wx.SYS_CARET_ON_MSEC, win)
         offmsec = wx.SystemSettings.GetMetric(wx.SYS_CARET_OFF_MSEC, win)
 
         # check values aren't -1
         if -1 in (onmsec, offmsec):
-            raise ValueError
+            raise ValueError("Unable to determine caret blink rate.")
 
         # attempt to average.
         # (wx systemsettings allows on and off time, but scintilla just takes a single period.)
-        return (onmsec +offmsec) / 2.0
+        return (onmsec + offmsec) / 2.0
 
-    except (AttributeError, ValueError):
+    except AttributeError:
         # Issue where wx.SYS_CARET_ON/OFF_MSEC is unavailable.
-        # Check
-        if '--no-caret-blink' in sys.argv:
-            return 0
-        else:
-            raise ValueError("Unable to determine caret blink rate.")
+        raise ValueError("Unable to determine caret blink rate.")
 
 #---------------------------------------------------------------------------
 # Set up a thread that will scan the wxWidgets docs for window styles,


### PR DESCRIPTION
Fixes #1238

Adds function `GetCaretPeriod` to `demo/Main.py` that will attempt to figure out a correct caret blink rate for the user from system settings.

Also allows users to manually disable blinking in the DemoPageEditor (if it is using `wx.stc.StyledTextCtrl`) by supplying a switch `--no-caret-blink` at launch. This feature isn't anything particularly elegant, it is merely a raw check in sys.argv (no argparse or equivalent code, so it won't have any runtime documentation to let users know it exists.)

Note: This does not change the caret in the search box, which will still blink.