### PR TITLE
Add stubs for the old webkit classes

### DIFF
--- a/docs/sphinx/itemToModuleMap.json
+++ b/docs/sphinx/itemToModuleMap.json
@@ -6560,6 +6560,7 @@
 "USE_GLCANVAS":"wx.glcanvas.",
 "USE_JOYSTICK":"wx.adv.",
 "USE_MEDIACTRL":"wx.media.",
+"USE_WEBKIT":"wx.webkit.",
 "USE_WEBVIEW":"wx.html2.",
 "Uint16":"wx.",
 "Uint32":"wx.",

--- a/etg/webkit.py
+++ b/etg/webkit.py
@@ -36,6 +36,11 @@ def run():
 
     module.addHeaderCode('#include <wx/html/webkit.h>')
 
+    tools.generateStubs('wxUSE_WEBKIT', module,
+                        extraHdrCode='extern const char* wxWebKitCtrlNameStr;\n',
+                        extraCppCode='const char* wxWebKitCtrlNameStr = "";\n')
+
+
     c = module.find('wxWebKitCtrl')
     assert isinstance(c, etgtools.ClassDef)
     c.addPrivateCopyCtor()


### PR DESCRIPTION
The feature will be disabled when built with the 10.15 SDK, so we need stubs for it.
