### PR TITLE
pywxrc: fix embedded binary resources for python3

### DIFF
--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -216,7 +216,7 @@ def __init_resources():
     __res.Load('%(resourceFilename)s')"""
 
     FILE_AS_STRING = """\
-    %(filename)s = '''\\
+    %(filename)s = b'''\\
 %(fileData)s'''
 
 """
@@ -226,7 +226,7 @@ def __init_resources():
 """
 
     ADD_FILE_TO_MEMFS = """\
-    wx.MemoryFSHandler.AddFile('XRC/%(memoryPath)s/%(filename)s', %(filename)s)
+    wx.MemoryFSHandler.AddFile('XRC/%(memoryPath)s/%(filename)s', memoryview(%(filename)s))
 """
 
     LOAD_RES_MEMFS = """\


### PR DESCRIPTION
Previously, I was getting errors 'No handler found for image type' and 'Unknown image data format' after updating from wxPython 'classic'.
