### PR TITLE
Check for Python errors upon return from overloaded virtual methods

### DIFF
--- a/etg/dataview.py
+++ b/etg/dataview.py
@@ -279,7 +279,12 @@ def run():
     # an out parameter.
     m.virtualCatcherCode = """\
         PyObject *sipResObj = sipCallMethod(&sipIsErr, sipMethod, "D", editor, sipType_wxWindow, NULL);
-        if (sipResObj == Py_None) {
+        if (sipResObj == NULL) {
+            if (PyErr_Occurred())
+                PyErr_Print();
+            sipRes = false;
+        }
+        else if (sipResObj == Py_None) {
             sipRes = false;
         } else {
             sipRes = true;

--- a/etg/grid.py
+++ b/etg/grid.py
@@ -243,14 +243,19 @@ def run():
                 result = sipCallMethod(0, sipMethod, "iiDN", row, col,
                                        const_cast<wxGrid *>(grid),sipType_wxGrid,NULL,
                                        new wxString(oldval),sipType_wxString,NULL);
-                if (result == Py_None) {
+                if (result == NULL) {
+                    if (PyErr_Occurred())
+                        PyErr_Print();
+                    sipRes = false;
+                }
+                else if (result == Py_None) {
                     sipRes = false;
                 }
                 else {
                     sipRes = true;
                     *newval = Py2wxString(result);
                 }
-                Py_DECREF(result);
+                Py_XDECREF(result);
                 """  if pureVirtual else "",  # only used with the base class
             )
 
@@ -337,7 +342,12 @@ def run():
     m.virtualCatcherCode = """\
         // virtualCatcherCode for GridTableBase.GetValue
         PyObject *result = sipCallMethod(&sipIsErr, sipMethod, "ii", row, col);
-        if (result == Py_None) {
+        if (result == NULL) {
+            if (PyErr_Occurred())
+                PyErr_Print();
+            sipRes = "";
+        }
+        else if (result == Py_None) {
             sipRes = "";
         }
         else {

--- a/etg/propgrideditors.py
+++ b/etg/propgrideditors.py
@@ -57,7 +57,12 @@ def run():
         PyObject *sipResObj = sipCallMethod(&sipIsErr, sipMethod, "DD",
                                             property, sipType_wxPGProperty, NULL,
                                             ctrl, sipType_wxWindow, NULL);
-        if (sipResObj == Py_None) {
+        if (sipResObj == NULL) {
+            if (PyErr_Occurred())
+                PyErr_Print();
+            sipRes = false;
+        }
+        else if (sipResObj == Py_None) {
             sipRes = false;
         } else if (sipResObj && !sipIsErr) {
             sipParseResult(&sipIsErr, sipMethod, sipResObj, "(bH5)", &sipRes, sipType_wxPGVariant, &variant);

--- a/etg/taskbar.py
+++ b/etg/taskbar.py
@@ -60,7 +60,8 @@ def run():
     method.virtualCatcherCode = """\
         // VirtualCatcherCode for wxTaskBarIcon.CreatePopupMenu
         PyObject *sipResObj = sipCallMethod(0, sipMethod, "");
-        sipParseResult(0, sipMethod, sipResObj, "H0", sipType_wxMenu, &sipRes);
+        if (!sipResObj || sipParseResult(0, sipMethod, sipResObj, "H0", sipType_wxMenu, &sipRes) < 0)
+            PyErr_Print();
         if (sipRes) {
             sipTransferTo(sipResObj, Py_None);
         }


### PR DESCRIPTION

Some cases of virtualCatcherCode were not properly checking for Python exceptions. This PR plugs those holes.