### PR TITLE
Ensure variable is created before referencing it in aui framemanager.

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -9654,6 +9654,8 @@ class AuiManager(wx.EvtHandler):
         if pane.IsFloating():
             diff = pane.floating_pos - (screenPt - self._action_offset)
             pane.floating_pos = screenPt - self._action_offset
+        else:
+            diff = wx.Point()
 
         framePos = pane.floating_pos
 


### PR DESCRIPTION
Fixes #1872 per the discussion there.

