### PR TITLE
GNUMakeBuilder: "make" command controllable via environment

### DIFF
--- a/buildtools/builder.py
+++ b/buildtools/builder.py
@@ -150,7 +150,9 @@ class Builder:
 # Concrete subclasses of abstract Builder interface
 
 class GNUMakeBuilder(Builder):
-    def __init__(self, commandName="make", formatName="GNUMake"):
+    def __init__(self, commandName=None, formatName="GNUMake"):
+        if commandName is None:
+            commandName = os.environ.get("MAKE", "make")
         Builder.__init__(self, commandName=commandName, formatName=formatName)
 
 


### PR DESCRIPTION
Some systems (notably BSDs) install GNU make as "gmake" - just
invoking "make" and hoping it understands GNU arguments will not
work there. Traditionally, an alternative "make" command can be
selected with the MAKE environment variable.
This changes GNUMakeBuilder (and by extension, AutoconfBuilder)
to invoke the command given in $MAKE and fall back to "make" if
MAKE has not been set.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #NNNN

