### PR TITLE
Fixes issue # 1554:

### DIFF
--- a/buildtools/builder.py
+++ b/buildtools/builder.py
@@ -224,7 +224,7 @@ class MSVCProjectBuilder(Builder):
             if os.environ.has_key(key):
                 self.programDir = os.path.join(os.environ[key], "..", "IDE")
 
-        if self.programDir == None:
+        if self.programDir is None:
             for version in ["9.0", "8", ".NET 2003"]:
                 msvcDir = "C:\\Program Files\\Microsoft Visual Studio %s\\Common7\\IDE" % version
                 if os.path.exists(msvcDir):

--- a/demo/Calendar.py
+++ b/demo/Calendar.py
@@ -59,7 +59,7 @@ def GetMonthList():
     for i in range(13):
         name = wx.lib.calendar.Month[i]
 
-        if name != None:
+        if name is not None:
             monthlist.append(name)
 
     return monthlist

--- a/demo/GridSimple.py
+++ b/demo/GridSimple.py
@@ -182,7 +182,7 @@ class SimpleGrid(gridlib.Grid): ##, mixins.GridAutoEditMixin):
 
 
     def OnIdle(self, evt):
-        if self.moveTo != None:
+        if self.moveTo is not None:
             self.SetGridCursor(self.moveTo[0], self.moveTo[1])
             self.moveTo = None
 

--- a/demo/Main.py
+++ b/demo/Main.py
@@ -2412,7 +2412,7 @@ class wxPythonDemo(wx.Frame):
         about.Destroy()
 
     def OnHelpFind(self, event):
-        if self.finddlg != None:
+        if self.finddlg is not None:
             return
 
         self.nb.SetSelection(1)
@@ -2422,7 +2422,7 @@ class wxPythonDemo(wx.Frame):
 
 
     def OnUpdateFindItems(self, evt):
-        evt.Enable(self.finddlg == None)
+        evt.Enable(self.finddlg is None)
 
 
     def OnFind(self, event):

--- a/demo/RichTextCtrl.py
+++ b/demo/RichTextCtrl.py
@@ -248,17 +248,17 @@ class RichTextFrame(wx.Frame):
             self.textAttr.SetFontFaceName(fontFace)
         if fontSize:
             self.textAttr.SetFontSize(fontSize)
-        if fontBold != None:
+        if fontBold is not None:
             if fontBold:
                 self.textAttr.SetFontWeight(wx.FONTWEIGHT_BOLD)
             else:
                 self.textAttr.SetFontWeight(wx.FONTWEIGHT_NORMAL)
-        if fontItalic != None:
+        if fontItalic is not None:
             if fontItalic:
                 self.textAttr.SetFontStyle(wx.FONTSTYLE_ITALIC)
             else:
                 self.textAttr.SetFontStyle(wx.FONTSTYLE_NORMAL)
-        if fontUnderline != None:
+        if fontUnderline is not None:
             if fontUnderline:
                 self.textAttr.SetFontUnderlined(True)
             else:

--- a/demo/agw/HyperTreeList.py
+++ b/demo/agw/HyperTreeList.py
@@ -929,7 +929,7 @@ class HyperTreeHeaderRenderer(object):
 
     def DrawHeaderButton(self, dc, rect, flags=0, params=None):
 
-        if params != None:
+        if params is not None:
             text_align = params.m_labelAlignment
             bitmap     = params.m_labelBitmap
             text_color = params.m_labelColour
@@ -965,7 +965,7 @@ class HyperTreeHeaderRenderer(object):
 
         dc.SetBackgroundMode(wx.TRANSPARENT)
 
-        if params == None:
+        if params is None:
             return
 
         # We need to draw the text and/or icon bitmap
@@ -1445,14 +1445,14 @@ class HyperTreeListDemo(wx.Frame):
 
             next = item
 
-            while next != None:
+            while next is not None:
 
                 self.tree.SetItemBackgroundColour(next, colour, col)
 
                 cookie=0
                 child, cockie = self.tree.GetNextChild(next, cookie)
 
-                while child != None:
+                while child is not None:
                     ColourItems(child, colour, col)
                     child, cookie = self.tree.GetNextChild(next, cookie)
 
@@ -1466,7 +1466,7 @@ class HyperTreeListDemo(wx.Frame):
         columnBackgroundColour = event.GetValue()
         selectedColumn = self.columnchoice.GetCurrentSelection()
         self.columnBackgroundColours[selectedColumn] = columnBackgroundColour
-        
+
         self.ColourColumnItems(columnBackgroundColour, selectedColumn)
 
         event.Skip()

--- a/demo/agw/RibbonBar.py
+++ b/demo/agw/RibbonBar.py
@@ -517,7 +517,7 @@ class RibbonFrame(wx.Frame):
 
         data = gallery.GetItemClientData(item)
 
-        if name != None:
+        if name is not None:
             name = data.GetName()
 
         return data.GetColour(), name
@@ -531,7 +531,7 @@ class RibbonFrame(wx.Frame):
         gallery = event.GetGallery()
         provider = gallery.GetArtProvider()
 
-        if event.GetGalleryItem() != None:
+        if event.GetGalleryItem() is not None:
             if provider == self._ribbon.GetArtProvider():
                 provider = provider.Clone()
                 gallery.SetArtProvider(provider)
@@ -835,7 +835,7 @@ class RibbonFrame(wx.Frame):
                     item = None
 
             # Colour not in gallery - add it
-            if item == None:
+            if item is None:
                 item = self.AddColourToGallery(gallery, clr.GetAsString(wx.C2S_HTML_SYNTAX), self._bitmap_creation_dc,
                                                clr)
                 gallery.Realize()

--- a/samples/grid/events.py
+++ b/samples/grid/events.py
@@ -117,7 +117,7 @@ class SimpleGrid(wx.grid.Grid):
 
 
     def OnIdle(self, evt):
-        if self.moveTo != None:
+        if self.moveTo is not None:
             self.SetGridCursor(self.moveTo[0], self.moveTo[1])
             self.moveTo = None
 

--- a/samples/ribbon/ribbonbar_demo.py
+++ b/samples/ribbon/ribbonbar_demo.py
@@ -324,7 +324,7 @@ class RibbonFrame(wx.Frame):
     def GetGalleryColour(self, gallery, item, name=None):
         data = gallery.GetItemClientData(item)
 
-        if name != None:
+        if name is not None:
             name = data.GetName()
 
         return data.GetColour(), name
@@ -337,7 +337,7 @@ class RibbonFrame(wx.Frame):
         gallery = event.GetGallery()
         provider = gallery.GetArtProvider()
 
-        if event.GetGalleryItem() != None:
+        if event.GetGalleryItem() is not None:
             if provider == self._ribbon.GetArtProvider():
                 gallery.SetArtProvider(provider)
 
@@ -607,7 +607,7 @@ class RibbonFrame(wx.Frame):
                     item = None
 
             # Colour not in gallery - add it
