### PR TITLE
wx.lib.gizmos.ledctrl text offset and text shift issue bugfix

### DIFF
--- a/wx/lib/gizmos/ledctrl.py
+++ b/wx/lib/gizmos/ledctrl.py
@@ -146,7 +146,7 @@ class LEDNumberCtrl(wx.Control):
         """
         if alignment != self.m_alignment:
             self.m_alignment = alignment
-            self._recalcInternals(self.GetClientSize())
+            self._recalcInternals()
 
             if redraw:
                 self.Refresh(False)
@@ -173,7 +173,7 @@ class LEDNumberCtrl(wx.Control):
                 assert ch in '0123456789-.: ', "LEDNumberCtrl can only display numeric string values."
 
             self.m_value = value
-            self._recalcInternals(self.GetClientSize())
+            self._recalcInternals()
 
             if redraw:
                 self.Refresh(False)
@@ -185,7 +185,7 @@ class LEDNumberCtrl(wx.Control):
 
 
     def OnSize(self, evt):
-        self._recalcInternals(evt.GetSize())
+        wx.CallAfter(self._recalcInternals)
         evt.Skip()
 
 
@@ -203,7 +203,7 @@ class LEDNumberCtrl(wx.Control):
             i -= offset
             # Draw faded lines if wanted.
             if self.m_drawFaded and ch != '.':
-                self._drawDigit(dc, c.DIGITALL, i);
+                self._drawDigit(dc, c.DIGITALL, i)
 
             if ch == '.':
                 # draw the decimal point in the previous segment
@@ -216,36 +216,28 @@ class LEDNumberCtrl(wx.Control):
                 self._drawDigit(dc, c.DIGITS[ch], i)
 
 
-    def _recalcInternals(self, size):
-        height = size.Height
+    def _recalcInternals(self):
+        clientWidth, height = self.GetClientSize()
 
-        if (height * 0.075) < 1:
-            self.m_lineMargin = 1
-        else:
-            self.m_lineMargin = int(height * 0.075)
-
-        if (height * 0.275) < 1:
-            self.m_lineLength = 1
-        else:
-            self.m_lineLength = int(height * 0.275)
+        self.m_lineMargin = max(1, int(height * 0.075))
+        self.m_lineLength = max(1, int(height * 0.275))
 
         self.m_lineWidth = self.m_lineMargin
         self.m_digitMargin = self.m_lineMargin * 4
 
         # Count the number of characters in the string; '.' characters are not
         # included because they do not take up space in the display
-        count = 0;
+        count = 0
         for ch in self.m_value:
             if ch != '.':
                 count += 1
 
         valueWidth = (self.m_lineLength + self.m_digitMargin) * count
-        clientWidth = size.Width
 
         if self.m_alignment == LED_ALIGN_LEFT:
-            self.m_leftStartPos = self.m_lineMargin
+            self.m_leftStartPos = (self.m_lineMargin * 3)
         elif self.m_alignment == LED_ALIGN_RIGHT:
-            self.m_leftStartPos = clientWidth - valueWidth - self.m_lineMargin
+            self.m_leftStartPos = clientWidth - valueWidth - (self.m_lineMargin * 3)
         elif self.m_alignment == LED_ALIGN_CENTER:
             self.m_leftStartPos = int((clientWidth - valueWidth) / 2)
         else:
@@ -268,40 +260,40 @@ class LEDNumberCtrl(wx.Control):
         dc.SetPen(wx.Pen(lineColor, self.m_lineWidth))
 
         if digit & c.LINE1:
-            dc.DrawLine(XPos + self.m_lineMargin * 2, self.m_lineMargin,
-                        XPos + self.m_lineLength + self.m_lineMargin * 2, self.m_lineMargin)
+            dc.DrawLine(XPos + self.m_lineMargin * 2, self.m_lineMargin * 2,
+                        XPos + self.m_lineLength + self.m_lineMargin * 2, self.m_lineMargin * 2)
 
         if digit & c.LINE2:
-            dc.DrawLine(XPos + self.m_lineLength + self.m_lineMargin * 3, self.m_lineMargin * 2,
-                        XPos + self.m_lineLength + self.m_lineMargin * 3, self.m_lineLength + (self.m_lineMargin * 2))
+            dc.DrawLine(XPos + self.m_lineLength + self.m_lineMargin * 3, self.m_lineMargin * 3,
+                        XPos + self.m_lineLength + self.m_lineMargin * 3, self.m_lineLength + (self.m_lineMargin * 3))
 
         if digit & c.LINE3:
-            dc.DrawLine(XPos + self.m_lineLength + self.m_lineMargin * 3, self.m_lineLength + (self.m_lineMargin * 4),
-                        XPos + self.m_lineLength + self.m_lineMargin * 3, self.m_lineLength * 2 + (self.m_lineMargin * 4))
+            dc.DrawLine(XPos + self.m_lineLength + self.m_lineMargin * 3, self.m_lineLength + (self.m_lineMargin * 5),
+                        XPos + self.m_lineLength + self.m_lineMargin * 3, self.m_lineLength * 2 + (self.m_lineMargin * 5))
 
         if digit & c.LINE4:
-            dc.DrawLine(XPos + self.m_lineMargin * 2, self.m_lineLength * 2 + (self.m_lineMargin * 5),
-                        XPos + self.m_lineLength + self.m_lineMargin * 2, self.m_lineLength * 2 + (self.m_lineMargin * 5))
+            dc.DrawLine(XPos + self.m_lineMargin * 2, self.m_lineLength * 2 + (self.m_lineMargin * 6),
+                        XPos + self.m_lineLength + self.m_lineMargin * 2, self.m_lineLength * 2 + (self.m_lineMargin * 6))
 
         if digit & c.LINE5:
-            dc.DrawLine(XPos + self.m_lineMargin, self.m_lineLength + (self.m_lineMargin * 4),
-                        XPos + self.m_lineMargin, self.m_lineLength * 2 + (self.m_lineMargin * 4))
+            dc.DrawLine(XPos + self.m_lineMargin, self.m_lineLength + (self.m_lineMargin * 5),
+                        XPos + self.m_lineMargin, self.m_lineLength * 2 + (self.m_lineMargin * 5))
 
         if digit & c.LINE6:
-            dc.DrawLine(XPos + self.m_lineMargin, self.m_lineMargin * 2,
-                        XPos + self.m_lineMargin, self.m_lineLength + (self.m_lineMargin * 2))
+            dc.DrawLine(XPos + self.m_lineMargin, self.m_lineMargin * 3,
+                        XPos + self.m_lineMargin, self.m_lineLength + (self.m_lineMargin * 3))
 
         if digit & c.LINE7:
-            dc.DrawLine(XPos + self.m_lineMargin * 2, self.m_lineLength + (self.m_lineMargin * 3),
-                        XPos + self.m_lineMargin * 2 + self.m_lineLength, self.m_lineLength + (self.m_lineMargin * 3))
+            dc.DrawLine(XPos + self.m_lineMargin * 2, self.m_lineLength + (self.m_lineMargin * 4),
+                        XPos + self.m_lineMargin * 2 + self.m_lineLength, self.m_lineLength + (self.m_lineMargin * 4))
 
         if digit & c.DECIMALSIGN:
-            dc.DrawLine(XPos + self.m_lineLength + self.m_lineMargin * 4, self.m_lineLength * 2 + (self.m_lineMargin * 5),
-                        XPos + self.m_lineLength + self.m_lineMargin * 4, self.m_lineLength * 2 + (self.m_lineMargin * 5))
+            dc.DrawLine(XPos + self.m_lineLength + self.m_lineMargin * 4, self.m_lineLength * 2 + (self.m_lineMargin * 6),
+                        XPos + self.m_lineLength + self.m_lineMargin * 4, self.m_lineLength * 2 + (self.m_lineMargin * 6))
 
         if digit & c.COLON:
             dc.SetBrush(wx.Brush(lineColor))
             centerX = XPos + (self.m_lineLength + self.m_digitMargin) / 2
             radius = self.m_lineWidth / 2
-            dc.DrawCircle(centerX, (self.m_lineLength + (self.m_lineMargin * 3)) / 2, radius)
-            dc.DrawCircle(centerX, (self.m_lineLength * 2 + (self.m_lineMargin * 5)) * 3 / 4, radius)
+            dc.DrawCircle(centerX, (self.m_lineLength + (self.m_lineMargin * 4)) / 2, radius)
+            dc.DrawCircle(centerX, (self.m_lineLength * 2 + (self.m_lineMargin * 6)) * 3 / 4, radius)


### PR DESCRIPTION
This was caused by the use of GetClientSize being used when the control is constructed and then event.GetSize() when a size event took place. These 2 methods return different values and causes the text to shift. After this issue was solved another issue existed. there is a border around the control. this border is not directly specified to be drawn when the widget is rendered. the dc defaults to a white pen with a width of 1. a pen is not set before drawing the box. so the white pen there for gets used. This white border is not taken into consideration when the text is drawn and causes the text to be offset slightly. this corrects the offset issue. There is also no calculation in place to determine the actual width and actual height of each character and without having that it is more like a guess to figure out exactly where to draw the characters to have them be centered correctly inside of the box. I kept the same mechanism in place and made an adjustment to fix this issue i believe. I do think that the current way it is being done makes the code a tad more difficult to read and could be simplified. This is something I may take care of in a future PR.

There is no issue that has been made for this problem. 

Please do some tests to ensure that the repairs have been made correctly and are going to work properly.



