### PR TITLE
Removed early termination test in CalculateDimensions of pdfViewer to…

### DIFF
--- a/wx/lib/pdfviewer/viewer.py
+++ b/wx/lib/pdfviewer/viewer.py
@@ -336,8 +336,6 @@ class pdfViewer(wx.ScrolledWindow):
                 self.font_scale_size = 1.0 / device_scale
 
         self.winwidth, self.winheight = self.GetClientSize()
-        if self.winheight < 100:
-            return
         self.Ypage = self.pageheight + self.nom_page_gap
         if self.zoomscale > 0.0:
             self.scale = self.zoomscale * device_scale
@@ -346,6 +344,8 @@ class pdfViewer(wx.ScrolledWindow):
                 self.scale = self.winwidth / self.pagewidth
             else:                           # fit page
                 self.scale = self.winheight / self.pageheight
+        if self.scale == 0.0: # this could happen if the window was not yet initialized
+            self.scale = 1.0
         self.Xpagepixels = int(round(self.pagewidth*self.scale))
         self.Ypagepixels = int(round(self.Ypage*self.scale))
 


### PR DESCRIPTION
Always perform full initialization of pdfViewer so that expected pdfViewer attributes always exist. Now, instead of performing a partial initialization, correctly handle the case where the containing window is still being initialized and is not reporting a correct client size.

Fixes #1177 

