### PR TITLE
Fix compilation when webkit is not available

### DIFF
--- a/etg/webview.py
+++ b/etg/webview.py
@@ -52,7 +52,7 @@ def run():
     module.addGlobalStr('wxWebViewDefaultURLStr', 0)
 
     module.addHeaderCode("""\
-        #ifndef wxWebViewIE_H
+        #if wxUSE_WEBVIEW && !defined(wxWebViewIE_H)
         enum wxWebViewIE_EmulationLevel
         {
             wxWEBVIEWIE_EMU_DEFAULT =    0,


### PR DESCRIPTION
Don't define an extra set of wxWebViewIE_EmulationLevel enums when webkit is not available.
