### PR TITLE
Initialize the old value of IntCtrl to the default one

### DIFF
--- a/wx/lib/intctrl.py
+++ b/wx/lib/intctrl.py
@@ -473,7 +473,6 @@ class IntCtrl(wx.TextCtrl):
             self.__allow_long = 0
         else:
             self.__allow_long = 1
-        self.__oldvalue = None
 
         if validator == wx.DefaultValidator:
             validator = IntValidator()
@@ -495,9 +494,7 @@ class IntCtrl(wx.TextCtrl):
             self.SetLongAllowed(allow_long)
         else:
             self.SetLongAllowed(1)
-        self.SetValue(value)
-        self.__oldvalue = 0
-
+        self.ChangeValue(value)
 
     def OnText( self, event ):
         """


### PR DESCRIPTION
Previously, it was initialized to zero.  Thus, the EVT_INT event
wouldn't be triggered if we change the value to zero regardless of the
initial value.  This change fixes the issue.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1365 

