### PR TITLE
Fixed a bug in the tabHeight calculation.

### DIFF
--- a/wx/lib/agw/flatnotebook.py
+++ b/wx/lib/agw/flatnotebook.py
@@ -2197,15 +2197,11 @@ class FNBRenderer(object):
         dc = wx.MemoryDC()
         dc.SelectObject(wx.Bitmap(1,1))
 
-        # For GTK it seems that we must do this steps in order
-        # for the tabs will get the proper height on initialization
-        # on MSW, preforming these steps yields wierd results
         normalFont = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
         boldFont = normalFont
 
-        if "__WXGTK__" in wx.PlatformInfo:
-            boldFont.SetWeight(wx.FONTWEIGHT_BOLD)
-            dc.SetFont(boldFont)
+        boldFont.SetWeight(wx.FONTWEIGHT_BOLD)
+        dc.SetFont(boldFont)
 
         height = dc.GetCharHeight()
 


### PR DESCRIPTION
flatnotebook:

The tabHeight gets calculated several times in flatnotebook.py. In the FNBRenderer class in "CalcTabHeight" the calculation is done differently. 
