### PR TITLE
Use WX_CONFIG from the environment if set

### DIFF
--- a/build.py
+++ b/build.py
@@ -1573,13 +1573,16 @@ def cmd_build_py(options, args):
         os.environ['WXPYTHON_RELEASE'] = 'yes'
 
     if not isWindows:
-        WX_CONFIG = posixjoin(BUILD_DIR, 'wx-config')
-        if options.use_syswx:
-            wxcfg = posixjoin(options.prefix, 'bin', 'wx-config')
-            if options.prefix and os.path.exists(wxcfg):
-                WX_CONFIG = wxcfg
-            else:
-                WX_CONFIG = 'wx-config' # hope it is on the PATH
+        if 'WX_CONFIG' in os.environ:
+            WX_CONFIG = os.environ['WX_CONFIG']
+        else:
+            WX_CONFIG = posixjoin(BUILD_DIR, 'wx-config')
+            if options.use_syswx:
+                wxcfg = posixjoin(options.prefix, 'bin', 'wx-config')
+                if options.prefix and os.path.exists(wxcfg):
+                    WX_CONFIG = wxcfg
+                else:
+                    WX_CONFIG = 'wx-config' # hope it is on the PATH
 
 
     wafBuildBase = wafBuildDir = getWafBuildBase()

--- a/build.py
+++ b/build.py
@@ -1573,9 +1573,8 @@ def cmd_build_py(options, args):
         os.environ['WXPYTHON_RELEASE'] = 'yes'
 
     if not isWindows:
-        if 'WX_CONFIG' in os.environ:
-            WX_CONFIG = os.environ['WX_CONFIG']
-        else:
+        WX_CONFIG = os.environ.get('WX_CONFIG', None)
+        if WX_CONFIG is None:
             WX_CONFIG = posixjoin(BUILD_DIR, 'wx-config')
             if options.use_syswx:
                 wxcfg = posixjoin(options.prefix, 'bin', 'wx-config')

--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -400,10 +400,7 @@ class Configuration(object):
         """
         # if WX_CONFIG hasn't been set to an explicit value then construct one.
         if self.WX_CONFIG is None:
-            if 'WX_CONFIG' in os.environ:
-                self.WX_CONFIG = os.environ['WX_CONFIG']
-            else:
-                self.WX_CONFIG='wx-config'
+            self.WX_CONFIG = os.environ.get('WX_CONFIG', 'wx-config')
             port = self.WXPORT
             if port == "x11":
                 port = "x11univ"

--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -400,7 +400,10 @@ class Configuration(object):
         """
         # if WX_CONFIG hasn't been set to an explicit value then construct one.
         if self.WX_CONFIG is None:
-            self.WX_CONFIG='wx-config'
+            if 'WX_CONFIG' in os.environ:
+                self.WX_CONFIG = os.environ['WX_CONFIG']
+            else:
+                self.WX_CONFIG='wx-config'
             port = self.WXPORT
             if port == "x11":
                 port = "x11univ"


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

if WX_CONFIG is set in the environment then use that instead of defaulting to "wx-config"	

Fixes #1488

