### PR TITLE
Explicitly indicate that we don't want an alpha channel when rendering pdf image

### DIFF
--- a/wx/lib/pdfviewer/viewer.py
+++ b/wx/lib/pdfviewer/viewer.py
@@ -515,11 +515,8 @@ class mupdfProcessor(object):
         page = self.pdfdoc.loadPage(pageno)
         matrix = fitz.Matrix(scale, scale)
         try:
-            pix = page.getPixmap(matrix=matrix)   # MUST be keyword arg(s)
-            if [int(v) for v in fitz.version[1].split('.')] >= [1,15,0]:
-                bmp = wx.Bitmap.FromBuffer(pix.width, pix.height, pix.samples)
-            else:
-                bmp = wx.Bitmap.FromBufferRGBA(pix.width, pix.height, pix.samples)
+            pix = page.getPixmap(matrix=matrix, alpha=False)   # MUST be keyword arg(s)
+            bmp = wx.Bitmap.FromBuffer(pix.width, pix.height, pix.samples)
             gc.DrawBitmap(bmp, 0, 0, pix.width, pix.height)
             self.zoom_error = False
         except (RuntimeError, MemoryError):


### PR DESCRIPTION
I have found that the change in default behavior of getPixmap in MuPDF with respect to whether getPixmap returns an image with or without an alpha channel did not happen exactly between 1.14 and 1.15 but in between versions, so my previous patch (#1516) to the pdfviewer will not work for some versions of MuPDF.

I think an altogether cleaner solution to this problem that is also future proof against future changes in MuPDF default behavior is to not rely on the default and instead explicitly indicate in the call to `getPixmap` whether an alpha channel should be returned.

This is a patch to this effect.

Fixes #1350

