### PR TITLE
new event wx.lib.agw.aui.EVT_AUI_PANE_CLOSED

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -132,6 +132,7 @@ if wx.Platform == "__WXMSW__":
 # AUI Events
 wxEVT_AUI_PANE_BUTTON = wx.NewEventType()
 wxEVT_AUI_PANE_CLOSE = wx.NewEventType()
+wxEVT_AUI_PANE_CLOSED = wx.NewEventType()
 wxEVT_AUI_PANE_MAXIMIZE = wx.NewEventType()
 wxEVT_AUI_PANE_RESTORE = wx.NewEventType()
 wxEVT_AUI_RENDER = wx.NewEventType()
@@ -148,6 +149,8 @@ wxEVT_AUI_PERSPECTIVE_CHANGED = wx.NewEventType()
 EVT_AUI_PANE_BUTTON = wx.PyEventBinder(wxEVT_AUI_PANE_BUTTON, 0)
 """ Fires an event when the user left-clicks on a pane button. """
 EVT_AUI_PANE_CLOSE = wx.PyEventBinder(wxEVT_AUI_PANE_CLOSE, 0)
+""" A pane in `AuiManager` is about to be closed. """
+EVT_AUI_PANE_CLOSED = wx.PyEventBinder(wxEVT_AUI_PANE_CLOSED, 0)
 """ A pane in `AuiManager` has been closed. """
 EVT_AUI_PANE_MAXIMIZE = wx.PyEventBinder(wxEVT_AUI_PANE_MAXIMIZE, 0)
 """ A pane in `AuiManager` has been maximized. """
@@ -5079,6 +5082,13 @@ class AuiManager(wx.EvtHandler):
 
         if to_destroy:
             to_destroy.Destroy()
+
+        # Now inform the app that we closed a pane.
+        e = AuiManagerEvent(wxEVT_AUI_PANE_CLOSED)
+        e.SetPane(pane_info)
+        e.SetCanVeto(False)
+        e.SetId(wxEVT_AUI_PANE_CLOSED)
+        wx.CallAfter(self.ProcessMgrEvent, e)
 
 
     def MaximizePane(self, pane_info, savesizes=True):

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -5084,11 +5084,7 @@ class AuiManager(wx.EvtHandler):
             to_destroy.Destroy()
 
         # Now inform the app that we closed a pane.
-        e = AuiManagerEvent(wxEVT_AUI_PANE_CLOSED)
-        e.SetPane(pane_info)
-        e.SetCanVeto(False)
-        e.SetId(wxEVT_AUI_PANE_CLOSED)
-        wx.CallAfter(self.ProcessMgrEvent, e)
+        self.FireEvent(wxEVT_AUI_PANE_CLOSED, pane_info)
 
 
     def MaximizePane(self, pane_info, savesizes=True):

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -5086,7 +5086,6 @@ class AuiManager(wx.EvtHandler):
         # Now inform the app that we closed a pane.
         self.FireEvent(wxEVT_AUI_PANE_CLOSED, pane_info)
 
-
     def MaximizePane(self, pane_info, savesizes=True):
         """
         Maximizes the input pane.


### PR DESCRIPTION
I needed an event when a pane was closed, but the existing `wx.lib.agw.aui.EVT_AUI_PANE_CLOSE` is fired when a pane is about to be closed and that sometimes led to timing issues.
I added an extra event that is fired when the pane is really closed.
I was thinking about to rename EVT_AUI_PANE_CLOSE to EVT_AUI_PANE_CLOSING (which better fits), but that could break older code. So i just changed the docstring.