### PR TITLE
pywxrc: fix embedded resources in python 2.7 AND 3

### DIFF
--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -226,7 +226,7 @@ def __init_resources():
 """
 
     ADD_FILE_TO_MEMFS = """\
-    wx.MemoryFSHandler.AddFile('XRC/%(memoryPath)s/%(filename)s', memoryview(%(filename)s))
+    wx.MemoryFSHandler.AddFile('XRC/%(memoryPath)s/%(filename)s', bytearray(%(filename)s))
 """
 
     LOAD_RES_MEMFS = """\


### PR DESCRIPTION
It turns out that memoryview() was resulting in an empty file in python 2.7, whereas bytearray is working in both 2.7 and 3.

Fixes https://github.com/wxWidgets/Phoenix/pull/1679#issuecomment-645731403
