### PR TITLE
Set transfer flag for subMenu in MenuItem constructor

### DIFF
--- a/etg/menuitem.py
+++ b/etg/menuitem.py
@@ -36,6 +36,7 @@ def run():
     c.addPrivateCopyCtor()
     tools.removeVirtuals(c)
 
+    c.find('wxMenuItem.subMenu').transfer = True
     c.find('SetSubMenu.menu').transfer = True
 
     # deprecated and removed


### PR DESCRIPTION
This fixes a crash when wx.MenuItem with a submenu.

Fixes #1648.
