### PR TITLE
Do not strip wx prefix from parameter names

### DIFF
--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -49,6 +49,7 @@ def removeWxPrefixes(node):
            and item.name.startswith('wx') \
            and not item.name.startswith('wxEVT_') \
            and not isinstance(item, (extractors.TypedefDef,
+                                     extractors.ParamDef,
                                      extractors.MethodDef )):  # TODO: Any others?
                 item.pyName = item.name[2:]
                 item.wxDropped = True


### PR DESCRIPTION
Parameter names should not be mangled, as this causes mismatches between
extractor and xml data:

```
SEVERE: Incompatibility between function/method signature and list of parameters in `wx.html.HtmlHelpWindow.__init__`:
The parameter `WindowID` appears in the method signature but could not be found in the parameter list.
  ==> Function/Method signature from `extractors`: __init__(parent, WindowID, pos=wx.DefaultPosition, size=wx.DefaultSize, style=wx.TAB_TRAVERSAL|wx.BORDER_NONE, helpStyle=HF_DEFAULT_STYLE, data=None)
  ==> Parameter list from wxWidgets XML items:     ['parent', 'wxWindowID', 'pos', 'size', 'style', 'helpStyle', 'data']
```
```
  ==> Function/Method signature from `extractors`: SetAssertMode(AppAssertMode)
  ==> Parameter list from wxWidgets XML items:     ['wxAppAssertMode']
```
