### PR TITLE
Backport syntaxwarnings

### DIFF
--- a/wx/lib/masked/maskededit.py
+++ b/wx/lib/masked/maskededit.py
@@ -2645,7 +2645,7 @@ class MaskedEditMixin:
                         raise ve
                     elif replace_to > end:
 ####                        dbg(indent=0)
-                        ve = ValueError('"%s" will not fit into field %d of control "%s"' (choice, index, self.name))
+                        ve = ValueError('"%s" will not fit into field %d of control "%s"' % (choice, index, self.name))
                         ve.value = choice
                         ve.index = index
                         raise ve

--- a/wx/lib/plot/plotcanvas.py
+++ b/wx/lib/plot/plotcanvas.py
@@ -1852,12 +1852,12 @@ class PlotCanvas(wx.Panel):
         # Get ticks and textExtents for axis if required
         xticks = yticks = None
         xTextExtent = yTextExtent = (0, 0)  # No text for ticks
-        if self._xSpec is not 'none':
+        if self._xSpec != 'none':
             xticks = self._xticks(xAxis[0], xAxis[1])
             # w h of x axis text last number on axis
             xTextExtent = dc.GetTextExtent(xticks[-1][1])
 
-        if self._ySpec is not 'none':
+        if self._ySpec != 'none':
             yticks = self._yticks(yAxis[0], yAxis[1])
             if self.logScale[1]:
                 # make sure we have enough room to display SI notation.


### PR DESCRIPTION
This is a backport of a couple fixes for SyntaxWarnings, in case you end up doing another 4.0.x release.