### PR TITLE
build.py: append PYTHONPATH

### DIFF
--- a/build.py
+++ b/build.py
@@ -167,7 +167,7 @@ def main(args):
     setPythonVersion(args)
     setDevModeOptions(args)
 
-    os.environ['PYTHONPATH'] = phoenixDir()
+    os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + os.pathsep + phoenixDir()
     os.environ['PYTHONUNBUFFERED'] = 'yes'
     os.environ['WXWIN'] = wxDir()
 
@@ -2223,7 +2223,7 @@ def cmd_setpythonpath(options, args):
     assert os.getcwd() == phoenixDir()
 
     sys.path.insert(0, phoenixDir())
-    os.environ['PYTHONPATH'] = phoenixDir()
+    os.environ['PYTHONPATH'] = os.environ.get('PYTHONPATH', '') + os.pathsep + phoenixDir()
 
 
 


### PR DESCRIPTION
based on deliciouslytyped's commit by a similar name
and the suggested changes https://github.com/wxWidgets/Phoenix/pull/1584#issuecomment-607526241

if `PYTHONPATH` was previously nonexistent it will now start with `:`, i'm assuming that's harmless

addresses #1314 (@deliciouslytyped mentioned this would only be a partial fix in their PR)

fixes #1584

