### PR TITLE
Use the defined text color in a SuperToolTip

### DIFF
--- a/wx/lib/agw/supertooltip.py
+++ b/wx/lib/agw/supertooltip.py
@@ -320,7 +320,9 @@ class ToolTipWindowBase(object):
             maxWidth = max(bmpWidth+(textWidth+self._spacing*3), maxWidth)
         # Calculate the header height
         height = max(textHeight, bmpHeight)
+        normalText = classParent.GetTextColour()
         if header:
+            dc.SetTextForeground(normalText)
             dc.DrawText(header, bmpXPos+bmpWidth+self._spacing, (height-textHeight+self._spacing)/2)
         if headerBmp and headerBmp.IsOk():
             dc.DrawBitmap(headerBmp, bmpXPos, (height-bmpHeight+self._spacing)/2, True)
@@ -345,7 +347,6 @@ class ToolTipWindowBase(object):
         lines = classParent.GetMessage().split("\n")
         yText = yPos
         embImgPos = yPos
-        normalText = wx.SystemSettings.GetColour(wx.SYS_COLOUR_MENUTEXT)
         hyperLinkText = wx.BLUE
         messagePos = self._getTextExtent(dc, lines[0] if lines else "")[1] // 2 + self._spacing
         for line in lines:


### PR DESCRIPTION
Previously, the text color was hardcoded as the system's text menu
color.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1380 

