### PR TITLE
Eliminate deprecation warning

### DIFF
--- a/wx/py/buffer.py
+++ b/wx/py/buffer.py
@@ -3,7 +3,7 @@
 __author__ = "Patrick K. O'Brien <pobrien@orbtech.com>"
 
 from .interpreter import Interpreter
-import imp
+import types
 import os
 import sys
 
@@ -111,7 +111,7 @@ class Buffer:
         text = text.replace('\r\n', '\n')
         text = text.replace('\r', '\n')
         name = self.modulename or self.name
-        module = imp.new_module(name)
+        module = types.ModuleType(name)
         newspace = module.__dict__.copy()
         try:
             try:


### PR DESCRIPTION
Remove import of 'imp' module to eliminate deprecation warning.
