### PR TITLE
Optimize away an unnecessary extra wx.AuiNotebook DoSizing() call

### DIFF
--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -3420,6 +3420,9 @@ class AuiNotebook(wx.Panel):
                 tabctrl.SetArtProvider(art.Clone())
                 tab_frame.DoSizing()
 
+            return True
+
+        return False
 
     def UpdateHintWindowSize(self):
         """ Updates the :class:`~wx.lib.agw.aui.framemanager.AuiManager` hint window size. """
@@ -3641,8 +3644,10 @@ class AuiNotebook(wx.Panel):
             control.Reparent(active_tabctrl)
             control.Show()
 
-        self.UpdateTabCtrlHeight(force=force)
-        self.DoSizing()
+        # Note that we don't need to call DoSizing() if the height has changed, as
+        # it's already called from UpdateTabCtrlHeight() itself in this case.
+        if not self.UpdateTabCtrlHeight(force=force):
+            self.DoSizing()
         active_tabctrl.DoShowHide()
 
         # adjust selected index


### PR DESCRIPTION
There is no need to call DoSizing() again if it has just been called
from UpdateTabCtrlHeight().

See https://github.com/wxWidgets/wxWidgets/commit/dca84c823c78d8f686d23a8a8efa189d17cc7d0c
