### PR TITLE
Use setuptools' monkeypatching when getting supported compiler to build wx

### DIFF
--- a/build.py
+++ b/build.py
@@ -763,7 +763,7 @@ def checkCompiler(quiet=False):
         # Make sure that the compiler that Python wants to use can be found.
         # It will terminate if the compiler is not found or other exceptions
         # are raised.
-        cmd = "import distutils.msvc9compiler as msvc; " \
+        cmd = "import setuptools, distutils.msvc9compiler as msvc; " \
               "mc = msvc.MSVCCompiler(); " \
               "mc.initialize(); " \
               "print(mc.cc)"
@@ -774,7 +774,7 @@ def checkCompiler(quiet=False):
         # Now get the environment variables which that compiler needs from
         # its vcvarsall.bat command and load them into this process's
         # environment.
-        cmd = "import distutils.msvc9compiler as msvc; " \
+        cmd = "import setuptools, distutils.msvc9compiler as msvc; " \
               "arch = msvc.PLAT_TO_VCVARS[msvc.get_platform()]; " \
               "env = msvc.query_vcvarsall(msvc.VERSION, arch); " \
               "print(env)"


### PR DESCRIPTION
Related to #364 

The current build system uses distutils to find an appropriate compiler. setuptools extends distutils to detect more compiler,s such as the VC2017 build tools. Setuptools also patches distutils in such a way that it gives much more detailed errors about what it misses, i.e. not just vcvarsall.bat couldn't be found, but Visual C++ 14.1 is missing, etc.

Filing this as a draft pr. I'm particularly interested in whether the tests will still pass for the several python versions supported.