### PR TITLE
Allow building with STL wxWidgets variant

### DIFF
--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -520,14 +520,14 @@ def addSipConvertToSubClassCode(klass):
     %ConvertToSubClassCode
         const wxClassInfo* info   = sipCpp->GetClassInfo();
         wxString           name   = info->GetClassName();
-        bool               exists = sipFindType(name) != NULL;
+        bool               exists = sipFindType(name.c_str()) != NULL;
         while (info && !exists) {
             info = info->GetBaseClass1();
             name = info->GetClassName();
-            exists = sipFindType(name) != NULL;
+            exists = sipFindType(name.c_str()) != NULL;
         }
         if (info)
-            sipType = sipFindType(name);
+            sipType = sipFindType(name.c_str());
         else
             sipType = NULL;
     %End

--- a/src/pgvariant.sip
+++ b/src/pgvariant.sip
@@ -182,7 +182,7 @@ PyObject* wxPGVariant_out_helper(const wxVariant& value)
             size_t idx = 0;
             PyObject* value = PyList_New(0);
             for (idx=0; idx < sipCpp->GetCount(); idx++) {
-                PyObject* item = wxPGVariant_out_helper(sipCpp->Item(idx));
+                PyObject* item = wxPGVariant_out_helper(sipCpp->Item(idx)->GetData());
                 PyList_Append(value, item);
             }
             return value;

--- a/src/variant.sip
+++ b/src/variant.sip
@@ -77,7 +77,7 @@
             size_t idx = 0;
             PyObject* value = PyList_New(0);
             for (idx=0; idx < sipCpp->GetCount(); idx++) {
-                PyObject* item = wxVariant_out_helper(sipCpp->Item(idx));
+                PyObject* item = wxVariant_out_helper(sipCpp->Item(idx)->GetData());
                 PyList_Append(value, item);
             }
             return value;

--- a/src/wxpy_api.sip
+++ b/src/wxpy_api.sip
@@ -111,7 +111,7 @@ static PyObject* i_wxPyConstructObject(void* ptr,
     if (pos != wxNOT_FOUND)
         name = name.Mid(pos + nsDelimiter.Len());
 
-    const sipTypeDef* td = sipFindType(name);
+    const sipTypeDef* td = sipFindType(name.c_str());
     if (!td)
         return NULL;
     PyObject* transferObj = setThisOwn ? Py_None : NULL;
@@ -129,7 +129,7 @@ static bool i_wxPyWrappedPtr_Check(PyObject* obj)
 // Check if a PyObject is a specific wrapped class or subclass
 static bool i_wxPyWrappedPtr_TypeCheck(PyObject* obj, const wxString& className)
 {
-    const sipTypeDef* td = sipFindType(className);
+    const sipTypeDef* td = sipFindType(className.c_str());
     if (!td)
         return false;
     return sipCanConvertToType(obj, td, SIP_NO_CONVERTORS);
@@ -139,7 +139,7 @@ static bool i_wxPyWrappedPtr_TypeCheck(PyObject* obj, const wxString& className)
 // Convert a wrapped SIP object to its C++ pointer, ensuring that it is of the expected type
 static bool i_wxPyConvertWrappedPtr(PyObject* obj, void **ptr, const wxString& className)
 {
-    const sipTypeDef* td = sipFindType(className);
+    const sipTypeDef* td = sipFindType(className.c_str());
     if (!td)
         return false;
     if (! sipCanConvertToType(obj, td, SIP_NO_CONVERTORS))


### PR DESCRIPTION
While wxPython defaults to building the bundled wxWidgets with USE_STL=0,
it should still be possible to use a use a system wxWidgets built with
USE_STL=1.

Fixes two issues:
- Use explicit char* conversion for wxString
- Correctly convert/dereference list node before wrapping it into Variant.