-            if item == None:
+            if item is None:
                 item = self.AddColourToGallery(gallery,
                                                clr.GetAsString(wx.C2S_HTML_SYNTAX),
                                                self._bitmap_creation_dc,

--- a/unittests/test_xrc.py
+++ b/unittests/test_xrc.py
@@ -23,7 +23,7 @@ class xrc_Tests(wtc.WidgetTestCase):
         self.assertTrue(isinstance(id, int))
 
         ctrl = xrc.XRCCTRL(f, 'TitleText')
-        self.assertTrue(ctrl != None)
+        self.assertTrue(ctrl is not None)
         self.assertTrue(isinstance(ctrl, wx.StaticText))
 
 

--- a/wx/lib/agw/artmanager.py
+++ b/wx/lib/agw/artmanager.py
@@ -1322,7 +1322,7 @@ class ArtManager(wx.EvtHandler):
                 pSetLayeredWindowAttributes = win32api.GetProcAddress(self._winlib,
                                                                       "SetLayeredWindowAttributes")
 
-                if pSetLayeredWindowAttributes == None:
+                if pSetLayeredWindowAttributes is None:
                     return
 
                 exstyle = win32api.GetWindowLong(hwnd, win32con.GWL_EXSTYLE)

--- a/wx/lib/agw/aui/auibar.py
+++ b/wx/lib/agw/aui/auibar.py
@@ -3871,7 +3871,7 @@ class AuiToolBar(wx.Control):
         """
 
         # start a drag event
-        if not self._dragging and self._action_item != None and self._action_pos != wx.Point(-1, -1) and \
+        if not self._dragging and self._action_item is not None and self._action_pos != wx.Point(-1, -1) and \
            abs(event.GetX() - self._action_pos.x) + abs(event.GetY() - self._action_pos.y) > 5:
 
             self.SetToolTip("")

--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -4858,10 +4858,10 @@ class AuiNotebook(wx.Panel):
             self._textCtrl.StopEditing()
 
         ctrl = event.GetEventObject()
-        assert ctrl != None
+        assert ctrl is not None
 
         wnd = ctrl.GetWindowFromIdx(event.GetSelection())
-        assert wnd != None
+        assert wnd is not None
 
         self.SetSelectionToWindow(wnd)
 

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -604,7 +604,7 @@ class AuiPaneInfo(object):
         :note: A pane structure is valid if it has an associated window.
         """
 
-        return self.window != None
+        return self.window is not None
 
 
     def IsMaximized(self):

--- a/wx/lib/agw/aui/tabmdi.py
+++ b/wx/lib/agw/aui/tabmdi.py
@@ -116,11 +116,11 @@ class AuiMDIParentFrame(wx.Frame):
 
         else:
 
-            if pChild.GetMenuBar() == None:
+            if pChild.GetMenuBar() is None:
                 return
 
             # Do we need to save the current bar?
-            if self._pMyMenuBar == None:
+            if self._pMyMenuBar is None:
                 self._pMyMenuBar = self.GetMenuBar()
 
             self.SetMenuBar(pChild.GetMenuBar())

--- a/wx/lib/agw/customtreectrl.py
+++ b/wx/lib/agw/customtreectrl.py
@@ -2623,7 +2623,7 @@ class GenericTreeItem(object):
         # evaluate children
         for child in self._children:
             res, flags = child.HitTest(point, theCtrl, flags, level + 1)
-            if res != None:
+            if res is not None:
                 return res, flags
 
         return None, 0
@@ -3417,7 +3417,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
          ``EVT_TREE_ITEM_CHECKED`` events.
         """
 
-        if checked == None:
+        if checked is None:
             self.AutoToggleChild(item)
         else:
             self.AutoCheckChild(item, checked)
@@ -4646,7 +4646,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
 
         parent = item.GetParent()
 
-        if parent == None:
+        if parent is None:
             # root item doesn't have any siblings
             return None
 
@@ -4674,7 +4674,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
 
         parent = item.GetParent()
 
-        if parent == None:
+        if parent is None:
             # root item doesn't have any siblings
             return None
 
@@ -5314,7 +5314,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
         :param `item`: an instance of :class:`GenericTreeItem`.
         """
 
-        if self._editCtrl != None and item != self._editCtrl.item() and self.IsDescendantOf(item, self._editCtrl.item()):
+        if self._editCtrl is not None and item != self._editCtrl.item() and self.IsDescendantOf(item, self._editCtrl.item()):
             self._editCtrl.StopEditing()
 
         if item != self._key_current and self.IsDescendantOf(item, self._key_current):
@@ -5353,7 +5353,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
 
         self._dirty = True     # do this first so stuff below doesn't cause flicker
 
-        if self._editCtrl != None and self.IsDescendantOf(item, self._editCtrl.item()):
+        if self._editCtrl is not None and self.IsDescendantOf(item, self._editCtrl.item()):
             # can't delete the item being edited, cancel editing it first
             self._editCtrl.StopEditing()
 
@@ -5677,7 +5677,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
 
         parent = crt_item.GetParent()
 
-        if parent == None: # This is root item
+        if parent is None: # This is root item
             return self.TagAllChildrenUntilLast(crt_item, last_item, select)
 
         children = parent.GetChildren()
@@ -7655,14 +7655,14 @@ class CustomTreeCtrl(wx.ScrolledWindow):
         if flags:
             return None, flags
 
-        if self._anchor == None:
+        if self._anchor is None:
             flags = TREE_HITTEST_NOWHERE
             return None, flags
 
         point = self.CalcUnscrolledPosition(*point)
         hit, flags = self._anchor.HitTest(point, self, flags, 0)
 
-        if hit == None:
+        if hit is None:
             flags = TREE_HITTEST_NOWHERE
             return None, flags
 
@@ -7729,7 +7729,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
             else:
                 wx.YieldIfNeeded()
 
-        if self._editCtrl != None and item != self._editCtrl.item():
+        if self._editCtrl is not None and item != self._editCtrl.item():
             self._editCtrl.StopEditing()
 
         if self._editCtrl is None:
@@ -8010,14 +8010,14 @@ class CustomTreeCtrl(wx.ScrolledWindow):
 
             self._dragCount = 0
 
-            if item == None:
-                if self._editCtrl != None and item != self._editCtrl.item():
+            if item is None:
+                if self._editCtrl is not None and item != self._editCtrl.item():
                     self._editCtrl.StopEditing()
                 return  # we hit the blank area
 
             if event.RightDown():
 
-                if self._editCtrl != None and item != self._editCtrl.item():
+                if self._editCtrl is not None and item != self._editCtrl.item():
                     self._editCtrl.StopEditing()
 
                 self._hasFocus = True
@@ -8077,11 +8077,11 @@ class CustomTreeCtrl(wx.ScrolledWindow):
             else: # !RightDown() && !LeftUp() ==> LeftDown() || LeftDClick()
 
                 if not item or not item.IsEnabled():
-                    if self._editCtrl != None and item != self._editCtrl.item():
+                    if self._editCtrl is not None and item != self._editCtrl.item():
                         self._editCtrl.StopEditing()
                     return
 
-                if self._editCtrl != None and item != self._editCtrl.item():
+                if self._editCtrl is not None and item != self._editCtrl.item():
                     self._editCtrl.StopEditing()
 
                 self._hasFocus = True

--- a/wx/lib/agw/flatmenu.py
+++ b/wx/lib/agw/flatmenu.py
@@ -1050,7 +1050,7 @@ class FMRenderer(object):
 
         # switch according to the status
         if state == ControlFocus:
-            if colour == None:
+            if colour is None:
                 penColour   = self.buttonFocusBorderColour
                 brushColour = self.buttonFocusFaceColour
             else:
@@ -1058,14 +1058,14 @@ class FMRenderer(object):
                 brushColour = ArtManager.Get().LightColour(colour, 75)
 
         elif state == ControlPressed:
-            if colour == None:
+            if colour is None:
                 penColour   = self.buttonPressedBorderColour
                 brushColour = self.buttonPressedFaceColour
             else:
                 penColour   = colour
                 brushColour = ArtManager.Get().LightColour(colour, 60)
         else:
-            if colour == None:
+            if colour is None:
                 penColour   = self.buttonBorderColour
                 brushColour = self.buttonFaceColour
             else:
@@ -5026,7 +5026,7 @@ class FlatMenuItem(object):
     def IsSubMenu(self):
         """ Returns whether an item is a sub-menu or not. """
 
-        return self._subMenu != None
+        return self._subMenu is not None
 
 
     def SetNormalBitmap(self, bmp):
@@ -7089,7 +7089,7 @@ class FlatMenu(FlatMenuBase):
          ``wx.NOT_FOUND`` if one was not found.
         """
 
-        if item == None or len(self._itemsArr) == 0:
+        if item is None or len(self._itemsArr) == 0:
             return wx.NOT_FOUND
 
         for i in range(len(self._itemsArr)):

--- a/wx/lib/agw/flatnotebook.py
+++ b/wx/lib/agw/flatnotebook.py
@@ -2169,7 +2169,7 @@ class FNBRenderer(object):
             # Default style
             tabWidth += 2*shapePoints
 
-        hasImage = pc._ImageList != None and pc._pagesInfoVec[tabIdx].GetImageIndex() != -1
+        hasImage = pc._ImageList is not None and pc._pagesInfoVec[tabIdx].GetImageIndex() != -1
 
         # For VC71 style, we only add the icon size (16 pixels)
         if hasImage:
@@ -3657,7 +3657,7 @@ class FNBRendererRibbonTabs(FNBRenderer):
             # Default style
             tabWidth += 2*shapePoints
 
-        hasImage = pc._ImageList != None and pc._pagesInfoVec[tabIdx].GetImageIndex() != -1
+        hasImage = pc._ImageList is not None and pc._pagesInfoVec[tabIdx].GetImageIndex() != -1
 
         # For VC71 style, we only add the icon size (16 pixels)
         if hasImage:
@@ -5631,7 +5631,7 @@ class PageContainer(wx.Panel):
             #! fix for tabfocus
             da_page = self._pParent.GetPage(page)
 
-            if da_page != None:
+            if da_page is not None:
                 da_page.SetFocus()
 
         if not self.IsTabVisible(page):

--- a/wx/lib/agw/floatspin.py
+++ b/wx/lib/agw/floatspin.py
@@ -842,11 +842,11 @@ class FloatSpin(wx.Control):
         :note: This method doesn't modify the current value.
         """
 
-        if (min_val != None):
+        if (min_val is not None):
             self._min = FixedPoint(str(min_val), 20)
         else:
             self._min = None
-        if (max_val != None):
+        if (max_val is not None):
             self._max = FixedPoint(str(max_val), 20)
         else:
             self._max = None
@@ -893,12 +893,12 @@ class FloatSpin(wx.Control):
         :return: A clamped copy of `var`.
         """
 
-        if (self._min != None):
+        if (self._min is not None):
             if (var < self._min):
                 var = self._min
                 return var
 
-        if (self._max != None):
+        if (self._max is not None):
             if (var > self._max):
                 var = self._max
 
@@ -1160,7 +1160,7 @@ class FloatSpin(wx.Control):
     def HasRange(self):
         """ Returns whether :class:`FloatSpin` range has been set or not. """
 
-        return (self._min != None) or (self._max != None)
+        return (self._min is not None) or (self._max is not None)
 
 
     def InRange(self, value):
@@ -1172,10 +1172,10 @@ class FloatSpin(wx.Control):
 
         if (not self.HasRange()):
             return True
-        if (self._min != None):
+        if (self._min is not None):
             if (value < self._min):
                 return False
-        if (self._max != None):
+        if (self._max is not None):
             if (value > self._max):
                 return False
         return True
@@ -1473,7 +1473,7 @@ class FixedPoint(object):
     __copy__ = __deepcopy__ = copy
 
     def __eq__(self, other):
-        if (other == None):
+        if other is None:
             return False
         xn, yn, p = _norm(self, other)
         return not _cmp(xn, yn)

--- a/wx/lib/agw/hypertreelist.py
+++ b/wx/lib/agw/hypertreelist.py
@@ -893,7 +893,7 @@ class TreeListHeaderWindow(wx.Window):
             if image != -1 and imageList:
                 params.m_labelBitmap = imageList.GetBitmap(image)
 
-            if self._headerCustomRenderer != None:
+            if self._headerCustomRenderer is not None:
                self._headerCustomRenderer.DrawHeaderButton(dc, rect, flags, params)
             else:
                 wx.RendererNative.Get().DrawHeaderButton(self, dc, rect, flags,
@@ -902,7 +902,7 @@ class TreeListHeaderWindow(wx.Window):
         # Fill up any unused space to the right of the columns
         if x < w:
             rect = wx.Rect(x, 0, w-x, h)
-            if self._headerCustomRenderer != None:
+            if self._headerCustomRenderer is not None:
                self._headerCustomRenderer.DrawHeaderButton(dc, rect)
             else:
                 wx.RendererNative.Get().DrawHeaderButton(self, dc, rect)
@@ -2591,7 +2591,7 @@ class TreeListMainWindow(CustomTreeCtrl):
 
         self._dirty = True     # do this first so stuff below doesn't cause flicker
 
-        if self._editCtrl != None and self.IsDescendantOf(item, self._editCtrl.item()):
+        if self._editCtrl is not None and self.IsDescendantOf(item, self._editCtrl.item()):
             # can't delete the item being edited, cancel editing it first
             self._editCtrl.StopEditing()
 
@@ -2639,7 +2639,7 @@ class TreeListMainWindow(CustomTreeCtrl):
         :param `item`: an instance of :class:`TreeListItem`.
         """
 
-        if self._editCtrl != None and item != self._editCtrl.item() and self.IsDescendantOf(item, self._editCtrl.item()):
+        if self._editCtrl is not None and item != self._editCtrl.item() and self.IsDescendantOf(item, self._editCtrl.item()):
             self._editCtrl.StopEditing()
 
         if self.IsDescendantOf(item, self._selectItem):
@@ -3099,7 +3099,7 @@ class TreeListMainWindow(CustomTreeCtrl):
                         itemrect = wx.Rect(text_x-2, item.GetY() + off_h, text_w+2*_MARGIN, total_h - off_h)
                     colBgX = item.GetBackgroundColour(i)
 
-                    if colBgX != None and i != 0:
+                    if colBgX is not None and i != 0:
                         dc.SetBrush(wx.Brush(colBgX, wx.SOLID))
                         dc.SetPen(wx.TRANSPARENT_PEN)
                         dc.DrawRectangle(itemrect)
@@ -3116,7 +3116,7 @@ class TreeListMainWindow(CustomTreeCtrl):
                         itemrect = wx.Rect(text_x-2, item.GetY() + off_h, text_w+2*_MARGIN, total_h - off_h)
                     colBgX = item.GetBackgroundColour(i)
 
-                    if colBgX != None:
+                    if colBgX is not None:
                         dc.SetBrush(wx.Brush(colBgX, wx.SOLID))
                         dc.SetPen(wx.TRANSPARENT_PEN)
                         dc.DrawRectangle(itemrect)
@@ -3570,7 +3570,7 @@ class TreeListMainWindow(CustomTreeCtrl):
         if self._dirty:
             self.CalculatePositions()
 
-        if self._editCtrl != None and (item != self._editCtrl.item() or column != self._editCtrl.column()):
+        if self._editCtrl is not None and (item != self._editCtrl.item() or column != self._editCtrl.column()):
             self._editCtrl.StopEditing()
 
         self._editCtrl = self._owner.CreateEditCtrl(item, column)
@@ -3677,7 +3677,7 @@ class TreeListMainWindow(CustomTreeCtrl):
 
         if (event.LeftDown() or event.LeftUp() or event.RightDown() or \
             event.RightUp() or event.LeftDClick() or event.Dragging()):
-            if self._editCtrl != None and (item != self._editCtrl.item() or column != self._editCtrl.column()):
+            if self._editCtrl is not None and (item != self._editCtrl.item() or column != self._editCtrl.column()):
                 self._editCtrl.StopEditing()
 
         # We do not want a tooltip if we are dragging, or if the edit timer is running
@@ -3737,7 +3737,7 @@ class TreeListMainWindow(CustomTreeCtrl):
 
                 return # nothing to do, already done
 
-            if item == None:
+            if item is None:
                 return # we need an item to dragging
 
             # determine drag start
@@ -3823,7 +3823,7 @@ class TreeListMainWindow(CustomTreeCtrl):
             self._dragCount = 0
 
         # we process only the messages which happen on tree items
-        if (item == None or not self.IsItemEnabled(item)) and not event.GetWheelRotation():
+        if (item is None or not self.IsItemEnabled(item)) and not event.GetWheelRotation():
             self._owner.GetEventHandler().ProcessEvent(event)
             return
 
@@ -3850,7 +3850,7 @@ class TreeListMainWindow(CustomTreeCtrl):
                 if item == self._current and self._curColumn != -1 and \
                    self._owner.GetHeaderWindow().IsColumnEditable(self._curColumn) and \
                    flags & (wx.TREE_HITTEST_ONITEMLABEL | TREE_HITTEST_ONITEMCOLUMN) and \
-                   ((self._editCtrl != None and column != self._editCtrl.column()) or self._editCtrl is None):
+                   ((self._editCtrl is not None and column != self._editCtrl.column()) or self._editCtrl is None):
                     self._editTimer.Start(_EDIT_TIMER_TICKS, wx.TIMER_ONE_SHOT)
 
                 self._lastOnSame = False

--- a/wx/lib/agw/pygauge.py
+++ b/wx/lib/agw/pygauge.py
@@ -218,7 +218,7 @@ class PyGauge(wx.Window):
     def GetBarGradient(self):
         """ Returns a tuple containing the gradient start and end colours. """
 
-        if self._barGradient == None:
+        if self._barGradient is None:
             return None
 
         return self._barGradient[0]

--- a/wx/lib/agw/ribbon/art_msw.py
+++ b/wx/lib/agw/ribbon/art_msw.py
@@ -138,11 +138,11 @@ class RibbonMSWArtProvider(object):
 
         """
 
-        if primary != None:
+        if primary is not None:
             primary = self._primary_scheme_colour
-        if secondary != None:
+        if secondary is not None:
             secondary = self._secondary_scheme_colour
-        if tertiary != None:
+        if tertiary is not None:
             tertiary = self._tertiary_scheme_colour
 
         return primary, secondary, tertiary
@@ -1755,7 +1755,7 @@ class RibbonMSWArtProvider(object):
         true_rect = wx.Rect(*rect)
         true_rect = self.RemovePanelPadding(true_rect)
 
-        if wnd.GetExpandedPanel() != None:
+        if wnd.GetExpandedPanel() is not None:
             client_rect = wx.Rect(*true_rect)
             client_rect.x += 1
             client_rect.width -= 2
@@ -1896,7 +1896,7 @@ class RibbonMSWArtProvider(object):
         if isinstance(wnd, PANEL.RibbonPanel):
             panel = wnd
             hovered = allow_hovered and panel.IsHovered()
-            if panel.GetExpandedDummy() != None:
+            if panel.GetExpandedDummy() is not None:
                 offset = panel.GetExpandedDummy().GetPosition()
                 parent = panel.GetExpandedDummy().GetParent()
 
@@ -1906,7 +1906,7 @@ class RibbonMSWArtProvider(object):
                 panel = parent
                 if isinstance(panel, PANEL.RibbonPanel):
                     hovered = allow_hovered and panel.IsHovered()
-                    if panel.GetExpandedDummy() != None:
+                    if panel.GetExpandedDummy() is not None:
                         parent = panel.GetExpandedDummy()
 
             page = parent
@@ -1918,7 +1918,7 @@ class RibbonMSWArtProvider(object):
             if parent is None:
                 break
 
-        if page != None:
+        if page is not None:
             self.DrawPartialPageBackground(dc, wnd, rect, page, offset, hovered)
             return
 
@@ -2369,7 +2369,7 @@ class RibbonMSWArtProvider(object):
         else:
             client_size.IncBy(6, 6)
 
-        if client_offset != None:
+        if client_offset is not None:
             if self._flags & RIBBON_BAR_FLOW_VERTICAL:
                 client_offset = wx.Point(2, 3)
             else:
@@ -2404,7 +2404,7 @@ class RibbonMSWArtProvider(object):
         else:
             size.DecBy(6, 6)
 
-        if client_offset != None:
+        if client_offset is not None:
             if self._flags & RIBBON_BAR_FLOW_VERTICAL:
                 client_offset = wx.Point(2, 3)
             else:
@@ -2673,10 +2673,10 @@ class RibbonMSWArtProvider(object):
 
         """
 
-        if desired_bitmap_size != None:
+        if desired_bitmap_size is not None:
             desired_bitmap_size = wx.Size(16, 16)
 
-        if expanded_panel_direction != None:
+        if expanded_panel_direction is not None:
             if self._flags & RIBBON_BAR_FLOW_VERTICAL:
                 expanded_panel_direction = wx.EAST
             else:

--- a/wx/lib/agw/ribbon/bar.py
+++ b/wx/lib/agw/ribbon/bar.py
@@ -1028,7 +1028,7 @@ class RibbonBar(RibbonControl):
                 notification.SetEventObject(self)
                 self.GetEventHandler().ProcessEvent(notification)
 
-        elif tab == None:
+        elif tab is None:
             if self._tab_scroll_left_button_rect.Contains(event.GetPosition()):
                 self._tab_scroll_left_button_state |= RIBBON_SCROLL_BTN_ACTIVE | RIBBON_SCROLL_BTN_HOVERED
                 self.RefreshTabBar()

--- a/wx/lib/agw/ribbon/buttonbar.py
+++ b/wx/lib/agw/ribbon/buttonbar.py
@@ -990,7 +990,7 @@ class RibbonButtonBar(RibbonControl):
 
     def MakeLayouts(self):
 
-        if self._layouts_valid or self._art == None:
+        if self._layouts_valid or self._art is None:
             return
 
         # Clear existing layouts
@@ -1075,7 +1075,7 @@ class RibbonButtonBar(RibbonControl):
         if count >= first_btn or used_width >= available_width:
             return False, count
 
-        if last_button != None:
+        if last_button is not None:
             last_button = count
 
         layout = RibbonButtonBarLayout()
@@ -1158,17 +1158,17 @@ class RibbonButtonBar(RibbonControl):
 
                 break
 
-        if new_hovered == None and self.GetToolTip():
+        if new_hovered is None and self.GetToolTip():
             self.SetToolTip("")
 
-        if new_hovered != self._hovered_button or (self._hovered_button != None and \
+        if new_hovered != self._hovered_button or (self._hovered_button is not None and \
                                                    new_hovered_state != self._hovered_button.base.state):
 
-            if self._hovered_button != None:
+            if self._hovered_button is not None:
                 self._hovered_button.base.state &= ~RIBBON_BUTTONBAR_BUTTON_HOVER_MASK
 
             self._hovered_button = new_hovered
-            if self._hovered_button != None:
+            if self._hovered_button is not None:
                 self._hovered_button.base.state = new_hovered_state
                 self.SetToolTip(self._hovered_button.base.help_string)
 
@@ -1298,12 +1298,12 @@ class RibbonButtonBar(RibbonControl):
         """
 
         repaint = False
-        if self._hovered_button != None:
+        if self._hovered_button is not None:
             self._hovered_button.base.state &= ~RIBBON_BUTTONBAR_BUTTON_HOVER_MASK
             self._hovered_button = None
             repaint = True
 
-        if self._active_button != None and not self._lock_active_state:
+        if self._active_button is not None and not self._lock_active_state:
             self._active_button.base.state &= ~RIBBON_BUTTONBAR_BUTTON_ACTIVE_MASK
             repaint = True
 

--- a/wx/lib/agw/ribbon/gallery.py
+++ b/wx/lib/agw/ribbon/gallery.py
@@ -331,7 +331,7 @@ class RibbonGallery(RibbonControl):
             self._down_button_state = RIBBON_GALLERY_BUTTON_NORMAL
         if self._extension_button_state != RIBBON_GALLERY_BUTTON_DISABLED:
             self._extension_button_state = RIBBON_GALLERY_BUTTON_NORMAL
-        if self._hovered_item != None:
+        if self._hovered_item is not None:
             self._hovered_item = None
             notification = RibbonGalleryEvent(wxEVT_COMMAND_RIBBONGALLERY_HOVER_CHANGED, self.GetId())
             notification.SetEventObject(self)
@@ -382,7 +382,7 @@ class RibbonGallery(RibbonControl):
                 self._mouse_active_rect = wx.Rect(*self._extension_button_rect)
                 self._extension_button_state = RIBBON_GALLERY_BUTTON_ACTIVE
 
-        if self._mouse_active_rect != None:
+        if self._mouse_active_rect is not None:
             self.Refresh(False)
 
 
@@ -393,7 +393,7 @@ class RibbonGallery(RibbonControl):
         :param `event`: a :class:`MouseEvent` event to be processed.
         """
 
-        if self._mouse_active_rect != None:
+        if self._mouse_active_rect is not None:
             pos = event.GetPosition()
 
             if self._active_item:
@@ -417,7 +417,7 @@ class RibbonGallery(RibbonControl):
                     notification.SetEventObject(self)
                     self.GetEventHandler().ProcessEvent(notification)
 
-                elif self._active_item != None:
+                elif self._active_item is not None:
                     if self._selected_item != self._active_item:
                         self._selected_item = self._active_item
                         notification = RibbonGalleryEvent(wxEVT_COMMAND_RIBBONGALLERY_SELECTED, self.GetId())
@@ -486,7 +486,7 @@ class RibbonGallery(RibbonControl):
         :note: Reimplemented from :class:`wx.Window`.
         """
 
-        if self._scroll_limit == 0 or self._art == None:
+        if self._scroll_limit == 0 or self._art is None:
             return False
 
         line_size = self._bitmap_padded_size.GetHeight()
@@ -576,7 +576,7 @@ class RibbonGallery(RibbonControl):
 
         dc = wx.AutoBufferedPaintDC(self)
 
-        if self._art == None:
+        if self._art is None:
             return
 
         self._art.DrawGalleryBackground(dc, self, wx.Rect(0, 0, *self.GetSize()))
@@ -672,7 +672,7 @@ class RibbonGallery(RibbonControl):
 
     def CalculateMinSize(self):
 
-        if self._art == None or not self._bitmap_size.IsFullySpecified():
+        if self._art is None or not self._bitmap_size.IsFullySpecified():
             self.SetMinSize(wx.Size(20, 20))
         else:
             self._bitmap_padded_size = wx.Size(*self._bitmap_size)
@@ -702,7 +702,7 @@ class RibbonGallery(RibbonControl):
 
     def Layout(self):
 
-        if self._art == None:
+        if self._art is None:
             return False
 
         dc = wx.MemoryDC()
@@ -789,7 +789,7 @@ class RibbonGallery(RibbonControl):
         rather than :meth:`RibbonControl.GetNextSmallerSize() <lib.agw.ribbon.control.RibbonControl.GetNextSmallerSize>`.
         """
 
-        if self._art == None:
+        if self._art is None:
             return relative_to
 
         dc = wx.MemoryDC()
@@ -830,7 +830,7 @@ class RibbonGallery(RibbonControl):
         rather than :meth:`RibbonControl.GetNextLargerSize() <lib.agw.ribbon.control.RibbonControl.GetNextLargerSize>`.
         """
 
-        if self._art == None:
+        if self._art is None:
             return relative_to
 
         dc = wx.MemoryDC()

--- a/wx/lib/agw/ribbon/page.py
+++ b/wx/lib/agw/ribbon/page.py
@@ -561,7 +561,7 @@ class RibbonPage(RibbonControl):
 
                 if self._scroll_buttons_visible:
                     available_space -= self._scroll_amount
-                    if self._scroll_right_btn != None:
+                    if self._scroll_right_btn is not None:
                         available_space += GetSizeInOrientation(self._scroll_right_btn.GetSize(), major_axis)
 
                 if available_space > 0:
@@ -637,7 +637,7 @@ class RibbonPage(RibbonControl):
         self._scroll_buttons_visible = show_left or show_right
 
         if show_left:
-            if self._scroll_left_btn == None:
+            if self._scroll_left_btn is None:
 
                 temp_dc = wx.MemoryDC()
 
@@ -657,13 +657,13 @@ class RibbonPage(RibbonControl):
                 reposition = True
 
         else:
-            if self._scroll_left_btn != None:
+            if self._scroll_left_btn is not None:
                 self._scroll_left_btn.Destroy()
                 self._scroll_left_btn = None
                 reposition = True
 
         if show_right:
-            if self._scroll_right_btn == None:
+            if self._scroll_right_btn is None:
 
                 temp_dc = wx.MemoryDC()
 
@@ -684,7 +684,7 @@ class RibbonPage(RibbonControl):
                 reposition = True
 
         else:
-            if self._scroll_right_btn != None:
+            if self._scroll_right_btn is not None:
                 self._scroll_right_btn.Destroy()
                 self._scroll_right_btn = None
                 reposition = True
@@ -795,7 +795,7 @@ class RibbonPage(RibbonControl):
                                 largest_size = size
                                 largest_panel = panel
 
-            if largest_panel != None:
+            if largest_panel is not None:
                 if largest_panel.IsSizingContinuous():
                     size = largest_panel.GetSize()
                     amount = minimum_amount
@@ -850,7 +850,7 @@ class RibbonPage(RibbonControl):
             if not isinstance(panel, RibbonPanel):
                 continue
 
-            if panel.GetExpandedPanel() != None:
+            if panel.GetExpandedPanel() is not None:
                 return panel.HideExpanded()
 
         return False

--- a/wx/lib/agw/ribbon/panel.py
+++ b/wx/lib/agw/ribbon/panel.py
@@ -218,7 +218,7 @@ class RibbonPanel(RibbonControl):
         self._ext_button_hovered = False
         self._ext_button_rect = wx.Rect()
 
-        if self._art == None:
+        if self._art is None:
             parent = self.GetParent()
             if isinstance(parent, RibbonControl):
                 self._art = parent.GetArtProvider()
@@ -477,7 +477,7 @@ class RibbonPanel(RibbonControl):
 
         dc = wx.AutoBufferedPaintDC(self)
 
-        if self._art != None:
+        if self._art is not None:
             if self.IsMinimised():
                 self._art.DrawMinimisedPanel(dc, self, wx.Rect(0, 0, *self.GetSize()), self._minimised_icon_resized)
             else:
@@ -527,7 +527,7 @@ class RibbonPanel(RibbonControl):
         rather than :meth:`RibbonControl.GetNextSmallerSize() <lib.agw.ribbon.control.RibbonControl.GetNextSmallerSize>`.
         """
 
-        if self._expanded_panel != None:
+        if self._expanded_panel is not None:
             # Next size depends upon children, who are currently in the
             # expanded panel
             return self._expanded_panel.DoGetNextSmallerSize(direction, relative_to)
@@ -604,7 +604,7 @@ class RibbonPanel(RibbonControl):
         rather than :meth:`RibbonControl.GetNextLargerSize() <lib.agw.ribbon.control.RibbonControl.GetNextLargerSize>`.
         """
 
-        if self._expanded_panel != None:
+        if self._expanded_panel is not None:
             # Next size depends upon children, who are currently in the
             # expanded panel
             return self._expanded_panel.DoGetNextLargerSize(direction, relative_to)
@@ -693,7 +693,7 @@ class RibbonPanel(RibbonControl):
         overridden to do the calculation on demand.
         """
 
-        if self._expanded_panel != None:
+        if self._expanded_panel is not None:
             # Minimum size depends upon children, who are currently in the
             # expanded panel
             return self._expanded_panel.GetMinSize()
@@ -796,7 +796,7 @@ class RibbonPanel(RibbonControl):
         elif len(children) == 1:
             minimum_children_size = wx.Size(*children[0].GetMinSize())
 
-        if self._art != None:
+        if self._art is not None:
             temp_dc = wx.ClientDC(self)
             self._smallest_unminimised_size = self._art.GetPanelSize(temp_dc, self, wx.Size(*minimum_children_size), None)
 
@@ -857,7 +857,7 @@ class RibbonPanel(RibbonControl):
         """
 
         if self.IsMinimised():
-            if self._expanded_panel != None:
+            if self._expanded_panel is not None:
                 self.HideExpanded()
             else:
                 self.ShowExpanded()
@@ -917,7 +917,7 @@ class RibbonPanel(RibbonControl):
         if not self.IsMinimised():
             return False
 
-        if self._expanded_dummy != None or self._expanded_panel != None:
+        if self._expanded_dummy is not None or self._expanded_panel != None:
             return False
 
         size = self.GetBestSize()
@@ -1004,7 +1004,7 @@ class RibbonPanel(RibbonControl):
         :param `event`: a :class:`FocusEvent` event to be processed.
         """
 
-        if self._child_with_focus == None:
+        if self._child_with_focus is None:
             return # Should never happen, but a check can't hurt
 
         self._child_with_focus.Bind(wx.EVT_KILL_FOCUS, None)
@@ -1016,7 +1016,7 @@ class RibbonPanel(RibbonControl):
             receiver.Bind(wx.EVT_KILL_FOCUS, self.OnChildKillFocus)
             event.Skip()
 
-        elif receiver == None or receiver != self._expanded_dummy:
+        elif receiver is None or receiver != self._expanded_dummy:
             self.HideExpanded()
             # Do not skip event, as the panel has been de-expanded, causing the
             # child with focus to be reparented (and hidden). If the event
@@ -1036,7 +1036,7 @@ class RibbonPanel(RibbonControl):
         :see: :meth:`~RibbonPanel.HideExpanded`, :meth:`~RibbonPanel.GetExpandedPanel`
         """
 
-        if self._expanded_dummy == None:
+        if self._expanded_dummy is None:
             if self._expanded_panel:
                 return self._expanded_panel.HideExpanded()
             else:

--- a/wx/lib/agw/ribbon/toolbar.py
+++ b/wx/lib/agw/ribbon/toolbar.py
@@ -980,7 +980,7 @@ class RibbonToolBar(RibbonControl):
         :note: Reimplemented from :class:`~wx.lib.agw.ribbon.control.RibbonControl`.
         """
 
-        if self._art == None:
+        if self._art is None:
             return False
 
         # Calculate the size of each group and the position/size of each tool
@@ -1099,7 +1099,7 @@ class RibbonToolBar(RibbonControl):
         :param `event`: a :class:`wx.SizeEvent` event to be processed.
         """
 
-        if self._art == None:
+        if self._art is None:
             return
 
         # Choose row count with largest possible area
@@ -1226,7 +1226,7 @@ class RibbonToolBar(RibbonControl):
 
         dc = wx.AutoBufferedPaintDC(self)
 
-        if self._art == None:
+        if self._art is None:
             return
 
         self._art.DrawToolBarBackground(dc, self, wx.Rect(0, 0, *self.GetSize()))

--- a/wx/lib/agw/shapedbutton.py
+++ b/wx/lib/agw/shapedbutton.py
@@ -1124,7 +1124,7 @@ class SBitmapButton(SButton):
         if not self._isup:
             dw = dh = self._labeldelta
 
-        hasMask = bmp.GetMask() != None
+        hasMask = bmp.GetMask() is not None
         dc.DrawBitmap(bmp, (width - bw)//2 + dw, (height - bh)//2 + dh, hasMask)
 
 
@@ -1193,7 +1193,7 @@ class SBitmapTextButton(SBitmapButton):
 
         bmp = self._bmplabel
 
-        if bmp != None:     # if the bitmap is used
+        if bmp is not None:     # if the bitmap is used
 
             if self._bmpdisabled and not self.IsEnabled():
                 bmp = self._bmpdisabled
@@ -1209,7 +1209,7 @@ class SBitmapTextButton(SBitmapButton):
             if not self._isup:
                 dw = dh = self._labeldelta
 
-            hasMask = bmp.GetMask() != None
+            hasMask = bmp.GetMask() is not None
 
         else:
 
@@ -1234,7 +1234,7 @@ class SBitmapTextButton(SBitmapButton):
 
         rotangle = self.GetAngleOfRotation()*pi/180.0
 
-        if bmp != None:
+        if bmp is not None:
             if rotangle < 1.0/180.0:
                 dc.DrawBitmap(bmp, pos_x, (height - bh)//2 + dh, hasMask) # draw bitmap if available
                 pos_x = pos_x + 4   # extra spacing from bitmap

--- a/wx/lib/agw/supertooltip.py
+++ b/wx/lib/agw/supertooltip.py
@@ -663,7 +663,7 @@ class ToolTipWindowBase(object):
         pSetLayeredWindowAttributes = win32api.GetProcAddress(self._winlib,
                                                               "SetLayeredWindowAttributes")
 
-        if pSetLayeredWindowAttributes == None:
+        if pSetLayeredWindowAttributes is None:
             return
 
         exstyle = win32api.GetWindowLong(hwnd, win32con.GWL_EXSTYLE)

--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -1793,7 +1793,7 @@ class UltimateListItem(wx.Object):
     def HasAttributes(self):
         """ Returns ``True`` if the item has attributes associated with it. """
 
-        return self._attr != None
+        return self._attr is not None
 
 
     def GetTextColour(self):
@@ -2638,7 +2638,7 @@ class UltimateListItemData(object):
         :param `colour`: an instance of :class:`wx.Colour`.
         """
 
-        if colour == wx.NullColour or colour == None:
+        if colour == wx.NullColour or colour is None:
             if self._hasColour:
                 self._hasColour = False
                 del self._colour
@@ -5193,7 +5193,7 @@ class UltimateListHeaderWindow(wx.Control):
             # inside the column rect
             header_rect = wx.Rect(x-1, HEADER_OFFSET_Y-1, cw-1, ch)
 
-            if self._headerCustomRenderer != None:
+            if self._headerCustomRenderer is not None:
                self._headerCustomRenderer.DrawHeaderButton(dc, header_rect, flags)
 
                # The custom renderer will specify the color to draw the header text and buttons
@@ -5288,7 +5288,7 @@ class UltimateListHeaderWindow(wx.Control):
         # leave an unpainted area when columns are removed (and it looks better)
         if x < w:
             header_rect = wx.Rect(x, HEADER_OFFSET_Y, w - x, h)
-            if self._headerCustomRenderer != None:
+            if self._headerCustomRenderer is not None:
                 # Why does the custom renderer need this adjustment??
                 header_rect.x = header_rect.x - 1
                 header_rect.y = header_rect.y - 1
@@ -6467,7 +6467,7 @@ class UltimateListMainWindow(wx.ScrolledWindow):
 
         resizeCol = self._resizeColumn
 
-        if self._resizeColMinWidth == None:
+        if self._resizeColMinWidth is None:
             self._resizeColMinWidth = self.GetColumnWidth(resizeCol)
 
         # We're showing the vertical scrollbar -> allow for scrollbar width

--- a/wx/lib/buttons.py
+++ b/wx/lib/buttons.py
@@ -843,7 +843,7 @@ class GenBitmapButton(GenButton):
         bw,bh = bmp.GetWidth(), bmp.GetHeight()
         if not self.up:
             dx = dy = self.labelDelta
-        hasMask = bmp.GetMask() != None
+        hasMask = bmp.GetMask() is not None
         dc.DrawBitmap(bmp, (width-bw)/2+dx, (height-bh)/2+dy, hasMask)
 
 

--- a/wx/lib/docview.py
+++ b/wx/lib/docview.py
@@ -1595,21 +1595,21 @@ class DocManager(wx.EvtHandler):
         """
         Updates the user interface for the File Close command.
         """
-        event.Enable(self.GetCurrentDocument() != None)
+        event.Enable(self.GetCurrentDocument() is not None)
 
 
     def OnUpdateFileCloseAll(self, event):
         """
         Updates the user interface for the File Close All command.
         """
-        event.Enable(self.GetCurrentDocument() != None)
+        event.Enable(self.GetCurrentDocument() is not None)
 
 
     def OnUpdateFileRevert(self, event):
         """
         Updates the user interface for the File Revert command.
         """
-        event.Enable(self.GetCurrentDocument() != None)
+        event.Enable(self.GetCurrentDocument() is not None)
 
 
     def OnUpdateFileNew(self, event):
@@ -1624,14 +1624,14 @@ class DocManager(wx.EvtHandler):
         Updates the user interface for the File Save command.
         """
         doc = self.GetCurrentDocument()
-        event.Enable(doc != None and doc.IsModified())
+        event.Enable(doc is not None and doc.IsModified())
 
 
     def OnUpdateFileSaveAs(self, event):
         """
         Updates the user interface for the File Save As command.
         """
-        event.Enable(self.GetCurrentDocument() != None and self.GetCurrentDocument().GetWriteable())
+        event.Enable(self.GetCurrentDocument() is not None and self.GetCurrentDocument().GetWriteable())
 
 
     def OnUpdateUndo(self, event):
@@ -1639,7 +1639,7 @@ class DocManager(wx.EvtHandler):
         Updates the user interface for the Undo command.
         """
         doc = self.GetCurrentDocument()
-        event.Enable(doc != None and doc.GetCommandProcessor() != None and doc.GetCommandProcessor().CanUndo())
+        event.Enable(doc is not None and doc.GetCommandProcessor() is not None and doc.GetCommandProcessor().CanUndo())
         if doc and doc.GetCommandProcessor():
             doc.GetCommandProcessor().SetMenuStrings()
         else:
@@ -1651,7 +1651,7 @@ class DocManager(wx.EvtHandler):
         Updates the user interface for the Redo command.
         """
         doc = self.GetCurrentDocument()
-        event.Enable(doc != None and doc.GetCommandProcessor() != None and doc.GetCommandProcessor().CanRedo())
+        event.Enable(doc is not None and doc.GetCommandProcessor() is not None and doc.GetCommandProcessor().CanRedo())
         if doc and doc.GetCommandProcessor():
             doc.GetCommandProcessor().SetMenuStrings()
         else:
@@ -1662,7 +1662,7 @@ class DocManager(wx.EvtHandler):
         """
         Updates the user interface for the Print command.
         """
-        event.Enable(self.GetCurrentDocument() != None)
+        event.Enable(self.GetCurrentDocument() is not None)
 
 
     def OnUpdatePrintSetup(self, event):
@@ -1676,7 +1676,7 @@ class DocManager(wx.EvtHandler):
         """
         Updates the user interface for the Print Preview command.
         """
-        event.Enable(self.GetCurrentDocument() != None)
+        event.Enable(self.GetCurrentDocument() is not None)
 
 
     def GetCurrentView(self):
@@ -3116,7 +3116,7 @@ class CommandProcessor(wx.Object):
         Sets the menu labels according to the currently set menu and the
         current command state.
         """
-        if self.GetEditMenu() != None:
+        if self.GetEditMenu() is not None:
             undoCommand = self._GetCurrentCommand()
             redoCommand = self._GetCurrentRedoCommand()
             undoItem = self.GetEditMenu().FindItemById(wx.ID_UNDO)
@@ -3146,7 +3146,7 @@ class CommandProcessor(wx.Object):
         Returns ``True`` if the currently-active command can be undone,
         ``False`` otherwise.
         """
-        if self._GetCurrentCommand() == None:
+        if self._GetCurrentCommand() is None:
             return False
         return self._GetCurrentCommand().CanUndo()
 
@@ -3156,7 +3156,7 @@ class CommandProcessor(wx.Object):
         Returns ``True`` if the currently-active command can be redone,
         ``False`` otherwise.
         """
-        return self._GetCurrentRedoCommand() != None
+        return self._GetCurrentRedoCommand() is not None
 
 
     def Submit(self, command, storeIt=True):

--- a/wx/lib/fancytext.py
+++ b/wx/lib/fancytext.py
@@ -130,7 +130,7 @@ class Renderer:
     defaultColor = "black"
 
     def __init__(self, dc=None, x=0, y=None):
-        if dc == None:
+        if dc is None:
             dc = wx.MemoryDC()
         self.dc = dc
         self.offsets = [0]

--- a/wx/lib/filebrowsebutton.py
+++ b/wx/lib/filebrowsebutton.py
@@ -290,7 +290,7 @@ class FileBrowseButtonWithHistory( FileBrowseButton ):
 
     def GetHistory( self ):
         """Return the current history list"""
-        if self.historyCallBack != None:
+        if self.historyCallBack is not None:
             return self.historyCallBack()
         elif self.history:
             return list( self.history )
@@ -300,7 +300,7 @@ class FileBrowseButtonWithHistory( FileBrowseButton ):
 
     def OnSetFocus(self, event):
         """When the history scroll is selected, update the history"""
-        if self.historyCallBack != None:
+        if self.historyCallBack is not None:
             self.SetHistory( self.historyCallBack(), control=self.textControl)
         event.Skip()
 

--- a/wx/lib/gizmos/dynamicsash.py
+++ b/wx/lib/gizmos/dynamicsash.py
@@ -803,7 +803,7 @@ class _DynamicSashWindowImpl(wx.EvtHandler):
 
             if ((self.m_dragging == _DSR_HORIZONTAL_TAB and py >= 10 and py <= 90)
                         or (self.m_dragging == _DSR_VERTICAL_TAB and px >= 10 and px <= 90)):
-                if self.m_child[0] == None:
+                if self.m_child[0] is None:
                     self.Split(px, py)
                 else:
                     # It would be nice if moving *this* sash didn't implicitly move
@@ -815,7 +815,7 @@ class _DynamicSashWindowImpl(wx.EvtHandler):
                         layout.width.PercentOf(self.m_container, wx.Width, px)
                     self.m_container.Layout()
             else:
-                if self.m_child[0] != None:
+                if self.m_child[0] is not None:
                     if ((self.m_dragging == _DSR_HORIZONTAL_TAB and py <= 10)
                             or (self.m_dragging == _DSR_VERTICAL_TAB and px <= 10)):
                         self.Unify(1)

--- a/wx/lib/imagebrowser.py
+++ b/wx/lib/imagebrowser.py
@@ -463,7 +463,7 @@ class ImageDialog(wx.Dialog):
         self.set_dir = os.getcwd()
         self.set_file = None
 
-        if set_dir != None:
+        if set_dir is not None:
             if os.path.exists(set_dir):     # set to working directory if nothing set
                 self.set_dir = set_dir
 
@@ -780,7 +780,7 @@ class FindFiles:
             path = path.upper()
             value = i.upper()
 
-            if pattern.match(value) != None:
+            if pattern.match(value) is not None:
                 filelist.append(i)
 
 

--- a/wx/lib/intctrl.py
+++ b/wx/lib/intctrl.py
@@ -718,7 +718,7 @@ class IntCtrl(wx.TextCtrl):
         if max is None: max = value
 
         # if bounds set, and value is None, return False
-        if value == None and (min is not None or max is not None):
+        if value is None and (min is not None or max is not None):
             return 0
         else:
             return min <= value <= max

--- a/wx/lib/mixins/listctrl.py
+++ b/wx/lib/mixins/listctrl.py
@@ -297,7 +297,7 @@ class ListCtrlAutoWidthMixin:
 
         resizeCol = max(1, resizeCol)
 
-        if self._resizeColMinWidth == None:
+        if self._resizeColMinWidth is None:
             self._resizeColMinWidth = self.GetColumnWidth(resizeCol - 1)
 
         # Get total width

--- a/wx/lib/mixins/rubberband.py
+++ b/wx/lib/mixins/rubberband.py
@@ -182,13 +182,13 @@ class RubberBand:
         x, y = event.GetPosition()
 
         # First make sure we have started a box.
-        if self.currentBox == None and not event.LeftDown():
+        if self.currentBox is None and not event.LeftDown():
             # No box started yet.  Set cursor to the initial kind.
             self.__setCursor(wx.CURSOR_CROSS)
             return
 
         if event.LeftDown():
-            if self.currentBox == None:
+            if self.currentBox is None:
                 # No RB Box, so start a new one.
                 self.currentBox = (x, y, 0, 0)
                 self.hasLetUp   = 0
@@ -242,13 +242,13 @@ class RubberBand:
 
         x0,y0,w0,h0 = self.currentBox
         currentExtent = boxToExtent(self.currentBox)
-        if x == None:
+        if x is None:
             if w0 < 1:
                 w0 += 1
             else:
                 w0 -= 1
             x = x0 + w0
-        if y == None:
+        if y is None:
             if h0 < 1:
                 h0 += 1
             else:

--- a/wx/lib/ogl/canvas.py
+++ b/wx/lib/ogl/canvas.py
@@ -349,7 +349,7 @@ class ShapeCanvas(wx.ScrolledWindow):
             if object.IsShown() and \
                isinstance(object, LineShape) and \
                object.HitTest(x, y) and \
-               ((info == None) or isinstance(object, info)) and \
+               ((info is None) or isinstance(object, info)) and \
                (not notObject or not notObject.HasDescendant(object)):
                 temp_attachment, dist = object.HitTest(x, y)
                 # A line is trickier to spot than a normal object.
@@ -372,7 +372,7 @@ class ShapeCanvas(wx.ScrolledWindow):
                    (isinstance(object, DivisionShape) or
                     not isinstance(object, CompositeShape)) and
                     object.HitTest(x, y) and
-                    (info == None or isinstance(object, info)) and
+                    (info is None or isinstance(object, info)) and
                     (not notObject or not notObject.HasDescendant(object))):
                 temp_attachment, dist = object.HitTest(x, y)
                 if not isinstance(object, LineShape):

--- a/wx/lib/pdfwin_old.py
+++ b/wx/lib/pdfwin_old.py
@@ -19,7 +19,7 @@ _acroversion = None
 def get_acroversion():
     " Return version of Adobe Acrobat executable or None"
     global _acroversion
-    if _acroversion == None and wx.PlatformInfo[1] == 'wxMSW':
+    if _acroversion is None and wx.PlatformInfo[1] == 'wxMSW':
         import _winreg
         regKey = _winreg.HKEY_LOCAL_MACHINE
         acrokeys, acroversions = [], []

--- a/wx/lib/platebtn.py
+++ b/wx/lib/platebtn.py
@@ -188,7 +188,7 @@ class PlateButton(wx.Control):
         if bmp is not None and bmp.IsOk():
             bw, bh = bmp.GetSize()
             ypos = (self.GetSize()[1] - bh) // 2
-            gc.DrawBitmap(bmp, 6, ypos, bmp.GetMask() != None)
+            gc.DrawBitmap(bmp, 6, ypos, bmp.GetMask() is not None)
             return bw + 6
         else:
             return 6

--- a/wx/lib/pydocview.py
+++ b/wx/lib/pydocview.py
@@ -506,7 +506,7 @@ class DocMDIParentFrameMixIn:
         window.SetDefaultSize(size)
         window.SetOrientation(orientation)
         window.SetAlignment(alignment)
-        if sash != None:  # wx.SASH_TOP is 0 so check for None instead of just doing "if sash:"
+        if sash is not None:  # wx.SASH_TOP is 0 so check for None instead of just doing "if sash:"
             window.SetSashVisible(sash, True)
         ####
         def OnEmbeddedWindowSashDrag(event):
@@ -2590,7 +2590,7 @@ class FilePropertiesService(DocService):
                 if eventHandler.ProcessUpdateUIEvent(event):
                     return True
 
-            event.Enable(wx.GetApp().GetDocumentManager().GetCurrentDocument() != None)
+            event.Enable(wx.GetApp().GetDocumentManager().GetCurrentDocument() is not None)
             return True
         else:
             return False

--- a/wx/lib/sheet.py
+++ b/wx/lib/sheet.py
@@ -249,7 +249,7 @@ class CSheet(wx.grid.Grid):
     def Copy(self):
         """ Copy the currently selected cells to the clipboard """
         # TODO: raise an error when there are no cells selected?
-        if self._selected == None: return
+        if self._selected is None: return
         ((r1, c1), (r2, c2)) = self._selected
 
         # Build a string to put on the clipboard
@@ -289,7 +289,7 @@ class CSheet(wx.grid.Grid):
                 rows[i] = rows[i].split(tab)
 
             # Get the starting and ending cell range to paste into
-            if self._selected == None:          # If no cells selected...
+            if self._selected is None:          # If no cells selected...
                 r1 = self.GetGridCursorRow()    # Start the paste at the current location
                 c1 = self.GetGridCursorCol()
                 r2 = self.GetNumberRows()-1     # Go to maximum row and col extents
@@ -311,7 +311,7 @@ class CSheet(wx.grid.Grid):
 
     def Clear(self):
         """ Clear the currently selected cells """
-        if self._selected == None:              # If no selection...
+        if self._selected is None:              # If no selection...
             r = self.GetGridCursorRow()         # clear only current cell
             c = self.GetGridCursorCol()
             self.SetCellValue(r, c, "")

--- a/wx/py/interpreter.py
+++ b/wx/py/interpreter.py
@@ -73,7 +73,7 @@ class Interpreter(InteractiveInterpreter):
 
         # If an ast code module is passed, pass it to runModule instead
         more=False
-        if astMod != None:
+        if astMod is not None:
             self.runModule(astMod)
             self.more=False
         else:

--- a/wx/py/parse.py
+++ b/wx/py/parse.py
@@ -80,7 +80,7 @@ def testForContinuations(codeBlock,ignoreErrors=False):
         for r in result:
             j = r.group()
 
-            if stringMark == None:
+            if stringMark is None:
                 if j=='#': # If it is a legitimate comment, ignore everything after
                     commented=True
                     # get length up to last non-comment character

--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -250,7 +250,7 @@ class Shell(editwindow.EditWindow):
         self.stderr = sys.stderr
 
         # Import a default interpreter class if one isn't provided.
-        if InterpClass == None:
+        if InterpClass is None:
             from .interpreter import Interpreter
         else:
             Interpreter = InterpClass

--- a/wx/py/sliceshell.py
+++ b/wx/py/sliceshell.py
@@ -625,7 +625,7 @@ class SlicesShell(editwindow.EditWindow):
         self.stderr = sys.stderr
 
         # Import a default interpreter class if one isn't provided.
-        if InterpClass == None:
+        if InterpClass is None:
             from .interpreter import Interpreter
         else:
             Interpreter = InterpClass
@@ -2462,7 +2462,7 @@ class SlicesShell(editwindow.EditWindow):
         self.hasSyntaxError=False
         if useMultiCommand:
             result = self.BreakTextIntoCommands(command)
-            if result[0] == None:
+            if result[0] is None:
                 commands=[command]
                 self.hasSyntaxError=True
                 syntaxErrorLine=result[1]+1
@@ -3490,7 +3490,7 @@ class SlicesShell(editwindow.EditWindow):
 
         hasSyntaxError=False
         result = self.BreakTextIntoCommands(command)
-        if result[0] == None:
+        if result[0] is None:
             commands=[command]
             hasSyntaxError=True
         else:

--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -53,7 +53,7 @@ __res = None
 def get_resources():
     \"\"\" This function provides access to the XML resources in this module.\"\"\"
     global __res
-    if __res == None:
+    if __res is None:
         __init_resources()
     return __res
 


### PR DESCRIPTION
Fixes issue #1554:
Replaced "== None" and "!= None" with "is None" and "is not None", respectively, because the former is slower and error-prone.

"is" is generally preferred when comparing arbitrary objects to singletons like None because it is faster and more predictable. "is" always compares by object identity, whereas what "==" will do depends on the exact type of the operands and even on their ordering.

This recommendation is supported by PEP 8, which explicitly states that "comparisons to singletons like None should always be done with "is" or "is not", never the equality operators.
