### PR TITLE
Fix conditional in sip_generator generateCppMethod_sip()

### DIFF
--- a/etgtools/sip_generator.py
+++ b/etgtools/sip_generator.py
@@ -925,11 +925,11 @@ from .%s import *
             # SIP appends them all together.
             _needDocstring = False
         stream.write('%s%%MethodCode\n' % indent)
-        if not (method.isCtor and method.isDtor):
+        if not (method.isCtor or method.isDtor):
             stream.write('%sPyErr_Clear();\n' % (indent+' '*4))
             stream.write('%sPy_BEGIN_ALLOW_THREADS\n' % (indent+' '*4))
         stream.write(nci(method.body, len(indent)+4))
-        if not (method.isCtor and method.isDtor):
+        if not (method.isCtor or method.isDtor):
             stream.write('%sPy_END_ALLOW_THREADS\n' % (indent+' '*4))
             stream.write('%sif (PyErr_Occurred()) sipIsErr = 1;\n' % (indent+' '*4))
         stream.write('%s%%End\n\n' % indent)


### PR DESCRIPTION
When I added this code in 5e190eb, it was intended to be used in all cases except for constructors and destructors.  Instead, it was used in all cases.  This broke the wxRegion constructor and possibly other things.

Fixes #1878.
