### PR TITLE
Fixes issue #1577: possible memory leak

### DIFF
--- a/src/pseudodc.cpp
+++ b/src/pseudodc.cpp
@@ -141,11 +141,12 @@ pdcDrawPolyPolygonOp::pdcDrawPolyPolygonOp(int n, int count[], wxPoint points[],
 
 pdcDrawPolyPolygonOp::~pdcDrawPolyPolygonOp()
 {
-    if (m_points) delete m_points;
-    if (m_count) delete m_count;
+    if (m_points) delete[] m_points;
+    if (m_count) delete[] m_count;
     m_points=NULL;
     m_count=NULL;
 }
+
 
 // ----------------------------------------------------------------------------
 // pdcDrawLinesOp


### PR DESCRIPTION
Allocated array should be deallocated with delete [].
Deallocating it with delete can cause memory leaks.

Fixes #1577
