### PR TITLE
The wx.WS_EX_VALIDATE_RECURSIVELY extended style flag is obsolete

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -53,6 +53,11 @@ Other changes in this release:
   like wx.ListCtrl, wx.TreeCtrl and wx.dataview.DataViewCtrl. It has no effect 
   on the other platforms.
 
+* The wx.WS_EX_VALIDATE_RECURSIVELY extended style flag is obsolete, as it is
+  now the default (and only) behavior. The style flag has been added back into
+  wxPython for compatibility, but with a zero value. You can just stop using it
+  in your code with no change in behavior. (#1278)
+  
 
 
 

--- a/etg/defs.py
+++ b/etg/defs.py
@@ -108,6 +108,7 @@ def run():
     # TODO: these should be removed someday
     module.addPyCode("BG_STYLE_CUSTOM = BG_STYLE_PAINT")
     module.addPyCode("ADJUST_MINSIZE = 0")
+    module.addPyCode("WS_EX_VALIDATE_RECURSIVELY = 0")
 
 
     #-----------------------------------------------------------------

--- a/wx/lib/sized_controls.py
+++ b/wx/lib/sized_controls.py
@@ -597,8 +597,6 @@ class SizedDialog(wx.Dialog):
 
         wx.Dialog.__init__(self, *args, **kwargs)
 
-        self.SetExtraStyle(wx.WS_EX_VALIDATE_RECURSIVELY)
-
         self.borderLen = 12
         self.mainPanel = SizedPanel(self, -1)
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1278

