### PR TITLE
[ULC] fix calculation of line width

### DIFF
--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -6696,7 +6696,8 @@ class UltimateListMainWindow(wx.ScrolledWindow):
         image_width = 0
 
         for c in range(col):
-            image_x += self.GetColumnWidth(c)
+            if self.IsColumnShown(c):
+                image_x += self.GetColumnWidth(c)
 
         item = self.GetLine(line)
         if item.HasImage(col):


### PR DESCRIPTION
If one or more columns are hidden, HitTest would falsely report a hit when clicked right beside the last visible column within the range of the hidden column(s).


<details>
<summary>sample code to show HitTest problem.</summary>

```python
import wx
from wx.lib.agw import ultimatelistctrl as ulc


class TestFrame(wx.Frame):

    def __init__(self):
        super(TestFrame, self).__init__(None, size=(700, 300))

        self.lst_ctrl = ulc.UltimateListCtrl(self, agwStyle=ulc.ULC_REPORT)
        self.fill_list_ctrl(self.lst_ctrl)
        szr = wx.BoxSizer(wx.VERTICAL)
        szr.Add(wx.StaticText(
            self,
            label="right click on an item in different columns,"
                  "\nright behind the last column of an item and"
                  "\nnear the right border of the frame."
        ))
        szr.Add(self.lst_ctrl, 1, wx.EXPAND)
        self.SetSizer(szr)
        self.Bind(ulc.EVT_LIST_ITEM_RIGHT_CLICK, self.on_right_click)
        self.lst_ctrl.SetColumnWidth(2, wx.LIST_AUTOSIZE_USEHEADER)

    def on_right_click(self, event):
        evt_index = event.GetIndex()
        evt_column = event.GetColumn()

        print("  item index:", evt_index)
        print("column index:", evt_column)
        print()

    def fill_list_ctrl(self, ctrl):
        col_info = ulc.UltimateListItem()
        col_info.SetMask(ulc.ULC_MASK_TEXT | ulc.ULC_MASK_KIND)
        col_info.SetKind(0)
        col_info.SetText('this is column 0')
        ctrl.InsertColumnInfo(-1, col_info)

        col_info.SetText('this is column 1')
        col_info.SetShown(False)
        col_info.SetMask(ulc.ULC_MASK_TEXT | ulc.ULC_MASK_KIND | ulc.ULC_MASK_SHOWN)
        ctrl.InsertColumnInfo(-1, col_info)

        col_info.SetText('this is column 2 (column 1 is hidden)')
        col_info.SetMask(ulc.ULC_MASK_TEXT | ulc.ULC_MASK_KIND)
        ctrl.InsertColumnInfo(-1, col_info)

        for idx in range(5):
            item = ulc.UltimateListItem()
            item.SetId(idx)
            item.SetMask(ulc.ULC_MASK_TEXT | ulc.ULC_MASK_KIND)
            item.SetKind(0)
            item.SetColumn(0)
            item.SetText("row %d, column 0" % idx)

            ctrl.InsertItem(item)
            item.SetColumn(1)
            item.SetText("row %d, column 1" % idx)

            ctrl.SetItem(item)
            item.SetColumn(2)
            item.SetText("row %d, column 2" % idx)
            ctrl.SetItem(item)

        ctrl.SetColumnWidth(0, ulc.ULC_AUTOSIZE)
        ctrl.SetColumnWidth(1, ulc.ULC_AUTOSIZE)
        ctrl.SetColumnWidth(2, ulc.ULC_AUTOSIZE)


if __name__ == '__main__':
    app = wx.App()
    win = TestFrame()
    win.Show()
    app.MainLoop()
```


</details>