### PR TITLE
Use different typecheck code for wxArrayInt and wxArrayString in variant conversions

### DIFF
--- a/src/arrays.sip
+++ b/src/arrays.sip
@@ -23,22 +23,8 @@
         // Code to test a PyObject for compatibility
         // Verify that the object is a sequence, but not bytes or unicode
         if (!sipIsErr) {
-            if (PySequence_Check(sipPy) &&
-                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy))) {
-
-                Py_ssize_t i, len = PySequence_Length(sipPy);
-                bool failed;
-                for (i=0; i<len; i++) {
-                    PyObject* item = PySequence_GetItem(sipPy, i);
-                    failed = !PyBytes_Check(item) && !PyUnicode_Check(item);
-                    Py_DECREF(item);
-                    if (failed)
-                        return FALSE;
-                }
-                return TRUE;
-            }
-            return FALSE;
-
+            return (PySequence_Check(sipPy) &&
+                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy)));
         }
 
 
@@ -123,21 +109,8 @@ wxArrayString testArrayStringTypemap(const wxArrayString& arr);
     %ConvertToTypeCode
         // Code to test a PyObject for compatibility
         if (!sipIsErr) {
-            if (PySequence_Check(sipPy) &&
-                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy))) {
-
-                Py_ssize_t i, len = PySequence_Length(sipPy);
-                bool failed;
-                for (i=0; i<len; i++) {
-                    PyObject* item = PySequence_GetItem(sipPy, i);
-                    failed = !PyNumber_Check(item);
-                    Py_DECREF(item);
-                    if (failed)
-                        return FALSE;
-                }
-                return TRUE;
-            }
-            return FALSE;
+            return (PySequence_Check(sipPy) &&
+                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy)));
         }
 
         // Code to create a new wxArrayInt and convert a compatible PyObject
@@ -209,21 +182,8 @@ wxArrayInt testArrayIntTypemap(const wxArrayInt& arr);
     %ConvertToTypeCode
         // Code to test a PyObject for compatibility
         if (!sipIsErr) {
-            if (PySequence_Check(sipPy) &&
-                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy))) {
-
-                Py_ssize_t i, len = PySequence_Length(sipPy);
-                bool failed;
-                for (i=0; i<len; i++) {
-                    PyObject* item = PySequence_GetItem(sipPy, i);
-                    failed = !PyNumber_Check(item);
-                    Py_DECREF(item);
-                    if (failed)
-                        return FALSE;
-                }
-                return TRUE;
-            }
-            return FALSE;
+            return (PySequence_Check(sipPy) &&
+                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy)));
         }
 
         // Code to create a new wxArrayDouble and convert a compatible PyObject

--- a/src/arrays.sip
+++ b/src/arrays.sip
@@ -23,8 +23,22 @@
         // Code to test a PyObject for compatibility
         // Verify that the object is a sequence, but not bytes or unicode
         if (!sipIsErr) {
-            return (PySequence_Check(sipPy) && 
-                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy)));
+            if (PySequence_Check(sipPy) &&
+                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy))) {
+
+                Py_ssize_t i, len = PySequence_Length(sipPy);
+                bool failed;
+                for (i=0; i<len; i++) {
+                    PyObject* item = PySequence_GetItem(sipPy, i);
+                    failed = !PyBytes_Check(item) && !PyUnicode_Check(item);
+                    Py_DECREF(item);
+                    if (failed)
+                        return FALSE;
+                }
+                return TRUE;
+            }
+            return FALSE;
+
         }
 
 
