### PR TITLE
WIP: FileDialog SetExtraControlCreator

### DIFF
--- a/etg/filedlg.py
+++ b/etg/filedlg.py
@@ -38,8 +38,8 @@ def run():
     module.find('wxFileSelectorDefaultWildcardStr').ignore()
 
     c.find('ExtraControlCreatorFunction').ignore()
-
     c.find('SetExtraControlCreator').ignore()
+
     c.addHeaderCode("""\
         wxWindow* _callPythonExtraControlCreator(wxWindow* w)
         {
@@ -49,21 +49,21 @@ def run():
             PyObject* ccf = PyObject_GetAttrString(pyw, "_wxExtraControlCreatorFunction");
             if (ccf == NULL)
                 PyErr_SetString(PyExc_RuntimeError,
-                                            "extra control creator function disappeared");
+                                "extra control creator function disappeared");
             else {
                 PyObject* pycw = PyObject_CallFunction(ccf, "O", pyw);
                 if (pycw != NULL && pycw != Py_None) {
                     if (!sipCanConvertToType(pycw, sipType_wxWindow, SIP_NOT_NONE))
                         PyErr_Format(PyExc_ValueError,
-                                            "control creator did not return wxWindow: %R", pycw);
+                                     "control creator did not return wxWindow: %R", pycw);
                     else {
                         int iserr = 0;
                         cw = (wxWindow*) sipConvertToType(pycw, sipType_wxWindow, NULL,
-                                                            SIP_NOT_NONE, NULL, &iserr);
+                                                          SIP_NOT_NONE, NULL, &iserr);
                         if (iserr) {
-                            PyErr_Format(PyExc_ValueError,
-                                            "conversion failure for control creator "
-                                            "return value: %R", pycw);
+                            PyErr_Format(
+                                PyExc_ValueError,
+                                "conversion failure for control creator return value: %R", pycw);
                             cw = NULL;
                         }
                     }
@@ -72,28 +72,31 @@ def run():
             return cw;
         }
         """)
+
     c.addCppMethod('bool', 'SetExtraControlCreator', '(PyObject* ccf)',
         doc="""\
         Set extra control creator function to be called during dialog creation""",
         body="""\
         bool status = true;
         {
-        wxPyThreadBlocker blocker;
-        PyObject* pySelf = sipGetPyObject(self, sipType_wxWindow);
-        if (pySelf == NULL) {
-            PyErr_SetString(PyExc_ValueError, "expecting wxWindow object");
-            status = false;
-        }
-        else if (!PyCallable_Check(ccf)) {
-            PyErr_SetString(PyExc_ValueError, "expecting function or callable object");
-            status = false;
-        }
-        else if (PyObject_SetAttrString(pySelf, "_wxExtraControlCreatorFunction", ccf) < 0)
-            status = false;
-        self->SetExtraControlCreator(_callPythonExtraControlCreator);
+            wxPyThreadBlocker blocker;
+            PyObject* pySelf = sipGetPyObject(self, sipType_wxWindow);
+            if (pySelf == NULL) {
+                PyErr_SetString(PyExc_ValueError, "expecting wxWindow object");
+                status = false;
+            }
+            else if (!PyCallable_Check(ccf)) {
+                PyErr_SetString(PyExc_ValueError, "expecting function or callable object");
+                status = false;
+            }
+            else if (PyObject_SetAttrString(pySelf, "_wxExtraControlCreatorFunction", ccf) < 0)
+                status = false;
+            else
+                self->SetExtraControlCreator(_callPythonExtraControlCreator);
         }
         return status;
         """)
+
 
     c.find('GetFilenames').ignore()
     c.addCppMethod('wxArrayString*', 'GetFilenames', '()', doc="""\


### PR DESCRIPTION
Replaces #21 

Unfortunately this implementation probably will not work because it's possible for the creator function to be called with some other window as its parent in order to measure the size of the created controls. So we'll need to store and retrieve the creator function PyObject in some other way.
