### PR TITLE
Change the Python 2.7 requirement for numpy to be < 1.17, not ==1.16.1

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -1,5 +1,5 @@
 # Runtime dependencies needed when using wxPython Phoenix
-numpy==1.16.1 ; python_version <= '2.7'
+numpy < 1.17 ; python_version <= '2.7'
 numpy ; python_version >= '3.0'
 pillow
 six


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1415

