### PR TITLE
Add agw.aui.AUI_DOCKART_HINT_WINDOW_BORDER_COLOUR theming

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ New and improved in this release:
 * Simplified the implementation of the wx.App.InitLocale method. See the
   MigrationGuide for more information.
 
+* Added wx.lib.agw.aui.AUI_DOCKART_HINT_WINDOW_BORDER_COLOUR constant
+  so the hint window border color can be themed as well.
+
 
 
 

--- a/wx/lib/agw/aui/aui_constants.py
+++ b/wx/lib/agw/aui/aui_constants.py
@@ -345,6 +345,8 @@ AUI_DOCKART_DRAW_SASH_GRIP = 18
 """ Draw a sash grip on the sash. """
 AUI_DOCKART_HINT_WINDOW_COLOUR = 19
 """ Customizes the hint window background colour (currently light blue). """
+AUI_DOCKART_HINT_WINDOW_BORDER_COLOUR = 20
+""" Customizes the hint window border background colour (currently grey). """
 
 # Caption Gradient Type
 AUI_GRADIENT_NONE = 0
@@ -2576,6 +2578,7 @@ colourIconDockingPart2 = wx.Colour(180, 201, 225)
 colourIconShadow = wx.Colour(198, 198, 198)
 colourIconArrow = wx.Colour(77, 79, 170)
 colourHintBackground = wx.Colour(0, 64, 255)
+colourHintBorder = wx.Colour(60, 60, 60)
 guideSizeX, guideSizeY = 29, 32
 aeroguideSizeX, aeroguideSizeY = 31, 32
 whidbeySizeX, whidbeySizeY = 43, 30

--- a/wx/lib/agw/aui/dockart.py
+++ b/wx/lib/agw/aui/dockart.py
@@ -90,6 +90,7 @@ class AuiDefaultDockArt(object):
     ``AUI_DOCKART_GRADIENT_TYPE``                     Customizes the gradient type (no gradient, vertical or horizontal)
     ``AUI_DOCKART_DRAW_SASH_GRIP``                    Draw a sash grip on the sash
     ``AUI_DOCKART_HINT_WINDOW_COLOUR``                Customizes the hint window background colour (currently light blue)
+    ``AUI_DOCKART_HINT_WINDOW_BORDER_COLOUR``         Customizes the hint window border background colour (currently grey)
     ================================================  ======================================
 
 
@@ -241,6 +242,7 @@ class AuiDefaultDockArt(object):
         self._gripper_pen3 = wx.WHITE_PEN
 
         self._hint_background_colour = colourHintBackground
+        self._hint_border_colour = colourHintBorder
 
 
     def GetMetric(self, id):
@@ -326,6 +328,8 @@ class AuiDefaultDockArt(object):
             return self._gripper_brush.GetColour()
         elif id == AUI_DOCKART_HINT_WINDOW_COLOUR:
             return self._hint_background_colour
+        elif id == AUI_DOCKART_HINT_WINDOW_BORDER_COLOUR:
+            return self._hint_border_colour
         else:
             raise Exception("Invalid Colour Ordinal.")
 
@@ -377,6 +381,8 @@ class AuiDefaultDockArt(object):
             self._gripper_pen2.SetColour(StepColour(colour, 60))
         elif id == AUI_DOCKART_HINT_WINDOW_COLOUR:
             self._hint_background_colour = colour
+        elif id == AUI_DOCKART_HINT_WINDOW_BORDER_COLOUR:
+            self._hint_border_colour = colour
         else:
             raise Exception("Invalid Colour Ordinal.")
 


### PR DESCRIPTION
Hint window border color can be set now with AUI_DOCKART_HINT_WINDOW_BORDER_COLOUR

Optimizations:
Optimized venetian blind loop and removed unnecessary wxPoint to tuple in Paint method wx.Rect

Screenie
![AUI_DOCKART_HINT_WINDOW_BORDER_COLOUR](https://user-images.githubusercontent.com/4668356/89347337-28f44600-d670-11ea-9d4b-02ca73cf4fb5.png)


