### PR TITLE
Added Value-property for IntCtrl and FloatSpin

### DIFF
--- a/wx/lib/agw/floatspin.py
+++ b/wx/lib/agw/floatspin.py
@@ -1204,6 +1204,9 @@ class FloatSpin(wx.Control):
         return finite, snap_value
 
 
+    Value = property(GetValue, SetValue)
+
+
 
 # Class FixedPoint, version 0.0.4.
 # Released to the public domain 28-Mar-2001,
@@ -1763,6 +1766,7 @@ if __name__ == '__main__':
                                   increment=0.01, value=0.1, agwStyle=FS_LEFT)
             floatspin.SetFormat("%f")
             floatspin.SetDigits(2)
+            floatspin.Value = 0.2
 
 
     # our normal wxApp-derived class, as usual

--- a/wx/lib/intctrl.py
+++ b/wx/lib/intctrl.py
@@ -855,6 +855,9 @@ class IntCtrl(wx.TextCtrl):
                 wx.CallAfter(self.SetInsertionPoint, new_pos)
 
 
+    Value = property(GetValue, SetValue)
+
+
 
 #===========================================================================
 
@@ -902,7 +905,7 @@ if __name__ == '__main__':
 
         def OnClick(self, event):
             dlg = myDialog(self.panel, -1, "test IntCtrl")
-            dlg.int_ctrl.SetValue(501)
+            dlg.int_ctrl.Value = 501
             dlg.int_ctrl.SetInsertionPoint(1)
             dlg.int_ctrl.SetSelection(1,2)
             rc = dlg.ShowModal()


### PR DESCRIPTION
Fixes #1734 

`wx\lib\intctrl.py` overrides GetValue and SetValue, but did not override the Value property, causing fallback to wx.TextEntry.Value, which operates on strings. 

And FloatSpin in `wx\lib\agw\floatspin.py` lacked Value-property altogether, although it did have GetValue and SetValue. 