### PR TITLE
Fix GLCanvas demo when using HiDPI display

### DIFF
--- a/demo/GLCanvas.py
+++ b/demo/GLCanvas.py
@@ -102,7 +102,7 @@ class MyCanvasBase(glcanvas.GLCanvas):
 
 
     def DoSetViewport(self):
-        size = self.size = self.GetClientSize()
+        size = self.size = self.GetClientSize() * self.GetContentScaleFactor()
         self.SetCurrent(self.context)
         glViewport(0, 0, size.width, size.height)
 


### PR DESCRIPTION
OpenGL operates using physical pixels, so we need to factor in the scale factor when setting the GL viewport.

Fixes #1497 