### PR TITLE
Reduce item.GetState() calls to 1

### DIFF
--- a/wx/lib/agw/aui/auibar.py
+++ b/wx/lib/agw/aui/auibar.py
@@ -1007,27 +1007,28 @@ class AuiDefaultToolBarArt(object):
 
         bmp_rect, text_rect = self.GetToolsPosition(dc, item, rect)
 
-        if not item.GetState() & AUI_BUTTON_STATE_DISABLED:
+        item_state = item.GetState()
+        if not item_state & AUI_BUTTON_STATE_DISABLED:
 
-            if item.GetState() & AUI_BUTTON_STATE_PRESSED:
+            if item_state & AUI_BUTTON_STATE_PRESSED:
 
                 dc.SetPen(wx.Pen(self._highlight_colour))
                 dc.SetBrush(wx.Brush(StepColour(self._highlight_colour, 150)))
                 dc.DrawRectangle(rect)
 
-            elif item.GetState() & AUI_BUTTON_STATE_HOVER or item.IsSticky():
+            elif item_state & AUI_BUTTON_STATE_HOVER or item.IsSticky():
 
                 dc.SetPen(wx.Pen(self._highlight_colour))
                 dc.SetBrush(wx.Brush(StepColour(self._highlight_colour, 170)))
 
                 # draw an even lighter background for checked item hovers (since
                 # the hover background is the same colour as the check background)
-                if item.GetState() & AUI_BUTTON_STATE_CHECKED:
+                if item_state & AUI_BUTTON_STATE_CHECKED:
                     dc.SetBrush(wx.Brush(StepColour(self._highlight_colour, 180)))
 
                 dc.DrawRectangle(rect)
 
-            elif item.GetState() & AUI_BUTTON_STATE_CHECKED:
+            elif item_state & AUI_BUTTON_STATE_CHECKED:
 
                 # it's important to put this code in an else statment after the
                 # hover, otherwise hovers won't draw properly for checked items
@@ -1035,10 +1036,9 @@ class AuiDefaultToolBarArt(object):
                 dc.SetBrush(wx.Brush(StepColour(self._highlight_colour, 170)))
                 dc.DrawRectangle(rect)
 
-        if item.GetState() & AUI_BUTTON_STATE_DISABLED:
+        if item_state & AUI_BUTTON_STATE_DISABLED:
             bmp = item.GetDisabledBitmap()
-        elif item.GetState() & AUI_BUTTON_STATE_HOVER or \
-                item.GetState() & AUI_BUTTON_STATE_PRESSED:
+        elif item_state & AUI_BUTTON_STATE_HOVER or item_state & AUI_BUTTON_STATE_PRESSED:
             bmp = item.GetHoverBitmap()
             if not bmp:
                 bmp = item.GetBitmap()
@@ -1050,7 +1050,7 @@ class AuiDefaultToolBarArt(object):
 
         # set the item's text colour based on if it is disabled
         dc.SetTextForeground(wx.BLACK)
-        if item.GetState() & AUI_BUTTON_STATE_DISABLED:
+        if item_state & AUI_BUTTON_STATE_DISABLED:
             dc.SetTextForeground(DISABLED_TEXT_COLOUR)
 
         if self._agwFlags & AUI_TB_TEXT and item.GetLabel() != "":
@@ -1093,21 +1093,22 @@ class AuiDefaultToolBarArt(object):
 
         bmp_rect, text_rect = self.GetToolsPosition(dc, item, button_rect)
 
-        if item.GetState() & AUI_BUTTON_STATE_PRESSED:
+        item_state = item.GetState()
+        if item_state & AUI_BUTTON_STATE_PRESSED:
 
             dc.SetPen(wx.Pen(self._highlight_colour))
             dc.SetBrush(wx.Brush(StepColour(self._highlight_colour, 140)))
             dc.DrawRectangle(button_rect)
             dc.DrawRectangle(dropdown_rect)
 
-        elif item.GetState() & AUI_BUTTON_STATE_HOVER or item.IsSticky():
+        elif item_state & AUI_BUTTON_STATE_HOVER or item.IsSticky():
 
             dc.SetPen(wx.Pen(self._highlight_colour))
             dc.SetBrush(wx.Brush(StepColour(self._highlight_colour, 170)))
             dc.DrawRectangle(button_rect)
             dc.DrawRectangle(dropdown_rect)
 
-        elif item.GetState() & AUI_BUTTON_STATE_CHECKED:
+        elif item_state & AUI_BUTTON_STATE_CHECKED:
             # it's important to put this code in an else statment after the
             # hover, otherwise hovers won't draw properly for checked items
             dc.SetPen(wx.Pen(self._highlight_colour))
@@ -1115,7 +1116,7 @@ class AuiDefaultToolBarArt(object):
             dc.DrawRectangle(button_rect)
             dc.DrawRectangle(dropdown_rect)
 
-        if item.GetState() & AUI_BUTTON_STATE_DISABLED:
+        if item_state & AUI_BUTTON_STATE_DISABLED:
 
             bmp = item.GetDisabledBitmap()
             dropbmp = self._disabled_button_dropdown_bmp
@@ -1127,6 +1128,7 @@ class AuiDefaultToolBarArt(object):
 
         if bmp.IsOk():
             dc.DrawBitmap(bmp, bmp_rect.x, bmp_rect.y, True)
+
         if horizontal:
             dc.DrawBitmap(dropbmp, dropbmp_x, dropbmp_y, True)
         else:
@@ -1135,7 +1137,7 @@ class AuiDefaultToolBarArt(object):
 
         # set the item's text colour based on if it is disabled
         dc.SetTextForeground(wx.BLACK)
-        if item.GetState() & AUI_BUTTON_STATE_DISABLED:
+        if item_state & AUI_BUTTON_STATE_DISABLED:
             dc.SetTextForeground(DISABLED_TEXT_COLOUR)
 
         if self._agwFlags & AUI_TB_TEXT and item.GetLabel() != "":


### PR DESCRIPTION
With a toolbar(s) with x amount of buttons reduce the number of calls from possibly 3-6 each iteration down to 1.
