### PR TITLE
Preserve executable permission bits

### DIFF
--- a/build.py
+++ b/build.py
@@ -922,7 +922,7 @@ def _setTarItemPerms(tarinfo):
     if tarinfo.isdir():
         tarinfo.mode = 0o755
     else:
-        tarinfo.mode = 0o644
+        tarinfo.mode |= 0o644
     return tarinfo
 
 


### PR DESCRIPTION
Just add rw permissions, not clobber all, to preserve any executable bits that may already be set on some files. An additional fix for #1363, see also #1369.

Fixes #1363

