### PR TITLE
Remove tracking of application instance in wxPyApp

### DIFF
--- a/etg/app.py
+++ b/etg/app.py
@@ -43,7 +43,7 @@ def run():
 
     etgtools.prependText(c.detailedDoc,
          "Note that it is not intended for this class to be used directly from "
-         "Python. It is wrapped just for inheriting its methods from :class:`App`.")
+         "Python. It is wrapped just for inheriting its methods in :class:`App`.")
 
     # There's no need for the command line stuff as Python has its own ways to
     # deal with that
@@ -225,12 +225,11 @@ def run():
     module.insertItemBefore(c, enum)
 
     module.addHeaderCode("""\
-        class wxPyApp;
-        wxPyApp* wxGetApp();
+        wxAppConsole* wxGetApp();
         """)
     module.find('wxTheApp').ignore()
     f = module.find('wxGetApp')
-    f.type = 'wxPyApp*'
+    f.type = 'wxAppConsole*'
     f.briefDoc = "Returns the current application object."
     f.detailedDoc = []
 

--- a/src/app_ex.cpp
+++ b/src/app_ex.cpp
@@ -52,11 +52,10 @@ public:
         m_assertMode = wxAPP_ASSERT_EXCEPTION;
         m_startupComplete = false;
         //m_callFilterEvent = false;
-        ms_appInstance = this;
+        wxApp::SetInstance(this);
     }
 
     ~wxPyApp() {
-        ms_appInstance = NULL;
         wxApp::SetInstance(NULL);
     }
 
@@ -118,7 +117,6 @@ public:
 
     // implementation only
     void SetStartupComplete(bool val) { m_startupComplete = val; }
-    static wxPyApp* ms_appInstance;
 
 private:
     wxAppAssertMode m_assertMode;
@@ -128,7 +126,6 @@ private:
 
 IMPLEMENT_ABSTRACT_CLASS(wxPyApp, wxApp);
 
-wxPyApp* wxPyApp::ms_appInstance = NULL;
 extern PyObject* wxAssertionError;         // Exception object raised for wxASSERT failures
 
 
@@ -349,7 +346,7 @@ bool wxPyApp::IsDisplayAvailable()
 
 
 
-wxPyApp* wxGetApp()
+wxAppConsole* wxGetApp()
 {
-    return wxPyApp::ms_appInstance;
+    return wxApp::GetInstance();
 }


### PR DESCRIPTION
Remove tracking of application instance in wxPyApp, and just use the one already in wxAppConsole instead. This will enable wx.GetApp to still do the right thing when the wxApp is created outside of Python.

Fixes #1126

