### PR TITLE
Remove exception in py shell wrap() method

### DIFF
--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -1436,10 +1436,7 @@ class Shell(editwindow.EditWindow):
 
     def wrap(self, wrap=True):
         """Sets whether text is word wrapped."""
-        try:
-            self.SetWrapMode(wrap)
-        except AttributeError:
-            return 'Wrapping is not available in this version.'
+        self.SetWrapMode(wrap)
 
     def zoom(self, points=0):
         """Set the zoom level.


### PR DESCRIPTION
This exists in Scintilla when wxPython 4.0 Phoenix came out, so remove it as cruft.