@@ -37,13 +51,13 @@
             // Ensure each item is a bytes or string/unicode object
             if ( !PyBytes_Check(item) && !PyUnicode_Check(item) ) {
                 // raise a TypeError if not
-                PyErr_Format(PyExc_TypeError, 
+                PyErr_Format(PyExc_TypeError,
                              "Item at index %zd has type '%s' but a sequence of bytes or strings is expected",
                              i, sipPyTypeName(Py_TYPE(item)));
                 delete array;
                 Py_DECREF(item);
                 *sipIsErr = 1;
-                return 0;                
+                return 0;
             }
 
             // if it's a string object convert it to unicode first, assuming utf-8
@@ -109,8 +123,21 @@ wxArrayString testArrayStringTypemap(const wxArrayString& arr);
     %ConvertToTypeCode
         // Code to test a PyObject for compatibility
         if (!sipIsErr) {
-            return (PySequence_Check(sipPy) && 
-                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy)));
+            if (PySequence_Check(sipPy) &&
+                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy))) {
+
+                Py_ssize_t i, len = PySequence_Length(sipPy);
+                bool failed;
+                for (i=0; i<len; i++) {
+                    PyObject* item = PySequence_GetItem(sipPy, i);
+                    failed = !PyNumber_Check(item);
+                    Py_DECREF(item);
+                    if (failed)
+                        return FALSE;
+                }
+                return TRUE;
+            }
+            return FALSE;
         }
 
         // Code to create a new wxArrayInt and convert a compatible PyObject
@@ -122,13 +149,13 @@ wxArrayString testArrayStringTypemap(const wxArrayString& arr);
             // Ensure each item is a number object
             if ( !PyNumber_Check(item) ) {
                 // raise a TypeError if not
-                PyErr_Format(PyExc_TypeError, 
+                PyErr_Format(PyExc_TypeError,
                              "Item at index %zd has type '%s' but a sequence of numbers is expected",
                              i, sipPyTypeName(Py_TYPE(item)));
                 delete array;
                 Py_DECREF(item);
                 *sipIsErr = 1;
-                return 0;                
+                return 0;
             }
 
             // Convert to Integer
@@ -182,8 +209,21 @@ wxArrayInt testArrayIntTypemap(const wxArrayInt& arr);
     %ConvertToTypeCode
         // Code to test a PyObject for compatibility
         if (!sipIsErr) {
-            return (PySequence_Check(sipPy) && 
-                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy)));
+            if (PySequence_Check(sipPy) &&
+                    !(PyBytes_Check(sipPy) || PyUnicode_Check(sipPy))) {
+
+                Py_ssize_t i, len = PySequence_Length(sipPy);
+                bool failed;
+                for (i=0; i<len; i++) {
+                    PyObject* item = PySequence_GetItem(sipPy, i);
+                    failed = !PyNumber_Check(item);
+                    Py_DECREF(item);
+                    if (failed)
+                        return FALSE;
+                }
+                return TRUE;
+            }
+            return FALSE;
         }
 
         // Code to create a new wxArrayDouble and convert a compatible PyObject
@@ -195,13 +235,13 @@ wxArrayInt testArrayIntTypemap(const wxArrayInt& arr);
             // Ensure each item is a number object
             if ( !PyNumber_Check(item) ) {
                 // raise a TypeError if not
-                PyErr_Format(PyExc_TypeError, 
+                PyErr_Format(PyExc_TypeError,
                              "Item at index %zd has type '%s' but a sequence of numbers is expected",
                              i, sipPyTypeName(Py_TYPE(item)));
                 delete array;
                 Py_DECREF(item);
                 *sipIsErr = 1;
-                return 0;                
+                return 0;
             }
 
             // Convert to a Float

--- a/src/pgvariant.sip
+++ b/src/pgvariant.sip
@@ -58,7 +58,7 @@ wxVariant wxPGVariant_in_helper(PyObject* obj)
         value << *ptr;
     }
 
