### PR TITLE
Update build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -1876,7 +1876,7 @@ def cmd_cleanall(options, args):
         files += glob.glob(wc)
     delFiles(files)
 
-    cmd_clean_vagrant(options, args)
+    cmd_clean_docker(options, args)
 
 
 def cmd_buildall(options, args):


### PR DESCRIPTION
Call `cmd_clean_docker` in `cmd_cleanall` instead of `cmd_clean_vagrant`

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes: No opened issue that I'm aware of.
