### PR TITLE
AuiToolBar checks that it has not been Destroyed by the most recent a…

### DIFF
--- a/wx/lib/agw/aui/auibar.py
+++ b/wx/lib/agw/aui/auibar.py
@@ -3257,6 +3257,9 @@ class AuiToolBar(wx.Control):
     def DoIdleUpdate(self):
         """ Updates the toolbar during idle times. """
 
+        if not self:
+            return # The action Destroyed the toolbar!
+
         handler = self.GetEventHandler()
         if not handler:
             return
@@ -4028,4 +4031,3 @@ class AuiToolBar(wx.Control):
 
         manager = self.GetAuiManager()
         manager.StopPreviewTimer()
-


### PR DESCRIPTION
 `AuiToolBar` checks that it has not been Destroyed by the most recent action before doing any post-processing for the action. 
Fixes #1856 following the suggestion given there.