-    else if (sipCanConvertToType(obj, sipType_wxArrayInt, 0)) {
+    else if (wxPyCheckNumberSequence(obj)) {
         wxArrayInt* ptr;
         ptr = (wxArrayInt*)sipConvertToType(obj, sipType_wxArrayInt, NULL, 0, &state, &isErr);
         if (!isErr) {

--- a/src/wxpy_api.sip
+++ b/src/wxpy_api.sip
@@ -339,7 +339,7 @@ wxVariant i_wxVariant_in_helper(PyObject* obj)
         value << *ptr;
     }
 
-    else if (sipCanConvertToType(obj, sipType_wxArrayString, 0)) {
+    else if (wxPyCheckStringSequence(obj)) {
         wxArrayString* ptr;
         int state = 0;
         int isErr = 0;
@@ -486,6 +486,9 @@ bool i_wxPyNumberSequenceCheck(PyObject* obj, int reqLength=-1) {
     // to a wx type, like wxPoint, wxSize, wxColour, etc. Returns true if the
     // object is a Tuple, List or numpy Array of the proper length.
 
+    // See also i_wxPyCheckNumberSequence below which can be used in more
+    // general purpose situations and for sequences of any length.
+
     // tuples or lists are easy
     bool isFast = (PyTuple_Check(obj) || PyList_Check(obj));
 
@@ -596,7 +599,45 @@ wxDateTime* i_wxPyDate_ToWxDateTime(PyObject *obj) {
                           PyDateTime_GET_YEAR(obj));
 }
 
+//--------------------------------------------------------------------------
 
+bool i_wxPyCheckNumberSequence(PyObject *obj)
+{
+    if (PySequence_Check(obj) &&
+            !(PyBytes_Check(obj) || PyUnicode_Check(obj))) {
+
+        Py_ssize_t i, len = PySequence_Length(obj);
+        bool failed;
+        for (i=0; i<len; i++) {
+            PyObject* item = PySequence_GetItem(obj, i);
+            failed = !PyNumber_Check(item);
+            Py_DECREF(item);
+            if (failed)
+                return false;
+        }
+        return true;
+    }
+    return false;
+}
+
+bool i_wxPyCheckStringSequence(PyObject *obj)
+{
+    if (PySequence_Check(obj) &&
+            !(PyBytes_Check(obj) || PyUnicode_Check(obj))) {
+
+        Py_ssize_t i, len = PySequence_Length(obj);
+        bool failed;
+        for (i=0; i<len; i++) {
+            PyObject* item = PySequence_GetItem(obj, i);
+            failed = !PyBytes_Check(item) && !PyUnicode_Check(item);
+            Py_DECREF(item);
+            if (failed)
+                return false;
+        }
+        return true;
+    }
+    return false;
+}
 
 //--------------------------------------------------------------------------
 // An instance of the API structure
@@ -621,7 +662,9 @@ static wxPyAPI  API = {
     i_wxPyDateTime_Check,
     i_wxPyDate_Check,
     i_wxPyDateTime_ToWxDateTime,
-    i_wxPyDate_ToWxDateTime
+    i_wxPyDate_ToWxDateTime,
+    i_wxPyCheckNumberSequence,
+    i_wxPyCheckStringSequence
 };
 %End
 

--- a/wx/include/wxPython/wxpy_api.h
+++ b/wx/include/wxPython/wxpy_api.h
@@ -171,6 +171,9 @@ struct wxPyAPI {
     int           (*p_wxPyDate_Check)(PyObject *obj);
     wxDateTime*   (*p_wxPyDateTime_ToWxDateTime)(PyObject *obj);
     wxDateTime*   (*p_wxPyDate_ToWxDateTime)(PyObject *obj);
+
+    bool          (*p_wxPyCheckNumberSequence)(PyObject *obj);
+    bool          (*p_wxPyCheckStringSequence)(PyObject *obj);
     // Always add new items here at the end.
 };
 
@@ -287,6 +290,16 @@ inline wxDateTime* wxPyDateTime_ToWxDateTime(PyObject *obj)
 inline wxDateTime* wxPyDate_ToWxDateTime(PyObject *obj)
     { return wxPyGetAPIPtr()->p_wxPyDate_ToWxDateTime(obj); }
 
+
+inline bool wxPyCheckNumberSequence(PyObject *obj)
+{
+    return wxPyGetAPIPtr()->p_wxPyCheckNumberSequence(obj);
+}
+
+inline bool wxPyCheckStringSequence(PyObject *obj)
+{
+    return wxPyGetAPIPtr()->p_wxPyCheckStringSequence(obj);
+}
 
 //--------------------------------------------------------------------------
 // Convenience helper for RAII-style thread blocking


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1581 


