### PR TITLE
Fix stack overflow when overriding wx.CustomObject.SetData

### DIFF
--- a/etg/dataobj.py
+++ b/etg/dataobj.py
@@ -340,11 +340,11 @@ def run():
         body="return wxPyMakeBuffer(self->GetData(), self->GetSize());")
 
     c.find('SetData').ignore()
-    c.addCppMethod('bool', 'SetData', '(wxPyBuffer* buf)',
+    c.addCppMethod_sip('bool', 'SetData', '(wxPyBuffer* buf)',
         cppSignature='bool (size_t len, const void* buf)',
         isVirtual=True,
         doc="Copies data from the provided buffer to this data object's buffer",
-        body="return self->SetData(buf->m_len, buf->m_ptr);")
+        body="sipRes = (sipSelfWasArg ? sipCpp-> ::wxCustomDataObject::SetData(buf->m_len, buf->m_ptr) : sipCpp->SetData(buf->m_len, buf->m_ptr));")
 
     addGetAllFormats(c)
     addBaseVirtuals(c)


### PR DESCRIPTION
In the implementation of wx.CustomData.SetData, we need to check the
sipSelfWasArg variable to determine whether to call the parent class
implementation of SetData.  To do this, we switched to using addCppMethod_sip
which allows us to access the sipSelfWasArg variable.  The sip generator
stuff for CppMethod_sip needed some additions to match the behavior of
CppMethod.

Fixes #1645 

