### PR TITLE
time.clock() is removed in Python 3.8

### DIFF
--- a/samples/floatcanvas/Animation.py
+++ b/samples/floatcanvas/Animation.py
@@ -7,7 +7,10 @@ this is very old-style code: don't imitate it!
 
 """
 
-from time import clock
+try:
+    from time import process_time as clock
+except ImportError:
+    from time import clock
 import wx
 print(wx.VERSION_STRING)
 from numpy import *

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -98,7 +98,10 @@ __date__ = "31 March 2009"
 
 import wx
 # just for isinstance
-import time
+try:
+    from time import time, process_time as clock
+except ImportError:
+    from time import time, clock
 import warnings
 
 import six
@@ -4751,8 +4754,8 @@ class AuiManager(wx.EvtHandler):
 
         # if the pane's name identifier is blank, create a random string
         if pinfo.name == "" or already_exists:
-            pinfo.name = ("%s%08x%08x%08x") % (pinfo.window.GetName(), int(time.time()),
-                                               int(time.clock()), len(self._panes))
+            pinfo.name = ("%s%08x%08x%08x") % (pinfo.window.GetName(), int(time()),
+                                               int(clock()), len(self._panes))
 
         # set initial proportion (if not already set)
         if pinfo.dock_proportion == 0:


### PR DESCRIPTION
Two more places where `time.clock()` is called. Adopt the imports accordingly.

from Python [docs](https://docs.python.org/3/library/time.html#time.clock):

```
time.clock()

    Deprecated since version 3.3, will be removed in version 3.8: The behaviour of
    this function depends on the platform: use perf_counter() or process_time() 
    instead, depending on your requirements, to have a well defined behaviour.
```