### PR TITLE
Fix numpy version to 1.16.1 for Python 2.7

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,4 +1,4 @@
 # Runtime dependencies needed when using wxPython Phoenix
-numpy
+numpy==1.16.1 ; python_version <= '2.7'
 pillow
 six


### PR DESCRIPTION
Fixes #1374

