### PR TITLE
Fix sized_controls SetSizerType for grid sizers

### DIFF
--- a/wx/lib/sized_controls.py
+++ b/wx/lib/sized_controls.py
@@ -436,11 +436,11 @@ class SizedParent:
 
             if 'growable_row' in options:
                 row, proportion = options['growable_row']
-                sizer.SetGrowableRow(row, proportion)
+                sizer.AddGrowableRow(row, proportion)
 
             if 'growable_col' in options:
                 col, proportion = options['growable_col']
-                sizer.SetGrowableCol(col, proportion)
+                sizer.AddGrowableCol(col, proportion)
 
             if 'hgap' in options:
                 sizer.SetHGap(options['hgap'])


### PR DESCRIPTION
SetGrowableCol / SetGrowableRow seems to have never existed as far as I can see, so it seems this bug has existed for a long time.

Fixes #1729

