### PR TITLE
Feature: Colouring columns in hypertreelist

### DIFF
--- a/demo/agw/HyperTreeList.py
+++ b/demo/agw/HyperTreeList.py
@@ -1046,6 +1046,9 @@ class HyperTreeListDemo(wx.Frame):
         panel.SetSizer(sizer)
         sizer.Layout()
 
+        self.columnBackgroundColours = [None for i in range(self.tree.GetColumnCount())]
+
+
         self.leftpanel = wx.ScrolledWindow(splitter, -1, style=wx.SUNKEN_BORDER)
         self.PopulateLeftPanel(self.tree.styles, self.tree.events)
 
@@ -1160,6 +1163,20 @@ class HyperTreeListDemo(wx.Frame):
         self.columncolour.Bind(csel.EVT_COLOURSELECT, self.OnColumnColour)
         flexgridcolumn.Add(label, 0, wx.ALIGN_CENTER_VERTICAL)
         flexgridcolumn.Add(self.columncolour, 0)
+
+        label = wx.StaticText(self.leftpanel, -1, "Column Background Colour")
+        label.SetFont(wx.Font(8, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, 0, ""))
+        self.columnchoice = wx.Choice(self.leftpanel, -1, choices = ["1","2","3"])
+        self.columnchoice.SetSelection(0)
+        self.columnchoice.Bind(wx.EVT_CHOICE, self.OnColumnChoiceChanged)
+        self.columnbackgroundcolour = csel.ColourSelect(self.leftpanel, -1, "Choose...", wx.BLACK)
+        self.columnbackgroundcolour.Bind(csel.EVT_COLOURSELECT, self.OnColumnBackgroundColour)
+        self.columnbackgroundcolour.SetColour(wx.Colour(255,255,255,0))
+        flexgridcolumn.Add(label, 0, wx.ALIGN_CENTER_VERTICAL)
+        hSizer = wx.BoxSizer(wx.HORIZONTAL)
+        hSizer.Add(self.columnchoice, 0)
+        hSizer.Add(self.columnbackgroundcolour)
+        flexgridcolumn.Add(hSizer)
 
         label = wx.StaticText(self.leftpanel, -1, "Alignment")
         label.SetFont(wx.Font(8, wx.FONTFAMILY_DEFAULT, wx.FONTSTYLE_NORMAL, wx.FONTWEIGHT_BOLD, 0, ""))
@@ -1359,6 +1376,10 @@ class HyperTreeListDemo(wx.Frame):
         panelsizer.Add(self.tree, 1, wx.EXPAND)
         panelsizer.Layout()
 
+        for col in range(self.tree.GetColumnCount()):
+            colColour = self.columnBackgroundColours[col]
+            self.ColourColumnItems(colColour, col)
+
         panelparent.Thaw()
 
 
@@ -1411,6 +1432,45 @@ class HyperTreeListDemo(wx.Frame):
 
         event.Skip()
 
+    def OnColumnChoiceChanged(self, event):
+
+        selectedColumn = self.columnchoice.GetCurrentSelection()
+
+        if  selectedColumn in range(3):
+            colour = self.columnBackgroundColours[selectedColumn]
+            self.columnbackgroundcolour.SetValue(colour)
+
+    def ColourColumnItems(self, colour, col):
+
+        def ColourItems(item,colour,col):
+
+            next = item
+
+            while next != None:
+
+                self.tree.SetItemBackgroundColour(next, colour, col)
+                
+                cockie=0
+                child, cockie = self.tree.GetNextChild(next, cockie)
+
+                while child != None:
+                    ColourItems(child, colour, col)
+                    child, cockie = self.tree.GetNextChild(next, cockie)
+
+                next = self.tree.GetNextSibling(next)
+
+        root = self.tree.GetRootItem()
+        ColourItems(root, colour, col)
+
+    def OnColumnBackgroundColour(self, event):
+
+        columnBackgroundColour = event.GetValue()
+        selectedColumn = self.columnchoice.GetCurrentSelection()
+        self.columnBackgroundColours[selectedColumn] = columnBackgroundColour
+        
+        self.ColourColumnItems(columnBackgroundColour, selectedColumn)
+
+        event.Skip()
 
     def OnColumnAlignment(self, event):
 

--- a/unittests/test_lib_agw_hypertreelist.py
+++ b/unittests/test_lib_agw_hypertreelist.py
@@ -71,12 +71,53 @@ class lib_agw_hypertreelist_Tests(wtc.WidgetTestCase):
         HTL.TR_TWIST_BUTTONS
         HTL.TR_VIRTUAL
         HTL.TREE_HITTEST_ONITEMCHECKICON
+        HTL.TR_FILL_WHOLE_COLUMN_BACKGROUND
 
     def test_lib_agw_hypertreelistEvents(self):
         HTL.EVT_TREE_ITEM_CHECKED
         HTL.EVT_TREE_ITEM_CHECKING
         HTL.EVT_TREE_ITEM_HYPERLINK
 
+    def test_lib_agw_hypertreelistSetItemColour(self):
+        tree = HTL.HyperTreeList(self.frame)
+        tree.AddColumn("First column")
+        root = tree.AddRoot('root item')
+        child = tree.AppendItem(root, 'child item')
+        
+        self.assertEqual(None, tree.GetItemBackgroundColour(root))
+        
+        colour = wx.RED
+        tree.SetItemBackgroundColour(child, colour)
+        self.assertEqual(colour, tree.GetItemBackgroundColour(child))
+
+    def test_lib_agw_hypertreelistSetItemColourOfColumns(self):
+        tree = HTL.HyperTreeList(self.frame)
+        tree.AddColumn("First column")
+        tree.AddColumn("Second column")
+        tree.AddColumn("Third column")
+        root = tree.AddRoot('root item')
+        child = tree.AppendItem(root, 'child item')
+
+        colColour0 = wx.GREEN
+        colColour2 = wx.RED
+        tree.SetItemBackgroundColour(child, colColour0)
+        tree.SetItemBackgroundColour(child, colColour2, column=2)
+
+        self.assertEqual(colColour2, tree.GetItemBackgroundColour(child, column=2))
+        self.assertNotEqual(tree.GetItemBackgroundColour(child),
+                         tree.GetItemBackgroundColour(child,column=2))
+        self.assertEqual(None, tree.GetItemBackgroundColour(child, column=1))
+
+    def test_lib_agw_hypertreelistColourWholeItemColumns(self):
+
+        tree = HTL.HyperTreeList(self.frame, agwStyle=HTL.TR_DEFAULT_STYLE|
+                                                      HTL.TR_FILL_WHOLE_COLUMN_BACKGROUND)
+        tree.AddColumn("First column")
+        tree.AddColumn("Second column")
+        root = tree.AddRoot('root item')
+            
+        tree.SetItemBackgroundColour(root, wx.RED)
+        tree.SetItemBackgroundColour(root, wx.GREEN, column=1)
 
 #---------------------------------------------------------------------------
 


### PR DESCRIPTION
Till now it is not possible to colour the columns in a hypertreelist 
(except the first).
I need this feature, because I want to highlight differencies between columns!

![hypertreelist_coloured_columns](https://user-images.githubusercontent.com/30863072/63857376-e0360680-c9a3-11e9-970c-fb89d6025298.JPG)



