### PR TITLE
Stop fly-out timers before closing the floating pane.

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -3116,6 +3116,9 @@ class AuiFloatingFrame(wx.MiniFrame):
             if self._owner_mgr and self._owner_mgr._action_window == self:
                 self._owner_mgr._action_window = None
 
+            self._fly_timer.Stop()
+            self._check_fly_timer.Stop()
+
             self._mgr.UnInit()
             self.Destroy()
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1501

