### PR TITLE
Remove deprecated style 'TB_3DBUTTONS' from ShortcutEditor

### DIFF
--- a/wx/lib/agw/shortcuteditor.py
+++ b/wx/lib/agw/shortcuteditor.py
@@ -946,7 +946,7 @@ class HTMLHelpWindow(wx.Frame):
 
         self.htmlFile = htmlFile
 
-        toolbar = self.CreateToolBar(wx.TB_HORIZONTAL|wx.TB_FLAT|wx.TB_TEXT|wx.TB_3DBUTTONS)
+        toolbar = self.CreateToolBar(wx.TB_HORIZONTAL|wx.TB_FLAT|wx.TB_TEXT)
         self.BuildToolBar(toolbar)
 
         self.html = wx.html.HtmlWindow(self, style=wx.SUNKEN_BORDER)


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #1788  

Simply removes the obsolete style "wx.TB_3DBUTTONS" used in AGW ShortcutEditor.

