### PR TITLE
Set transfer flag on wxPGWindowList constructor and SetSecondary method

### DIFF
--- a/etg/propgrideditors.py
+++ b/etg/propgrideditors.py
@@ -89,6 +89,13 @@ def run():
         if hasattr(item, 'type') and 'wxVariant' in item.type:
             item.type = item.type.replace('wxVariant', 'wxPGVariant')
 
+    # wxPGWindowList doesn't expect to own these, but wxPropertyGrid does,
+    # so flag them as transferred to the C++ side.
+    c = module.find('wxPGWindowList')
+    c.find('wxPGWindowList.primary').transfer = True
+    c.find('wxPGWindowList.secondary').transfer = True
+    c.find('SetSecondary.secondary').transfer = True
+
     #-----------------------------------------------------------------
     tools.doCommonTweaks(module)
     tools.runGenerators(module)


### PR DESCRIPTION
Fixes #1696.  wxPropertyGrid expects to delete both the primary and secondary
controls, so we need to prevent Python from doing so.