### PR TITLE
Update buttons.py

### DIFF
--- a/wx/lib/buttons.py
+++ b/wx/lib/buttons.py
@@ -174,17 +174,18 @@ class GenButton(wx.Control):
         self.SetInitialSize(size)
         self.SetBackgroundColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNFACE))
 
-        self.Bind(wx.EVT_LEFT_DOWN,        self.OnLeftDown)
-        self.Bind(wx.EVT_LEFT_UP,          self.OnLeftUp)
-        self.Bind(wx.EVT_LEFT_DCLICK,      self.OnLeftDown)
-        self.Bind(wx.EVT_MOTION,           self.OnMotion)
-        self.Bind(wx.EVT_SET_FOCUS,        self.OnGainFocus)
-        self.Bind(wx.EVT_KILL_FOCUS,       self.OnLoseFocus)
-        self.Bind(wx.EVT_KEY_DOWN,         self.OnKeyDown)
-        self.Bind(wx.EVT_KEY_UP,           self.OnKeyUp)
-        self.Bind(wx.EVT_PAINT,            self.OnPaint)
-        self.Bind(wx.EVT_ERASE_BACKGROUND, lambda evt: None)
-        self.Bind(wx.EVT_SIZE,             self.OnSize)
+        self.Bind(wx.EVT_LEFT_DOWN,          self.OnLeftDown)
+        self.Bind(wx.EVT_LEFT_UP,            self.OnLeftUp)
+        self.Bind(wx.EVT_LEFT_DCLICK,        self.OnLeftDown)
+        self.Bind(wx.EVT_MOTION,             self.OnMotion)
+        self.Bind(wx.EVT_SET_FOCUS,          self.OnGainFocus)
+        self.Bind(wx.EVT_KILL_FOCUS,         self.OnLoseFocus)
+        self.Bind(wx.EVT_MOUSE_CAPTURE_LOST, self.OnLoseCapture)
+        self.Bind(wx.EVT_KEY_DOWN,           self.OnKeyDown)
+        self.Bind(wx.EVT_KEY_UP,             self.OnKeyUp)
+        self.Bind(wx.EVT_PAINT,              self.OnPaint)
+        self.Bind(wx.EVT_ERASE_BACKGROUND,   lambda evt: None)
+        self.Bind(wx.EVT_SIZE,               self.OnSize)
         self.InitOtherEvents()
 
 
@@ -543,7 +544,7 @@ class GenButton(wx.Control):
         :param `event`: a :class:`wx.MouseEvent` event to be processed.
         """
 
-        if not self.IsEnabled():
+        if (not self.IsEnabled()) or self.HasCapture():
             return
 
         self.up = False
@@ -620,6 +621,18 @@ class GenButton(wx.Control):
         """
 
         self.hasFocus = False
+        self.Refresh()
+        self.Update()
+
+
+    def OnLoseCapture(self, event):
+        """
+        Handles the ``wx.EVT_MOUSE_CAPTURE_LOST`` event for :class:`GenButton`.
+
+        :param `event`: a :class:`wx.MouseCaptureLostEvent` event to be processed.
+        """
+
+        self.up = True
         self.Refresh()
         self.Update()
 
@@ -962,6 +975,9 @@ class __ToggleMixin(object):
             return
 
         self.saveUp = self.up
+        if self.HasCapture():
+            return
+
         self.up = not self.up
         self.CaptureMouse()
         self.SetFocus()


### PR DESCRIPTION
Fixes #1339 GenButton Capture issues

Unusual mouse capture issues which cropped up on a severely unresponsive machine (see https://discuss.wxpython.org/t/genbutton-mouse-capture/34081).

To patch I
- Added checks for attempts to capture the mouse more than once
- Added a mouse capture lost handler.  I wasn't sure what the behaviour should be so guessed at resetting the button to its unpressed state.

Difficult to test as I can't reproduce the original conditions. I tested the changes as far as possible (with some temporary CaptureMouse() calls to simulate unexpected circumstances) with wxPython 3.0.2.0 as that's the version I'm using.  Then applied the same patch to the Phoenix code.
