### PR TITLE
Do not mangle type of wxART_* identifiers

### DIFF
--- a/etg/artprov.py
+++ b/etg/artprov.py
@@ -52,13 +52,10 @@ def run():
     # deprecated and removed
     c.find('Insert').ignore()
 
-    # Change the types of the art constants from wxString to const char*
-    # since that is what they really are.
     artConsts = list()
     for item in module:
         if isinstance(item, etgtools.GlobalVarDef):
             if item.type in ['wxArtClient', 'wxArtID']:
-                item.type = 'const char*'
                 artConsts.append(item)
     # move them to the front of the module
     for item in artConsts:


### PR DESCRIPTION
Starting with wxWidgets 3.1.4, the identifiers are no longer const char[N].

Unfortunately, the implementation in 3.1.4 does not provide wxStrings
with static storage duration but just temporaries, so this can not be
used as constants from Phoenix, though 3.1.5 fixes this.

Fixes #1768 
See wxWidgets/wxWidgets#1996