### PR TITLE
Fixes floating point math in wx.lib.agw.aui

### DIFF
--- a/wx/lib/agw/aui/aui_switcherdialog.py
+++ b/wx/lib/agw/aui/aui_switcherdialog.py
@@ -621,12 +621,12 @@ class SwitcherItems(object):
                    and item.GetBitmap().GetHeight() <= 16:
                     x -= textMarginX
                     dc.DrawBitmap(item.GetBitmap(), x, item.GetRect().y + \
-                                  (item.GetRect().height - item.GetBitmap().GetHeight())/2,
+                                  (item.GetRect().height - item.GetBitmap().GetHeight())//2,
                                   True)
                     x += 16 + textMarginX
                 #x += textMarginX
 
-            y = item.GetRect().y + (item.GetRect().height - h)/2
+            y = item.GetRect().y + (item.GetRect().height - h)//2
             dc.DrawText(item.GetTitle(), x, y)
             dc.DestroyClippingRegion()
 

--- a/wx/lib/agw/aui/aui_utilities.py
+++ b/wx/lib/agw/aui/aui_utilities.py
@@ -322,9 +322,9 @@ def DarkenBitmap(bmp, caption_colour, new_colour):
     """
 
     image = bmp.ConvertToImage()
-    red = caption_colour.Red()/float(new_colour.Red())
-    green = caption_colour.Green()/float(new_colour.Green())
-    blue = caption_colour.Blue()/float(new_colour.Blue())
+    red = caption_colour.Red()/new_colour.Red()
+    green = caption_colour.Green()/new_colour.Green()
+    blue = caption_colour.Blue()/new_colour.Blue()
     image = image.AdjustChannels(red, green, blue)
     return image.ConvertToBitmap()
 
@@ -584,13 +584,13 @@ def RescaleScreenShot(bmp, thumbnail_size=200):
 
     if bmpW > bmpH:
         if bmpW > thumbnail_size:
-            ratio = bmpW/float(thumbnail_size)
-            newW, newH = int(bmpW/ratio), int(bmpH/ratio)
+            ratio = bmpW/thumbnail_size
+            newW, newH = bmpW//ratio, bmpH//ratio
             img.Rescale(newW, newH, wx.IMAGE_QUALITY_HIGH)
     else:
         if bmpH > thumbnail_size:
-            ratio = bmpH/float(thumbnail_size)
-            newW, newH = int(bmpW/ratio), int(bmpH/ratio)
+            ratio = bmpH/thumbnail_size
+            newW, newH = bmpW//ratio, bmpH//ratio
             img.Rescale(newW, newH, wx.IMAGE_QUALITY_HIGH)
 
     newBmp = img.ConvertToBitmap()
@@ -666,4 +666,7 @@ def CopyAttributes(newArt, oldArt):
             setattr(newArt, attr, getattr(oldArt, attr))
 
     return newArt
+
+
+
 

--- a/wx/lib/agw/aui/auibar.py
+++ b/wx/lib/agw/aui/auibar.py
@@ -979,16 +979,16 @@ class AuiDefaultToolBarArt(object):
 
         if orient == AUI_TBTOOL_HORIZONTAL:
             text_x = rect.x
-            text_y = rect.y + (rect.height-text_height)/2
+            text_y = rect.y + (rect.height-text_height)//2
             dc.DrawText(item.GetLabel(), text_x, text_y)
 
         elif orient == AUI_TBTOOL_VERT_CLOCKWISE:
-            text_x = rect.x + (rect.width+text_width)/2
+            text_x = rect.x + (rect.width+text_width)//2
             text_y = rect.y
             dc.DrawRotatedText(item.GetLabel(), text_x, text_y, 270)
 
         elif AUI_TBTOOL_VERT_COUNTERCLOCKWISE:
-            text_x = rect.x + (rect.width-text_width)/2
+            text_x = rect.x + (rect.width-text_width)//2
             text_y = rect.y + text_height
             dc.DrawRotatedText(item.GetLabel(), text_x, text_y, 90)
 
@@ -1086,8 +1086,8 @@ class AuiDefaultToolBarArt(object):
             dropbmp_width = dropbmp_height
             dropbmp_height = tmp
 
-        dropbmp_x = dropdown_rect.x + (dropdown_rect.width/2) - dropbmp_width/2
-        dropbmp_y = dropdown_rect.y + (dropdown_rect.height/2) - dropbmp_height/2
+        dropbmp_x = dropdown_rect.x + (dropdown_rect.width//2) - dropbmp_width//2
+        dropbmp_y = dropdown_rect.y + (dropdown_rect.height//2) - dropbmp_height//2
 
         bmp_rect, text_rect = self.GetToolsPosition(dc, item, button_rect)
 
@@ -1171,7 +1171,7 @@ class AuiDefaultToolBarArt(object):
         # set the label's text colour
         dc.SetTextForeground(wx.BLACK)
 
-        text_x = rect.x + (rect.width/2) - (text_width/2) + 1
+        text_x = rect.x + (rect.width//2) - (text_width//2) + 1
         text_y = rect.y + rect.height - text_height - 1
 
         if self._agwFlags & AUI_TB_TEXT and item.GetLabel() != "":
@@ -1264,18 +1264,18 @@ class AuiDefaultToolBarArt(object):
 
         if horizontal:
 
-            rect.x += (rect.width/2)
+            rect.x += (rect.width//2)
             rect.width = 1
-            new_height = (rect.height*3)/4
-            rect.y += (rect.height/2) - (new_height/2)
+            new_height = (rect.height*3)//4
+            rect.y += (rect.height//2) - (new_height//2)
             rect.height = new_height
 
         else:
 
-            rect.y += (rect.height/2)
+            rect.y += (rect.height//2)
             rect.height = 1
-            new_width = (rect.width*3)/4
-            rect.x += (rect.width/2) - (new_width/2)
+            new_width = (rect.width*3)//4
+            rect.x += (rect.width//2) - (new_width//2)
             rect.width = new_width
 
         start_colour = StepColour(self._base_colour, 80)
@@ -1359,8 +1359,8 @@ class AuiDefaultToolBarArt(object):
                 dc.SetBrush(wx.Brush(light_gray_bg))
                 dc.DrawRectangle(rect.x+1, rect.y, rect.width, rect.height)
 
-        x = rect.x + 1 + (rect.width-self._overflow_bmp.GetWidth())/2
-        y = rect.y + 1 + (rect.height-self._overflow_bmp.GetHeight())/2
+        x = rect.x + 1 + (rect.width-self._overflow_bmp.GetWidth())//2
+        y = rect.y + 1 + (rect.height-self._overflow_bmp.GetHeight())//2
         dc.DrawBitmap(self._overflow_bmp, x, y, True)
 
 
@@ -1492,21 +1492,21 @@ class AuiDefaultToolBarArt(object):
         bmp_x = bmp_y = text_x = text_y = 0
 
         if horizontal and text_bottom:
-            bmp_x = rect.x + (rect.width/2) - (bmp_width/2)
+            bmp_x = rect.x + (rect.width//2) - (bmp_width//2)
             bmp_y = rect.y + 3
-            text_x = rect.x + (rect.width/2) - (text_width/2)
+            text_x = rect.x + (rect.width//2) - (text_width//2)
             text_y = rect.y + ((bmp_y - rect.y) * 2) + bmp_height
 
         elif horizontal and text_right:
             bmp_x = rect.x + 3
-            bmp_y = rect.y + (rect.height/2) - (bmp_height / 2)
+            bmp_y = rect.y + (rect.height//2) - (bmp_height // 2)
             text_x = rect.x + ((bmp_x - rect.x) * 2) + bmp_width
-            text_y = rect.y + (rect.height/2) - (text_height/2)
+            text_y = rect.y + (rect.height//2) - (text_height//2)
 
         elif not horizontal and text_bottom:
-            bmp_x = rect.x + (rect.width / 2) - (bmp_width / 2)
+            bmp_x = rect.x + (rect.width // 2) - (bmp_width // 2)
             bmp_y = rect.y + 3
-            text_x = rect.x + (rect.width / 2) - (text_width / 2)
+            text_x = rect.x + (rect.width // 2) - (text_width // 2)
             text_y = rect.y + ((bmp_y - rect.y) * 2) + bmp_height
 
         bmp_rect = wx.Rect(bmp_x, bmp_y, bmp_width, bmp_height)
@@ -3257,9 +3257,6 @@ class AuiToolBar(wx.Control):
     def DoIdleUpdate(self):
         """ Updates the toolbar during idle times. """
 
-        if not self:
-            return # The action Destroyed the toolbar!
-
         handler = self.GetEventHandler()
         if not handler:
             return
@@ -4031,3 +4028,4 @@ class AuiToolBar(wx.Control):
 
         manager = self.GetAuiManager()
         manager.StopPreviewTimer()
+

--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -175,7 +175,7 @@ class TabTextCtrl(ExpandoTextCtrl):
         x += image_w
         w -= image_w + 4
 
-        y = (self._tabEdited.rect.height - h)/2 + 1
+        y = (self._tabEdited.rect.height - h)//2 + 1
 
         expandoStyle = wx.WANTS_CHARS
         if wx.Platform in ["__WXGTK__", "__WXMAC__"]:
@@ -864,7 +864,7 @@ class TabNavigatorWindow(wx.Dialog):
         # Draw the caption title and place the bitmap
         # get the bitmap optimal position, and draw it
         bmpPt, txtPt = wx.Point(), wx.Point()
-        bmpPt.y = (rect.height - self._props.Icon.GetHeight())/2
+        bmpPt.y = (rect.height - self._props.Icon.GetHeight())//2
         bmpPt.x = 3
         mem_dc.DrawBitmap(self._props.Icon, bmpPt.x, bmpPt.y, True)
 
@@ -875,7 +875,7 @@ class TabNavigatorWindow(wx.Dialog):
         fontHeight = mem_dc.GetCharHeight()
 
         txtPt.x = bmpPt.x + self._props.Icon.GetWidth() + 4
-        txtPt.y = (rect.height - fontHeight)/2
+        txtPt.y = (rect.height - fontHeight)//2
         mem_dc.SetTextForeground(wx.WHITE)
         mem_dc.DrawText("Opened tabs:", txtPt.x, txtPt.y)
         mem_dc.SelectObject(wx.NullBitmap)

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -95,10 +95,10 @@ is by running the AUI sample (`AUI.py`).
 __author__ = "Andrea Gavana <andrea.gavana@gmail.com>"
 __date__ = "31 March 2009"
 
-
 import wx
 # just for isinstance
 from time import time
+
 try:
     from time import perf_counter
 except ImportError:  # clock is removed in py3.8
@@ -125,6 +125,7 @@ _winxptheme = False
 if wx.Platform == "__WXMSW__":
     try:
         import winxptheme
+
         _winxptheme = True
     except ImportError:
         pass
@@ -177,6 +178,7 @@ EVT_AUI_PANE_ACTIVATED = wx.PyEventBinder(wxEVT_AUI_PANE_ACTIVATED, 0)
 EVT_AUI_PERSPECTIVE_CHANGED = wx.PyEventBinder(wxEVT_AUI_PERSPECTIVE_CHANGED, 0)
 """ The layout in `AuiManager` has been changed. """
 
+
 # ---------------------------------------------------------------------------- #
 
 class AuiDockInfo(object):
@@ -201,7 +203,6 @@ class AuiDockInfo(object):
         self.rect = wx.Rect()
         self.panes = []
 
-
     def IsOk(self):
         """
         Returns whether a dock is valid or not.
@@ -211,12 +212,10 @@ class AuiDockInfo(object):
 
         return self.dock_direction != 0
 
-
     def IsHorizontal(self):
         """ Returns whether the dock is horizontal or not. """
 
         return self.dock_direction in [AUI_DOCK_TOP, AUI_DOCK_BOTTOM]
-
 
     def IsVertical(self):
         """ Returns whether the dock is vertical or not. """
@@ -245,7 +244,6 @@ class AuiDockingGuideInfo(object):
             # dock direction (top, bottom, left, right, center)
             self.dock_direction = AUI_DOCK_NONE
 
-
     def Assign(self, other):
         """
         Assigns the properties of the `other` :class:`AuiDockingGuideInfo` to `self`.
@@ -255,7 +253,6 @@ class AuiDockingGuideInfo(object):
 
         self.host = other.host
         self.dock_direction = other.dock_direction
-
 
     def Host(self, h):
         """
@@ -267,13 +264,11 @@ class AuiDockingGuideInfo(object):
         self.host = h
         return self
 
-
     def Left(self):
         """ Sets the guide window to left docking. """
 
         self.dock_direction = AUI_DOCK_LEFT
         return self
-
 
     def Right(self):
         """ Sets the guide window to right docking. """
@@ -281,13 +276,11 @@ class AuiDockingGuideInfo(object):
         self.dock_direction = AUI_DOCK_RIGHT
         return self
 
-
     def Top(self):
         """ Sets the guide window to top docking. """
 
         self.dock_direction = AUI_DOCK_TOP
         return self
-
 
     def Bottom(self):
         """ Sets the guide window to bottom docking. """
@@ -295,13 +288,11 @@ class AuiDockingGuideInfo(object):
         self.dock_direction = AUI_DOCK_BOTTOM
         return self
 
-
     def Center(self):
         """ Sets the guide window to center docking. """
 
         self.dock_direction = AUI_DOCK_CENTER
         return self
-
 
     def Centre(self):
         """ Sets the guide window to centre docking. """
@@ -376,7 +367,6 @@ class AuiManagerEvent(wx.PyCommandEvent):
         self.canveto_flag = True
         self.dc = None
 
-
     def SetManager(self, mgr):
         """
         Associates a :class:`AuiManager` to the current event.
@@ -385,7 +375,6 @@ class AuiManagerEvent(wx.PyCommandEvent):
         """
 
         self.manager = mgr
-
 
     def SetDC(self, pdc):
         """
@@ -396,7 +385,6 @@ class AuiManagerEvent(wx.PyCommandEvent):
 
         self.dc = pdc
 
-
     def SetPane(self, p):
         """
         Associates a :class:`AuiPaneInfo` instance to this event.
@@ -405,7 +393,6 @@ class AuiManagerEvent(wx.PyCommandEvent):
         """
 
         self.pane = p
-
 
     def SetButton(self, b):
         """
@@ -416,30 +403,25 @@ class AuiManagerEvent(wx.PyCommandEvent):
 
         self.button = b
 
-
     def GetManager(self):
         """ Returns the associated :class:`AuiManager` (if any). """
 
         return self.manager
-
 
     def GetDC(self):
         """ Returns the associated :class:`wx.DC` device context (if any). """
 
         return self.dc
 
-
     def GetPane(self):
         """ Returns the associated :class:`AuiPaneInfo` structure (if any). """
 
         return self.pane
 
-
     def GetButton(self):
         """ Returns the associated :class:`AuiPaneButton` instance (if any). """
 
         return self.button
-
 
     def Veto(self, veto=True):
         """
@@ -454,12 +436,10 @@ class AuiManagerEvent(wx.PyCommandEvent):
 
         self.veto_flag = veto
 
-
     def GetVeto(self):
         """ Returns whether the event has been vetoed or not. """
 
         return self.veto_flag
-
 
     def SetCanVeto(self, can_veto):
         """
@@ -470,11 +450,10 @@ class AuiManagerEvent(wx.PyCommandEvent):
 
         self.canveto_flag = can_veto
 
-
     def CanVeto(self):
         """ Returns whether the event can be vetoed and has been vetoed. """
 
-        return  self.canveto_flag and self.veto_flag
+        return self.canveto_flag and self.veto_flag
 
 
 # ---------------------------------------------------------------------------- #
@@ -487,47 +466,46 @@ class AuiPaneInfo(object):
     size, minimum size, caption text among many other parameters.
     """
 
-    optionFloating         = 2**0
-    optionHidden           = 2**1
-    optionLeftDockable     = 2**2
-    optionRightDockable    = 2**3
-    optionTopDockable      = 2**4
-    optionBottomDockable   = 2**5
-    optionFloatable        = 2**6
-    optionMovable          = 2**7
-    optionResizable        = 2**8
-    optionPaneBorder       = 2**9
-    optionCaption          = 2**10
-    optionGripper          = 2**11
-    optionDestroyOnClose   = 2**12
-    optionToolbar          = 2**13
-    optionActive           = 2**14
-    optionGripperTop       = 2**15
-    optionMaximized        = 2**16
-    optionDockFixed        = 2**17
-    optionNotebookDockable = 2**18
-    optionMinimized        = 2**19
-    optionLeftSnapped      = 2**20
-    optionRightSnapped     = 2**21
-    optionTopSnapped       = 2**22
-    optionBottomSnapped    = 2**23
-    optionFlyOut           = 2**24
-    optionCaptionLeft      = 2**25
+    optionFloating = 2 ** 0
+    optionHidden = 2 ** 1
+    optionLeftDockable = 2 ** 2
+    optionRightDockable = 2 ** 3
+    optionTopDockable = 2 ** 4
+    optionBottomDockable = 2 ** 5
+    optionFloatable = 2 ** 6
+    optionMovable = 2 ** 7
+    optionResizable = 2 ** 8
+    optionPaneBorder = 2 ** 9
+    optionCaption = 2 ** 10
+    optionGripper = 2 ** 11
+    optionDestroyOnClose = 2 ** 12
+    optionToolbar = 2 ** 13
+    optionActive = 2 ** 14
+    optionGripperTop = 2 ** 15
+    optionMaximized = 2 ** 16
+    optionDockFixed = 2 ** 17
+    optionNotebookDockable = 2 ** 18
+    optionMinimized = 2 ** 19
+    optionLeftSnapped = 2 ** 20
+    optionRightSnapped = 2 ** 21
+    optionTopSnapped = 2 ** 22
+    optionBottomSnapped = 2 ** 23
+    optionFlyOut = 2 ** 24
+    optionCaptionLeft = 2 ** 25
 
-    buttonClose            = 2**26
-    buttonMaximize         = 2**27
-    buttonMinimize         = 2**28
-    buttonPin              = 2**29
+    buttonClose = 2 ** 26
+    buttonMaximize = 2 ** 27
+    buttonMinimize = 2 ** 28
+    buttonPin = 2 ** 29
 
-    buttonCustom1          = 2**30
-    buttonCustom2          = 2**31
-    buttonCustom3          = 2**32
+    buttonCustom1 = 2 ** 30
+    buttonCustom2 = 2 ** 31
+    buttonCustom3 = 2 ** 32
 
-    savedHiddenState       = 2**33    # used internally
-    actionPane             = 2**34    # used internally
-    wasMaximized           = 2**35    # used internally
-    needsRestore           = 2**36    # used internally
-
+    savedHiddenState = 2 ** 33  # used internally
+    actionPane = 2 ** 34  # used internally
+    wasMaximized = 2 ** 35  # used internally
+    needsRestore = 2 ** 36  # used internally
 
     def __init__(self):
         """ Default class constructor. """
@@ -561,7 +539,6 @@ class AuiPaneInfo(object):
 
         self.DefaultPane()
 
-
     def dock_direction_get(self):
         """
         Getter for the `dock_direction`.
@@ -573,7 +550,6 @@ class AuiPaneInfo(object):
             return AUI_DOCK_CENTER
         else:
             return self._dock_direction
-
 
     def dock_direction_set(self, value):
         """
@@ -609,54 +585,45 @@ class AuiPaneInfo(object):
 
         return self.window is not None
 
-
     def IsMaximized(self):
         """ Returns ``True`` if the pane is maximized. """
 
         return self.HasFlag(self.optionMaximized)
-
 
     def IsMinimized(self):
         """ Returns ``True`` if the pane is minimized. """
 
         return self.HasFlag(self.optionMinimized)
 
-
     def IsFixed(self):
         """ Returns ``True`` if the pane cannot be resized. """
 
         return not self.HasFlag(self.optionResizable)
-
 
     def IsResizeable(self):
         """ Returns ``True`` if the pane can be resized. """
 
         return self.HasFlag(self.optionResizable)
 
-
     def IsShown(self):
         """ Returns ``True`` if the pane is currently shown. """
 
         return not self.HasFlag(self.optionHidden)
-
 
     def IsFloating(self):
         """ Returns ``True`` if the pane is floating. """
 
         return self.HasFlag(self.optionFloating)
 
-
     def IsDocked(self):
         """ Returns ``True`` if the pane is docked. """
 
         return not self.HasFlag(self.optionFloating)
 
-
     def IsToolbar(self):
         """ Returns ``True`` if the pane contains a toolbar. """
 
         return self.HasFlag(self.optionToolbar)
-
 
     def IsTopDockable(self):
         """
@@ -666,7 +633,6 @@ class AuiPaneInfo(object):
 
         return self.HasFlag(self.optionTopDockable)
 
-
     def IsBottomDockable(self):
         """
         Returns ``True`` if the pane can be docked at the bottom
@@ -674,7 +640,6 @@ class AuiPaneInfo(object):
         """
 
         return self.HasFlag(self.optionBottomDockable)
-
 
     def IsLeftDockable(self):
         """
@@ -684,7 +649,6 @@ class AuiPaneInfo(object):
 
         return self.HasFlag(self.optionLeftDockable)
 
-
     def IsRightDockable(self):
         """
         Returns ``True`` if the pane can be docked at the right
@@ -693,13 +657,11 @@ class AuiPaneInfo(object):
 
         return self.HasFlag(self.optionRightDockable)
 
-
     def IsDockable(self):
         """ Returns ``True`` if the pane can be docked. """
 
         return self.IsTopDockable() or self.IsBottomDockable() or self.IsLeftDockable() or \
                self.IsRightDockable() or self.IsNotebookDockable()
-
 
     def IsFloatable(self):
         """
@@ -709,7 +671,6 @@ class AuiPaneInfo(object):
 
         return self.HasFlag(self.optionFloatable)
 
-
     def IsMovable(self):
         """
         Returns ``True`` if the docked frame can be undocked or moved to
@@ -717,7 +678,6 @@ class AuiPaneInfo(object):
         """
 
         return self.HasFlag(self.optionMovable)
-
 
     def IsDestroyOnClose(self):
         """
@@ -730,7 +690,6 @@ class AuiPaneInfo(object):
 
         return self.HasFlag(self.optionDestroyOnClose)
 
-
     def IsNotebookDockable(self):
         """
         Returns ``True`` if a pane can be docked on top to another to create a
@@ -739,30 +698,25 @@ class AuiPaneInfo(object):
 
         return self.HasFlag(self.optionNotebookDockable)
 
-
     def IsTopSnappable(self):
         """ Returns ``True`` if the pane can be snapped at the top of the managed frame. """
 
         return self.HasFlag(self.optionTopSnapped)
-
 
     def IsBottomSnappable(self):
         """ Returns ``True`` if the pane can be snapped at the bottom of the managed frame. """
 
         return self.HasFlag(self.optionBottomSnapped)
 
-
     def IsLeftSnappable(self):
         """ Returns ``True`` if the pane can be snapped on the left of the managed frame. """
 
         return self.HasFlag(self.optionLeftSnapped)
 
-
     def IsRightSnappable(self):
         """ Returns ``True`` if the pane can be snapped on the right of the managed frame. """
 
         return self.HasFlag(self.optionRightSnapped)
-
 
     def IsSnappable(self):
         """ Returns ``True`` if the pane can be snapped. """
@@ -770,54 +724,45 @@ class AuiPaneInfo(object):
         return self.IsTopSnappable() or self.IsBottomSnappable() or self.IsLeftSnappable() or \
                self.IsRightSnappable()
 
-
     def IsFlyOut(self):
         """ Returns ``True`` if the floating pane has a "fly-out" effect. """
 
         return self.HasFlag(self.optionFlyOut)
-
 
     def HasCaption(self):
         """ Returns ``True`` if the pane displays a caption. """
 
         return self.HasFlag(self.optionCaption)
 
-
     def HasCaptionLeft(self):
         """ Returns ``True`` if the pane displays a caption on the left (rotated by 90 degrees). """
 
         return self.HasFlag(self.optionCaptionLeft)
-
 
     def HasGripper(self):
         """ Returns ``True`` if the pane displays a gripper. """
 
         return self.HasFlag(self.optionGripper)
 
-
     def HasBorder(self):
         """ Returns ``True`` if the pane displays a border. """
 
         return self.HasFlag(self.optionPaneBorder)
-
 
     def HasCloseButton(self):
         """ Returns ``True`` if the pane displays a button to close the pane. """
 
         return self.HasFlag(self.buttonClose)
 
-
     def HasMaximizeButton(self):
         """ Returns ``True`` if the pane displays a button to maximize the pane. """
 
         return self.HasFlag(self.buttonMaximize)
 
-
     def HasMinimizeButton(self):
         """ Returns ``True`` if the pane displays a button to minimize the pane. """
 
         return self.HasFlag(self.buttonMinimize)
-
 
     def GetMinimizeMode(self):
         """
@@ -854,18 +799,15 @@ class AuiPaneInfo(object):
 
         return self.minimize_mode
 
-
     def HasPinButton(self):
         """ Returns ``True`` if the pane displays a button to float the pane. """
 
         return self.HasFlag(self.buttonPin)
 
-
     def HasGripperTop(self):
         """ Returns ``True`` if the pane displays a gripper at the top. """
 
         return self.HasFlag(self.optionGripperTop)
-
 
     def Window(self, w):
         """
@@ -880,7 +822,6 @@ class AuiPaneInfo(object):
 
         self.window = w
         return self
-
 
     def Name(self, name):
         """
@@ -901,7 +842,6 @@ class AuiPaneInfo(object):
         self.name = name
         return self
 
-
     def Caption(self, caption):
         """
         Sets the caption of the pane.
@@ -911,7 +851,6 @@ class AuiPaneInfo(object):
 
         self.caption = caption
         return self
-
 
     def Left(self):
         """
@@ -924,7 +863,6 @@ class AuiPaneInfo(object):
         self.dock_direction = AUI_DOCK_LEFT
         return self
 
-
     def Right(self):
         """
         Sets the pane dock position to the right side of the frame.
@@ -935,7 +873,6 @@ class AuiPaneInfo(object):
 
         self.dock_direction = AUI_DOCK_RIGHT
         return self
-
 
     def Top(self):
         """
@@ -948,7 +885,6 @@ class AuiPaneInfo(object):
         self.dock_direction = AUI_DOCK_TOP
         return self
 
-
     def Bottom(self):
         """
         Sets the pane dock position to the bottom of the frame.
@@ -959,7 +895,6 @@ class AuiPaneInfo(object):
 
         self.dock_direction = AUI_DOCK_BOTTOM
         return self
-
 
     def Center(self):
         """
@@ -975,7 +910,6 @@ class AuiPaneInfo(object):
         self.dock_direction = AUI_DOCK_CENTER
         return self
 
-
     def Centre(self):
         """
         Sets the pane to the center position of the frame.
@@ -989,7 +923,6 @@ class AuiPaneInfo(object):
 
         self.dock_direction = AUI_DOCK_CENTRE
         return self
-
 
     def Direction(self, direction):
         """
@@ -1005,7 +938,6 @@ class AuiPaneInfo(object):
         self.dock_direction = direction
         return self
 
-
     def Layer(self, layer):
         """
         Determines the layer of the docked pane.
@@ -1020,7 +952,6 @@ class AuiPaneInfo(object):
         self.dock_layer = layer
         return self
 
-
     def Row(self, row):
         """
         Determines the row of the docked pane.
@@ -1031,7 +962,6 @@ class AuiPaneInfo(object):
         self.dock_row = row
         return self
 
-
     def Position(self, pos):
         """
         Determines the position of the docked pane.
@@ -1041,7 +971,6 @@ class AuiPaneInfo(object):
 
         self.dock_pos = pos
         return self
-
 
     def MinSize(self, arg1=None, arg2=None):
         """
@@ -1061,10 +990,9 @@ class AuiPaneInfo(object):
         elif isinstance(arg1, six.integer_types) and arg2 is not None:
             ret = self.MinSize2(arg1, arg2)
         else:
-            raise Exception("Invalid argument passed to `MinSize`: arg1=%s, arg2=%s"%(repr(arg1), repr(arg2)))
+            raise Exception("Invalid argument passed to `MinSize`: arg1=%s, arg2=%s" % (repr(arg1), repr(arg2)))
 
         return ret
-
 
     def MinSize1(self, size):
         """
@@ -1075,7 +1003,6 @@ class AuiPaneInfo(object):
         self.min_size = size
         return self
 
-
     def MinSize2(self, x, y):
         """
         Sets the minimum size of the pane.
@@ -1085,7 +1012,6 @@ class AuiPaneInfo(object):
 
         self.min_size = wx.Size(x, y)
         return self
-
 
     def MaxSize(self, arg1=None, arg2=None):
         """
@@ -1105,10 +1031,9 @@ class AuiPaneInfo(object):
         elif isinstance(arg1, six.integer_types) and arg2 is not None:
             ret = self.MaxSize2(arg1, arg2)
         else:
-            raise Exception("Invalid argument passed to `MaxSize`: arg1=%s, arg2=%s"%(repr(arg1), repr(arg2)))
+            raise Exception("Invalid argument passed to `MaxSize`: arg1=%s, arg2=%s" % (repr(arg1), repr(arg2)))
 
         return ret
-
 
     def MaxSize1(self, size):
         """
@@ -1120,7 +1045,6 @@ class AuiPaneInfo(object):
         self.max_size = size
         return self
 
-
     def MaxSize2(self, x, y):
         """
         Sets the maximum size of the pane.
@@ -1128,9 +1052,8 @@ class AuiPaneInfo(object):
         :see: :meth:`MaxSize` for an explanation of input parameters.
         """
 
-        self.max_size.Set(x,y)
+        self.max_size.Set(x, y)
         return self
-
 
     def BestSize(self, arg1=None, arg2=None):
         """
@@ -1151,10 +1074,9 @@ class AuiPaneInfo(object):
         elif isinstance(arg1, six.integer_types) and arg2 is not None:
             ret = self.BestSize2(arg1, arg2)
         else:
-            raise Exception("Invalid argument passed to `BestSize`: arg1=%s, arg2=%s"%(repr(arg1), repr(arg2)))
+            raise Exception("Invalid argument passed to `BestSize`: arg1=%s, arg2=%s" % (repr(arg1), repr(arg2)))
 
         return ret
-
 
     def BestSize1(self, size):
         """
@@ -1166,7 +1088,6 @@ class AuiPaneInfo(object):
         self.best_size = size
         return self
 
-
     def BestSize2(self, x, y):
         """
         Sets the best size of the pane.
@@ -1174,9 +1095,8 @@ class AuiPaneInfo(object):
         :see: :meth:`BestSize` for an explanation of input parameters.
         """
 
-        self.best_size.Set(x,y)
+        self.best_size.Set(x, y)
         return self
-
 
     def FloatingPosition(self, pos):
         """
@@ -1188,7 +1108,6 @@ class AuiPaneInfo(object):
         self.floating_pos = wx.Point(*pos)
         return self
 
-
     def FloatingSize(self, size):
         """
         Sets the size of the floating pane.
@@ -1199,12 +1118,10 @@ class AuiPaneInfo(object):
         self.floating_size = wx.Size(*size)
         return self
 
-
     def Maximize(self):
         """ Makes the pane take up the full area."""
 
         return self.SetFlag(self.optionMaximized, True)
-
 
     def Minimize(self):
         """
@@ -1220,7 +1137,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionMinimized, True)
-
 
     def MinimizeMode(self, mode):
         """
@@ -1261,7 +1177,6 @@ class AuiPaneInfo(object):
         self.minimize_mode = mode
         return self
 
-
     def MinimizeTarget(self, toolbarPane):
         """
         Minimizes the panes using a :class:`AuiPaneInfo` as a target. As :class:`AuiPaneInfo` properties
@@ -1282,12 +1197,10 @@ class AuiPaneInfo(object):
         self.minimize_target = toolbarPane.name
         return self
 
-
     def Restore(self):
         """ Is the reverse of :meth:`Maximize` and :meth:`Minimize`."""
 
         return self.SetFlag(self.optionMaximized | self.optionMinimized, False)
-
 
     def Fixed(self):
         """
@@ -1296,7 +1209,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionResizable, False)
-
 
     def Resizable(self, resizable=True):
         """
@@ -1310,7 +1222,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionResizable, resizable)
 
-
     def Transparent(self, alpha):
         """
         Makes the pane transparent when floating.
@@ -1319,11 +1230,10 @@ class AuiPaneInfo(object):
         """
 
         if alpha < 0 or alpha > 255:
-            raise Exception("Invalid transparency value (%s)"%repr(alpha))
+            raise Exception("Invalid transparency value (%s)" % repr(alpha))
 
         self.transparent = alpha
         self.needsTransparency = True
-
 
     def Dock(self):
         """ Indicates that a pane should be docked. It is the opposite of :meth:`Float`. """
@@ -1334,7 +1244,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionFloating, False)
 
-
     def Float(self):
         """ Indicates that a pane should be floated. It is the opposite of :meth:`Dock`. """
 
@@ -1343,7 +1252,6 @@ class AuiPaneInfo(object):
             self.dock_direction = AUI_DOCK_NONE
 
         return self.SetFlag(self.optionFloating, True)
-
 
     def Hide(self):
         """
@@ -1354,7 +1262,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionHidden, True)
 
-
     def Show(self, show=True):
         """
         Indicates that a pane should be shown.
@@ -1363,7 +1270,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionHidden, not show)
-
 
     # By defaulting to 1000, the tab will get placed at the end
     def NotebookPage(self, id, tab_position=1000):
@@ -1385,7 +1291,6 @@ class AuiPaneInfo(object):
 
         return self
 
-
     def NotebookControl(self, id):
         """
         Forces a pane to be a notebook control (:class:`~wx.lib.agw.aui.auibook.AuiNotebook`).
@@ -1402,33 +1307,28 @@ class AuiPaneInfo(object):
 
         return self
 
-
     def HasNotebook(self):
         """ Returns whether a pane has a :class:`~wx.lib.agw.aui.auibook.AuiNotebook` or not. """
 
         return self.notebook_id >= 0
-
 
     def IsNotebookPage(self):
         """ Returns whether the pane is a notebook page in a :class:`~wx.lib.agw.aui.auibook.AuiNotebook`. """
 
         return self.notebook_id >= 0 and self.dock_direction == AUI_DOCK_NOTEBOOK_PAGE
 
-
     def IsNotebookControl(self):
         """ Returns whether the pane is a notebook control (:class:`~wx.lib.agw.aui.auibook.AuiNotebook`). """
 
         return not self.IsNotebookPage() and self.HasNotebook()
 
-
     def SetNameFromNotebookId(self):
         """ Sets the pane name once docked in a :class:`~wx.lib.agw.aui.auibook.AuiNotebook` using the notebook id. """
 
         if self.notebook_id >= 0:
-            self.name = "__notebook_%d"%self.notebook_id
+            self.name = "__notebook_%d" % self.notebook_id
 
         return self
-
 
     def CaptionVisible(self, visible=True, left=False):
         """
@@ -1446,7 +1346,6 @@ class AuiPaneInfo(object):
         self.SetFlag(self.optionCaptionLeft, False)
         return self.SetFlag(self.optionCaption, visible)
 
-
     def PaneBorder(self, visible=True):
         """
         Indicates that a border should be drawn for the pane.
@@ -1455,7 +1354,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionPaneBorder, visible)
-
 
     def Gripper(self, visible=True):
         """
@@ -1466,7 +1364,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionGripper, visible)
 
-
     def GripperTop(self, attop=True):
         """
         Indicates that a gripper should be drawn at the top of the pane.
@@ -1475,7 +1372,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionGripperTop, attop)
-
 
     def CloseButton(self, visible=True):
         """
@@ -1486,7 +1382,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.buttonClose, visible)
 
-
     def MaximizeButton(self, visible=True):
         """
         Indicates that a maximize button should be drawn for the pane.
@@ -1495,7 +1390,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.buttonMaximize, visible)
-
 
     def MinimizeButton(self, visible=True):
         """
@@ -1506,7 +1400,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.buttonMinimize, visible)
 
-
     def PinButton(self, visible=True):
         """
         Indicates that a pin button should be drawn for the pane.
@@ -1515,7 +1408,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.buttonPin, visible)
-
 
     def DestroyOnClose(self, b=True):
         """
@@ -1530,7 +1422,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionDestroyOnClose, b)
 
-
     def TopDockable(self, b=True):
         """
         Indicates whether a pane can be docked at the top of the frame.
@@ -1539,7 +1430,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionTopDockable, b)
-
 
     def BottomDockable(self, b=True):
         """
@@ -1550,7 +1440,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionBottomDockable, b)
 
-
     def LeftDockable(self, b=True):
         """
         Indicates whether a pane can be docked on the left of the frame.
@@ -1560,7 +1449,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionLeftDockable, b)
 
-
     def RightDockable(self, b=True):
         """
         Indicates whether a pane can be docked on the right of the frame.
@@ -1569,7 +1457,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionRightDockable, b)
-
 
     def Floatable(self, b=True):
         """
@@ -1581,7 +1468,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionFloatable, b)
 
-
     def Movable(self, b=True):
         """
         Indicates whether a pane can be moved.
@@ -1591,7 +1477,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionMovable, b)
 
-
     def NotebookDockable(self, b=True):
         """
         Indicates whether a pane can be docked in an automatic :class:`~wx.lib.agw.aui.auibook.AuiNotebook`.
@@ -1600,7 +1485,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionNotebookDockable, b)
-
 
     def DockFixed(self, b=True):
         """
@@ -1613,7 +1497,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionDockFixed, b)
 
-
     def Dockable(self, b=True):
         """
         Specifies whether a frame can be docked or not. It is the same as specifying
@@ -1624,7 +1507,6 @@ class AuiPaneInfo(object):
 
         return self.TopDockable(b).BottomDockable(b).LeftDockable(b).RightDockable(b)
 
-
     def TopSnappable(self, b=True):
         """
         Indicates whether a pane can be snapped at the top of the main frame.
@@ -1633,7 +1515,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionTopSnapped, b)
-
 
     def BottomSnappable(self, b=True):
         """
@@ -1644,7 +1525,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionBottomSnapped, b)
 
-
     def LeftSnappable(self, b=True):
         """
         Indicates whether a pane can be snapped on the left of the main frame.
@@ -1654,7 +1534,6 @@ class AuiPaneInfo(object):
 
         return self.SetFlag(self.optionLeftSnapped, b)
 
-
     def RightSnappable(self, b=True):
         """
         Indicates whether a pane can be snapped on the right of the main frame.
@@ -1663,7 +1542,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionRightSnapped, b)
-
 
     def Snappable(self, b=True):
         """
@@ -1675,7 +1553,6 @@ class AuiPaneInfo(object):
 
         return self.TopSnappable(b).BottomSnappable(b).LeftSnappable(b).RightSnappable(b)
 
-
     def FlyOut(self, b=True):
         """
         Indicates whether a pane, when floating, has a "fly-out" effect
@@ -1685,7 +1562,6 @@ class AuiPaneInfo(object):
         """
 
         return self.SetFlag(self.optionFlyOut, b)
-
 
     # Copy over the members that pertain to docking position
     def SetDockPos(self, source):
@@ -1707,7 +1583,6 @@ class AuiPaneInfo(object):
 
         return self
 
-
     def DefaultPane(self):
         """ Specifies that the pane should adopt the default pane settings. """
 
@@ -1721,7 +1596,6 @@ class AuiPaneInfo(object):
         self.state = state
         return self
 
-
     def CentrePane(self):
         """
         Specifies that the pane should adopt the default center pane settings.
@@ -1731,7 +1605,6 @@ class AuiPaneInfo(object):
         """
 
         return self.CenterPane()
-
 
     def CenterPane(self):
         """
@@ -1743,7 +1616,6 @@ class AuiPaneInfo(object):
 
         self.state = 0
         return self.Center().PaneBorder().Resizable()
-
 
     def ToolbarPane(self):
         """ Specifies that the pane should adopt the default toolbar pane settings. """
@@ -1761,7 +1633,6 @@ class AuiPaneInfo(object):
 
         return self
 
-
     def Icon(self, icon):
         """
         Specifies whether an icon is drawn on the left of the caption text when
@@ -1777,7 +1648,6 @@ class AuiPaneInfo(object):
 
         self.icon = icon
         return self
-
 
     def SetFlag(self, flag, option_state):
         """
@@ -1802,7 +1672,6 @@ class AuiPaneInfo(object):
 
         return self
 
-
     def HasFlag(self, flag):
         """
         Returns ``True`` if the the property specified by flag is active for the pane.
@@ -1811,7 +1680,6 @@ class AuiPaneInfo(object):
         """
 
         return (self.state & flag and [True] or [False])[0]
-
 
     def ResetButtons(self):
         """
@@ -1838,7 +1706,6 @@ class AuiPaneInfo(object):
             button = AuiPaneButton(AUI_BUTTON_CLOSE)
             self.buttons.append(button)
 
-
     def CountButtons(self):
         """ Returns the number of visible buttons in the docked pane. """
 
@@ -1858,7 +1725,6 @@ class AuiPaneInfo(object):
                 n += 1
 
         return n
-
 
     def IsHorizontal(self):
         """ Returns ``True`` if the pane `dock_direction` is horizontal. """
@@ -1883,7 +1749,7 @@ class AuiDockingGuide(wx.Frame):
 
     def __init__(self, parent, id=wx.ID_ANY, title="", pos=wx.DefaultPosition,
                  size=wx.DefaultSize, style=wx.FRAME_TOOL_WINDOW | wx.STAY_ON_TOP |
-                 wx.FRAME_NO_TASKBAR | wx.NO_BORDER, name="AuiDockingGuide"):
+                                            wx.FRAME_NO_TASKBAR | wx.NO_BORDER, name="AuiDockingGuide"):
         """
         Default class constructor. Used internally, do not call it in your code!
 
@@ -1901,7 +1767,6 @@ class AuiDockingGuide(wx.Frame):
 
         wx.Frame.__init__(self, parent, id, title, pos, size, style, name=name)
 
-
     def HitTest(self, x, y):
         """
         To be overridden by parent classes.
@@ -1912,7 +1777,6 @@ class AuiDockingGuide(wx.Frame):
 
         return 0
 
-
     def ValidateNotebookDocking(self, valid):
         """
         To be overridden by parent classes.
@@ -1922,6 +1786,7 @@ class AuiDockingGuide(wx.Frame):
         """
 
         return 0
+
 
 # ============================================================================
 # implementation
@@ -1962,7 +1827,6 @@ class AuiDockingGuideWindow(wx.Window):
         self.Bind(wx.EVT_ERASE_BACKGROUND, self.OnEraseBackground)
         self.Bind(wx.EVT_PAINT, self.OnPaint)
 
-
     def SetValid(self, valid):
         """
         Sets the docking direction as valid or invalid.
@@ -1972,12 +1836,10 @@ class AuiDockingGuideWindow(wx.Window):
 
         self._valid = valid
 
-
     def IsValid(self):
         """ Returns whether the docking direction is valid. """
 
         return self._valid
-
 
     def OnEraseBackground(self, event):
         """
@@ -1989,7 +1851,6 @@ class AuiDockingGuideWindow(wx.Window):
         """
 
         pass
-
 
     def DrawBackground(self, dc):
         """
@@ -2014,13 +1875,13 @@ class AuiDockingGuideWindow(wx.Window):
         if self._direction != wx.CENTER:
 
             if not self._center or self._direction != wx.BOTTOM:
-                dc.DrawLine(left, top, right+1, top)
+                dc.DrawLine(left, top, right + 1, top)
             if not self._center or self._direction != wx.RIGHT:
-                dc.DrawLine(left, top, left, bottom+1)
+                dc.DrawLine(left, top, left, bottom + 1)
             if not self._center or self._direction != wx.LEFT:
-                dc.DrawLine(right, top, right, bottom+1)
+                dc.DrawLine(right, top, right, bottom + 1)
             if not self._center or self._direction != wx.TOP:
-                dc.DrawLine(left, bottom, right+1, bottom)
+                dc.DrawLine(left, bottom, right + 1, bottom)
 
             dc.SetPen(wx.Pen(colourTargetShade))
 
@@ -2028,7 +1889,6 @@ class AuiDockingGuideWindow(wx.Window):
                 dc.DrawLine(left + 1, top + 1, left + 1, bottom)
             if self._direction != wx.BOTTOM:
                 dc.DrawLine(left + 1, top + 1, right, top + 1)
-
 
     def DrawDottedLine(self, dc, point, length, vertical):
         """
@@ -2046,7 +1906,6 @@ class AuiDockingGuideWindow(wx.Window):
                 point.y += 2
             else:
                 point.x += 2
-
 
     def DrawIcon(self, dc):
         """
@@ -2074,24 +1933,24 @@ class AuiDockingGuideWindow(wx.Window):
         rect.Deflate(1, 1)
 
         if self._direction == wx.TOP:
-            rect.height -= rect.height / 2
+            rect.height -= rect.height // 2
             point = rect.GetBottomLeft()
             length = rect.width
 
         elif self._direction == wx.LEFT:
-            rect.width -= rect.width / 2
+            rect.width -= rect.width // 2
             point = rect.GetTopRight()
             length = rect.height
 
         elif self._direction == wx.RIGHT:
-            rect.x += rect.width / 2
-            rect.width -= rect.width / 2
+            rect.x += rect.width // 2
+            rect.width -= rect.width // 2
             point = rect.GetTopLeft()
             length = rect.height
 
         elif self._direction == wx.BOTTOM:
-            rect.y += rect.height / 2
-            rect.height -= rect.height / 2
+            rect.y += rect.height // 2
+            rect.height -= rect.height // 2
             point = rect.GetTopLeft()
             length = rect.width
 
@@ -2117,7 +1976,6 @@ class AuiDockingGuideWindow(wx.Window):
         else:
             self.DrawDottedLine(dc, point, length, True)
 
-
     def DrawArrow(self, dc):
         """
         Draws the docking guide arrow icon (not used if the docking guide images are ok).
@@ -2128,8 +1986,8 @@ class AuiDockingGuideWindow(wx.Window):
         rect = self.GetClientRect()
         point = wx.Point()
 
-        point.x = (rect.GetLeft() + rect.GetRight()) / 2
-        point.y = (rect.GetTop() + rect.GetBottom()) / 2
+        point.x = (rect.GetLeft() + rect.GetRight()) // 2
+        point.y = (rect.GetTop() + rect.GetBottom()) // 2
         rx, ry = wx.Size(), wx.Size()
 
         if self._direction == wx.TOP:
@@ -2148,18 +2006,17 @@ class AuiDockingGuideWindow(wx.Window):
             rx = wx.Size(-1, 0)
             ry = wx.Size(0, -1)
 
-        point.x += ry.x*3
-        point.y += ry.y*3
+        point.x += ry.x * 3
+        point.y += ry.y * 3
 
         dc.SetPen(wx.Pen(colourIconArrow))
 
         for i in range(4):
-            pt1 = wx.Point(point.x - rx.x*i, point.y - rx.y*i)
-            pt2 = wx.Point(point.x + rx.x*(i+1), point.y + rx.y*(i+1))
+            pt1 = wx.Point(point.x - rx.x * i, point.y - rx.y * i)
+            pt2 = wx.Point(point.x + rx.x * (i + 1), point.y + rx.y * (i + 1))
             dc.DrawLine(pt1, pt2)
             point.x += ry.x
             point.y += ry.y
-
 
     def OnPaint(self, event):
         """
@@ -2167,13 +2024,13 @@ class AuiDockingGuideWindow(wx.Window):
 
         :param `event`: a :class:`PaintEvent` to be processed.
         """
-
         dc = wx.AutoBufferedPaintDC(self)
+
         if self._currentImage.IsOk() and self._valid:
             dc.DrawBitmap(self._currentImage, 0, 0, True)
         else:
+            dc = wx.AutoBufferedPaintDC(self)
             self.Draw(dc)
-
 
     def Draw(self, dc):
         """
@@ -2187,7 +2044,6 @@ class AuiDockingGuideWindow(wx.Window):
         if self._valid:
             self.DrawIcon(dc)
             self.DrawArrow(dc)
-
 
     def UpdateDockGuide(self, pos):
         """
@@ -2280,7 +2136,6 @@ class AuiSingleDockingGuide(AuiDockingGuide):
 
         self.target = AuiDockingGuideWindow(self, self.rect, direction, False, useAero)
 
-
     def CreateShapesWithStyle(self, useWhidbey):
         """
         Creates the docking guide window shape based on which docking bitmaps are used.
@@ -2299,9 +2154,7 @@ class AuiSingleDockingGuide(AuiDockingGuide):
         useAero = (useWhidbey and [2] or [1])[0]
         bmp, dummy = GetDockingImage(self._direction, useAero, False)
         region = wx.Region(bmp)
-
         self.region = region
-
 
     def AeroMove(self, pos):
         """
@@ -2311,7 +2164,6 @@ class AuiSingleDockingGuide(AuiDockingGuide):
         """
 
         pass
-
 
     def SetGuideShape(self, event=None):
         """
@@ -2326,7 +2178,6 @@ class AuiSingleDockingGuide(AuiDockingGuide):
             # Skip the event on wxGTK
             event.Skip()
             wx.CallAfter(wx.SafeYield, self, True)
-
 
     def SetShape(self, region):
         """
@@ -2346,7 +2197,6 @@ class AuiSingleDockingGuide(AuiDockingGuide):
         else:
             super(AuiSingleDockingGuide, self).SetShape(region)
 
-
     def SetValid(self, valid):
         """
         Sets the docking direction as valid or invalid.
@@ -2356,12 +2206,10 @@ class AuiSingleDockingGuide(AuiDockingGuide):
 
         self._valid = valid
 
-
     def IsValid(self):
         """ Returns whether the docking direction is valid. """
 
         return self._valid
-
 
     def UpdateDockGuide(self, pos):
         """
@@ -2373,7 +2221,6 @@ class AuiSingleDockingGuide(AuiDockingGuide):
         """
 
         self.target.UpdateDockGuide(pos)
-
 
     def HitTest(self, x, y):
         """
@@ -2405,7 +2252,7 @@ class AuiCenterDockingGuide(AuiDockingGuide):
         """
 
         AuiDockingGuide.__init__(self, parent, style=wx.FRAME_TOOL_WINDOW | wx.STAY_ON_TOP |
-                                 wx.FRAME_NO_TASKBAR | wx.NO_BORDER | wx.FRAME_SHAPED,
+                                                     wx.FRAME_NO_TASKBAR | wx.NO_BORDER | wx.FRAME_SHAPED,
                                  name="auiCenterDockTarget")
 
         self.Hide()
@@ -2422,7 +2269,6 @@ class AuiCenterDockingGuide(AuiDockingGuide):
 
         self.Bind(wx.EVT_ERASE_BACKGROUND, self.OnEraseBackground)
         self.Bind(wx.EVT_PAINT, self.OnPaint)
-
 
     def CreateShapesWithStyle(self):
         """ Creates the docking guide window shape based on which docking bitmaps are used. """
@@ -2445,7 +2291,7 @@ class AuiCenterDockingGuide(AuiDockingGuide):
 
         rectLeft = wx.Rect(0, sizeY, sizeY, sizeX)
         rectTop = wx.Rect(sizeY, 0, sizeX, sizeY)
-        rectRight = wx.Rect(sizeY+sizeX, sizeY, sizeY, sizeX)
+        rectRight = wx.Rect(sizeY + sizeX, sizeY, sizeY, sizeX)
         rectBottom = wx.Rect(sizeY, sizeX + sizeY, sizeX, sizeY)
         rectCenter = wx.Rect(sizeY, sizeY, sizeX, sizeX)
 
@@ -2457,29 +2303,28 @@ class AuiCenterDockingGuide(AuiDockingGuide):
             self.targetBottom = AuiDockingGuideWindow(self, rectBottom, wx.BOTTOM, True, useAero)
             self.targetCenter = AuiDockingGuideWindow(self, rectCenter, wx.CENTER, True, useAero)
 
-
             # top-left diamond
-            tld = [wx.Point(rectTop.x, rectTop.y+rectTop.height-8),
-                   wx.Point(rectLeft.x+rectLeft.width-8, rectLeft.y),
+            tld = [wx.Point(rectTop.x, rectTop.y + rectTop.height - 8),
+                   wx.Point(rectLeft.x + rectLeft.width - 8, rectLeft.y),
                    rectTop.GetBottomLeft()]
             # bottom-left diamond
-            bld = [wx.Point(rectLeft.x+rectLeft.width-8, rectLeft.y+rectLeft.height),
-                   wx.Point(rectBottom.x, rectBottom.y+8),
+            bld = [wx.Point(rectLeft.x + rectLeft.width - 8, rectLeft.y + rectLeft.height),
+                   wx.Point(rectBottom.x, rectBottom.y + 8),
                    rectBottom.GetTopLeft()]
             # top-right diamond
-            trd = [wx.Point(rectTop.x+rectTop.width, rectTop.y+rectTop.height-8),
-                   wx.Point(rectRight.x+8, rectRight.y),
+            trd = [wx.Point(rectTop.x + rectTop.width, rectTop.y + rectTop.height - 8),
+                   wx.Point(rectRight.x + 8, rectRight.y),
                    rectRight.GetTopLeft()]
             # bottom-right diamond
-            brd = [wx.Point(rectRight.x+8, rectRight.y+rectRight.height),
-                   wx.Point(rectBottom.x+rectBottom.width, rectBottom.y+8),
+            brd = [wx.Point(rectRight.x + 8, rectRight.y + rectRight.height),
+                   wx.Point(rectBottom.x + rectBottom.width, rectBottom.y + 8),
                    rectBottom.GetTopRight()]
 
             self._triangles = [tld[0:2], bld[0:2],
-                               [wx.Point(rectTop.x+rectTop.width-1, rectTop.y+rectTop.height-8),
-                                wx.Point(rectRight.x+7, rectRight.y)],
-                               [wx.Point(rectRight.x+7, rectRight.y+rectRight.height),
-                                wx.Point(rectBottom.x+rectBottom.width-1, rectBottom.y+8)]]
+                               [wx.Point(rectTop.x + rectTop.width - 1, rectTop.y + rectTop.height - 8),
+                                wx.Point(rectRight.x + 7, rectRight.y)],
+                               [wx.Point(rectRight.x + 7, rectRight.y + rectRight.height),
+                                wx.Point(rectBottom.x + rectBottom.width - 1, rectBottom.y + 8)]]
 
             region = wx.Region()
             region.Union(rectLeft)
@@ -2516,9 +2361,7 @@ class AuiCenterDockingGuide(AuiDockingGuide):
             self._aeroRects = [rectLeft, rectTop, rectRight, rectBottom, rectCenter]
             self._valid = True
 
-
         self.region = region
-
 
     def SetGuideShape(self, event=None):
         """
@@ -2533,7 +2376,6 @@ class AuiCenterDockingGuide(AuiDockingGuide):
             # Skip the event on wxGTK
             event.Skip()
             wx.CallAfter(wx.SafeYield, self, True)
-
 
     def UpdateDockGuide(self, pos):
         """
@@ -2565,7 +2407,6 @@ class AuiCenterDockingGuide(AuiDockingGuide):
                 self._aeroBmp = self._allAeroBmps[-1]
                 self.Refresh()
 
-
     def HitTest(self, x, y):
         """
         Checks if the mouse position is inside the target windows rect.
@@ -2590,11 +2431,10 @@ class AuiCenterDockingGuide(AuiDockingGuide):
             lenRects = len(self._aeroRects)
             for indx, rect in enumerate(self._aeroRects):
                 if rect.Contains((x, y)):
-                    if indx < lenRects or (indx == lenRects-1 and self._valid):
+                    if indx < lenRects or (indx == lenRects - 1 and self._valid):
                         return constants[indx]
 
         return -1
-
 
     def ValidateNotebookDocking(self, valid):
         """
@@ -2613,7 +2453,6 @@ class AuiCenterDockingGuide(AuiDockingGuide):
             if self._valid != valid:
                 self._valid = valid
                 self.Refresh()
-
 
     def AeroMove(self, pos):
         """
@@ -2635,7 +2474,7 @@ class AuiCenterDockingGuide(AuiDockingGuide):
         size = self.GetSize()
 
         leftRect, topRect, rightRect, bottomRect, centerRect = self._aeroRects
-        thePos = pos + wx.Point((size.x-sizeY)/2, (size.y-sizeX)/2)
+        thePos = pos + wx.Point((size.x - sizeY) // 2, (size.y - sizeX) // 2)
 
         centerRect.SetTopLeft(thePos)
 
@@ -2643,7 +2482,6 @@ class AuiCenterDockingGuide(AuiDockingGuide):
         topRect.SetTopLeft(thePos + wx.Point(0, -sizeY))
         rightRect.SetTopLeft(thePos + wx.Point(sizeX, 0))
         bottomRect.SetTopLeft(thePos + wx.Point(0, sizeX))
-
 
     def OnEraseBackground(self, event):
         """
@@ -2655,7 +2493,6 @@ class AuiCenterDockingGuide(AuiDockingGuide):
         """
 
         pass
-
 
     def OnPaint(self, event):
         """
@@ -2681,8 +2518,8 @@ class AuiCenterDockingGuide(AuiDockingGuide):
             if not self._valid:
                 diff = (self._useAero == 2 and [1] or [0])[0]
                 bmpX, bmpY = self._deniedBitmap.GetWidth(), self._deniedBitmap.GetHeight()
-                xPos, yPos = (rect.x + (rect.width)/2 - bmpX/2), (rect.y + (rect.height)/2 - bmpY/2)
-                dc.DrawBitmap(self._deniedBitmap, xPos+1, yPos+diff, True)
+                xPos, yPos = (rect.x + (rect.width) // 2 - bmpX // 2), (rect.y + (rect.height) // 2 - bmpY // 2)
+                dc.DrawBitmap(self._deniedBitmap, xPos + 1, yPos + diff, True)
 
             return
 
@@ -2700,7 +2537,7 @@ class AuiDockingHintWindow(wx.Frame):
 
     def __init__(self, parent, id=wx.ID_ANY, title="", pos=wx.DefaultPosition,
                  size=wx.Size(1, 1), style=wx.FRAME_TOOL_WINDOW | wx.FRAME_FLOAT_ON_PARENT |
-                 wx.FRAME_NO_TASKBAR | wx.NO_BORDER | wx.FRAME_SHAPED,
+                                           wx.FRAME_NO_TASKBAR | wx.NO_BORDER | wx.FRAME_SHAPED,
                  name="auiHintWindow"):
         """
         Default class constructor. Used internally, do not call it in your code!
@@ -2744,7 +2581,6 @@ class AuiDockingHintWindow(wx.Frame):
 
         self.Bind(wx.EVT_SIZE, self.OnSize)
 
-
     def MakeVenetianBlinds(self):
         """
         Creates the "venetian blind" effect if :class:`AuiManager` has the ``AUI_MGR_VENETIAN_BLINDS_HINT``
@@ -2765,12 +2601,11 @@ class AuiDockingHintWindow(wx.Frame):
         ##         region.Union(0, y, size_x, 1)
         region_Union = region.Union  # local opt
         [region_Union(0, y, size_x, 1) for y in range(size_y)
-            if 16 * ((y & 8 and [1] or [0])[0] | (y & 4 and [2] or [0])[0] |
-                     (y & 2 and [4] or [0])[0] | (y & 1 and [8] or [0])[0])
-                     + 8 < amount]
+         if 16 * ((y & 8 and [1] or [0])[0] | (y & 4 and [2] or [0])[0] |
+                  (y & 2 and [4] or [0])[0] | (y & 1 and [8] or [0])[0])
+         + 8 < amount]
 
         self.SetShape(region)
-
 
     def SetBlindMode(self, agwFlags):
         """
@@ -2793,7 +2628,6 @@ class AuiDockingHintWindow(wx.Frame):
             else:
                 self.SetTransparent(0)
 
-
     def SetShape(self, region):
         """
         If the platform supports it, sets the shape of the window to that depicted by `region`.
@@ -2811,7 +2645,6 @@ class AuiDockingHintWindow(wx.Frame):
             return
         else:
             super(AuiDockingHintWindow, self).SetShape(region)
-
 
     def Show(self, show=True):
         """
@@ -2836,7 +2669,6 @@ class AuiDockingHintWindow(wx.Frame):
             # Need to manually do layout since its a borderless frame.
             self.Layout()
 
-
     def OnSize(self, event):
         """
         Handles the ``wx.EVT_SIZE`` event for :class:`AuiDockingHintWindow`.
@@ -2848,7 +2680,6 @@ class AuiDockingHintWindow(wx.Frame):
             self.MakeVenetianBlinds()
 
         self.Refresh()
-
 
     def OnPaint(self, event):
         """
@@ -2877,7 +2708,7 @@ class AuiFloatingFrame(wx.MiniFrame):
 
     def __init__(self, parent, owner_mgr, pane=None, id=wx.ID_ANY, title="",
                  style=wx.FRAME_TOOL_WINDOW | wx.FRAME_FLOAT_ON_PARENT |
-                 wx.FRAME_NO_TASKBAR | wx.CLIP_CHILDREN):
+                       wx.FRAME_NO_TASKBAR | wx.CLIP_CHILDREN):
         """
         Default class constructor. Used internally, do not call it in your code!
 
@@ -2946,7 +2777,6 @@ class AuiFloatingFrame(wx.MiniFrame):
         self._mgr.SetArtProvider(owner_mgr.GetArtProvider())
         self._mgr.SetAGWFlags(owner_mgr.GetAGWFlags())
 
-
     def CopyAttributes(self, pane):
         """
         Copies all the attributes of the input `pane` into another :class:`AuiPaneInfo`.
@@ -2982,7 +2812,6 @@ class AuiFloatingFrame(wx.MiniFrame):
 
         return contained_pane
 
-
     def SetPaneWindow(self, pane):
         """
         Sets all the properties of a pane.
@@ -3001,9 +2830,9 @@ class AuiFloatingFrame(wx.MiniFrame):
         contained_pane = self.CopyAttributes(pane)
 
         contained_pane.Dock().Center().Show(). \
-                       CaptionVisible(False). \
-                       PaneBorder(False). \
-                       Layer(0).Row(0).Position(0)
+            CaptionVisible(False). \
+            PaneBorder(False). \
+            Layer(0).Row(0).Position(0)
 
         if not contained_pane.HasGripper() and not self._useNativeMiniframes:
             contained_pane.CaptionVisible(True)
@@ -3018,30 +2847,31 @@ class AuiFloatingFrame(wx.MiniFrame):
         pane_best_size = contained_pane.best_size
         if pane_best_size.IsFullySpecified() and (pane_best_size.x < pane_min_size.x or \
                                                   pane_best_size.y < pane_min_size.y):
-
             pane_min_size = pane_best_size
             self._pane_window.SetMinSize(pane_min_size)
 
         # if the frame window's max size is greater than the min size
         # then set the max size to the min size as well
         cur_max_size = self.GetMaxSize()
-        if cur_max_size.IsFullySpecified() and  (cur_max_size.x < pane_min_size.x or \
-                                                 cur_max_size.y < pane_min_size.y):
+        if cur_max_size.IsFullySpecified() and (cur_max_size.x < pane_min_size.x or \
+                                                cur_max_size.y < pane_min_size.y):
             self.SetMaxSize(pane_min_size)
 
         art_provider = self._mgr.GetArtProvider()
         caption_size = art_provider.GetMetric(AUI_DOCKART_CAPTION_SIZE)
         button_size = art_provider.GetMetric(AUI_DOCKART_PANE_BUTTON_SIZE) + \
-                      4*art_provider.GetMetric(AUI_DOCKART_PANE_BORDER_SIZE)
+                      4 * art_provider.GetMetric(AUI_DOCKART_PANE_BORDER_SIZE)
 
         min_size = pane.window.GetMinSize()
 
         if min_size.y < caption_size or min_size.x < button_size:
             new_x, new_y = min_size.x, min_size.y
             if min_size.y < caption_size:
-                new_y = (pane.IsResizeable() and [2*wx.SystemSettings.GetMetric(wx.SYS_EDGE_Y)+caption_size] or [1])[0]
+                new_y = \
+                (pane.IsResizeable() and [2 * wx.SystemSettings.GetMetric(wx.SYS_EDGE_Y) + caption_size] or [1])[0]
             if min_size.x < button_size:
-                new_x = (pane.IsResizeable() and [2*wx.SystemSettings.GetMetric(wx.SYS_EDGE_X)+button_size] or [1])[0]
+                new_x = (pane.IsResizeable() and [2 * wx.SystemSettings.GetMetric(wx.SYS_EDGE_X) + button_size] or [1])[
+                    0]
 
             self.SetMinSize((new_x, new_y))
         else:
@@ -3084,19 +2914,17 @@ class AuiFloatingFrame(wx.MiniFrame):
         self._owner_mgr._panes[indx] = pane
 
         self._fly_step = abs(pane.floating_size.y - \
-                             (caption_size + 2*wx.SystemSettings.GetMetric(wx.SYS_EDGE_Y)))/10
+                             (caption_size + 2 * wx.SystemSettings.GetMetric(wx.SYS_EDGE_Y))) // 10
 
         self._floating_size = wx.Size(*self.GetSize())
 
         if pane.IsFlyOut():
             self._check_fly_timer.Start(50)
 
-
     def GetOwnerManager(self):
         """ Returns the :class:`AuiManager` that manages the pane. """
 
         return self._owner_mgr
-
 
     def OnSize(self, event):
         """
@@ -3107,7 +2935,6 @@ class AuiFloatingFrame(wx.MiniFrame):
 
         if self._owner_mgr and self._send_size and self.IsShownOnScreen():
             self._owner_mgr.OnFloatingPaneResized(self._pane_window, event.GetSize())
-
 
     def OnClose(self, event):
         """
@@ -3134,7 +2961,6 @@ class AuiFloatingFrame(wx.MiniFrame):
             self._mgr.UnInit()
             self.Destroy()
 
-
     def OnActivate(self, event):
         """
         Handles the ``wx.EVT_ACTIVATE`` event for :class:`AuiFloatingFrame`.
@@ -3144,7 +2970,6 @@ class AuiFloatingFrame(wx.MiniFrame):
 
         if self._owner_mgr and event.GetActive():
             self._owner_mgr.OnFloatingPaneActivated(self._pane_window)
-
 
     def OnMove(self, event):
         """
@@ -3161,7 +2986,6 @@ class AuiFloatingFrame(wx.MiniFrame):
 
         if self._owner_mgr:
             self._owner_mgr.OnFloatingPaneMoved(self._pane_window, event)
-
 
     def OnMoveEvent(self, event):
         """
@@ -3244,7 +3068,6 @@ class AuiFloatingFrame(wx.MiniFrame):
         else:
             self.OnMoving(wx.Rect(event.GetPosition(), self.GetSize()), dir)
 
-
     def OnIdle(self, event):
         """
         Handles the ``wx.EVT_IDLE`` event for :class:`AuiFloatingFrame`.
@@ -3264,7 +3087,6 @@ class AuiFloatingFrame(wx.MiniFrame):
                 self.OnMoveFinished()
             else:
                 event.RequestMore()
-
 
     def OnMoveStart(self, event):
         """
@@ -3294,7 +3116,6 @@ class AuiFloatingFrame(wx.MiniFrame):
                 self._owner_mgr._action_offset = action_offset
                 self._owner_mgr.OnMotion_DragFloatingPane(point)
 
-
     def OnMoving(self, rect, direction):
         """
         The user is moving the floating pane.
@@ -3312,7 +3133,6 @@ class AuiFloatingFrame(wx.MiniFrame):
         # notify the owner manager that the pane is moving
         self.OnMoveStart(None)
         self._lastDirection = direction
-
 
     def OnMoveFinished(self):
         """
@@ -3336,7 +3156,6 @@ class AuiFloatingFrame(wx.MiniFrame):
 
             self._owner_mgr.OnFloatingPaneMoved(self._pane_window, point)
 
-
     def OnCheckFlyTimer(self, event):
         """
         Handles the ``wx.EVT_TIMER`` event for :class:`AuiFloatingFrame`.
@@ -3352,7 +3171,6 @@ class AuiFloatingFrame(wx.MiniFrame):
                 if self.IsShownOnScreen():
                     self.FlyOut()
 
-
     def OnFindManager(self, event):
         """
         Handles the ``EVT_AUI_FIND_MANAGER`` event for :class:`AuiFloatingFrame`.
@@ -3361,7 +3179,6 @@ class AuiFloatingFrame(wx.MiniFrame):
         """
 
         event.SetManager(self._owner_mgr)
-
 
     def FlyOut(self):
         """ Starts the flying in and out of a floating pane. """
@@ -3386,7 +3203,6 @@ class AuiFloatingFrame(wx.MiniFrame):
             self._send_size = False
             self._fly_timer.Start(5)
 
-
     def OnFlyTimer(self, event):
         """
         Handles the ``wx.EVT_TIMER`` event for :class:`AuiFloatingFrame`.
@@ -3404,7 +3220,7 @@ class AuiFloatingFrame(wx.MiniFrame):
             min_size = self._mgr.GetArtProvider().GetMetric(AUI_DOCKART_CAPTION_SIZE)
 
             if wx.Platform != "__WXMSW__":
-                min_size += 2*wx.SystemSettings.GetMetric(wx.SYS_EDGE_Y)
+                min_size += 2 * wx.SystemSettings.GetMetric(wx.SYS_EDGE_Y)
 
             if current_size.y - self._fly_step <= min_size:
                 self.SetClientSize((current_size.x, min_size))
@@ -3412,7 +3228,7 @@ class AuiFloatingFrame(wx.MiniFrame):
                 self._fly_timer.Stop()
                 self._send_size = True
             else:
-                self.SetClientSize((current_size.x, current_size.y-self._fly_step))
+                self.SetClientSize((current_size.x, current_size.y - self._fly_step))
 
         else:
             if current_size.y + self._fly_step >= floating_size.y:
@@ -3421,11 +3237,10 @@ class AuiFloatingFrame(wx.MiniFrame):
                 self._fly_timer.Stop()
                 self._send_size = True
             else:
-                self.SetClientSize((current_size.x, current_size.y+self._fly_step))
+                self.SetClientSize((current_size.x, current_size.y + self._fly_step))
 
         self.Update()
         self.Refresh()
-
 
     def FadeOut(self):
         """ Actually starts the fading out of the floating pane. """
@@ -3594,7 +3409,7 @@ def GetMaxRow(panes, dock_direction, dock_layer):
 
     for pane in panes:
         if pane.dock_direction == dock_direction and pane.dock_layer == dock_layer and \
-           pane.dock_row > max_row:
+                pane.dock_row > max_row:
             max_row = pane.dock_row
 
     return max_row
@@ -3633,7 +3448,7 @@ def DoInsertDockRow(panes, dock_direction, dock_layer, dock_row):
 
     for pane in panes:
         if not pane.IsFloating() and pane.dock_direction == dock_direction and \
-           pane.dock_layer == dock_layer and pane.dock_row >= dock_row:
+                pane.dock_layer == dock_layer and pane.dock_row >= dock_row:
             pane.dock_row += 1
 
     return panes
@@ -3654,8 +3469,8 @@ def DoInsertPane(panes, dock_direction, dock_layer, dock_row, dock_pos):
     for ii in range(len(panes)):
         pane = panes[ii]
         if not pane.IsFloating() and pane.dock_direction == dock_direction and \
-           pane.dock_layer == dock_layer and  pane.dock_row == dock_row and \
-           pane.dock_pos >= dock_pos:
+                pane.dock_layer == dock_layer and pane.dock_row == dock_row and \
+                pane.dock_pos >= dock_pos:
             pane.dock_pos = pane.dock_pos + 1
 
         panes[ii] = pane
@@ -3678,7 +3493,7 @@ def FindDocks(docks, dock_direction, dock_layer=-1, dock_row=-1, reverse=False):
     matchDocks = [(d.dock_layer, d.dock_row, d.dock_direction, d) for d in docks if \
                   (dock_direction == -1 or dock_direction == d.dock_direction) and \
                   ((dock_layer == -1 or dock_layer == d.dock_layer) and \
-                  (dock_row == -1 or dock_row == d.dock_row))]
+                   (dock_row == -1 or dock_row == d.dock_row))]
 
     arr = [x[-1] for x in sorted(matchDocks, reverse=reverse)]
 
@@ -3809,7 +3624,7 @@ def CheckEdgeDrop(window, docks, pt):
             return wx.LEFT
 
         if pt.x >= clientSize.x - auiLayerInsertOffset and \
-           pt.x < clientSize.x - auiLayerInsertOffset + auiLayerInsertPixels:
+                pt.x < clientSize.x - auiLayerInsertOffset + auiLayerInsertPixels:
             return wx.RIGHT
 
     if screenPt.x >= frameRect.GetLeft() and screenPt.x < frameRect.GetRight():
@@ -3817,7 +3632,7 @@ def CheckEdgeDrop(window, docks, pt):
             return wx.TOP
 
         if pt.y >= clientSize.y - auiLayerInsertOffset and \
-           pt.y < clientSize.y - auiLayerInsertOffset + auiLayerInsertPixels:
+                pt.y < clientSize.y - auiLayerInsertOffset + auiLayerInsertPixels:
             return wx.BOTTOM
 
     return -1
@@ -4137,6 +3952,7 @@ class AuiManager(wx.EvtHandler):
          ``AUI_MGR_AUTONB_NO_CAPTION``        Panes that merge into an automatic notebook will not have the pane caption visible
          ==================================== ==================================
 
+
          Default value for `agwFlags` is:
          ``AUI_MGR_DEFAULT`` = ``AUI_MGR_ALLOW_FLOATING`` | ``AUI_MGR_TRANSPARENT_HINT`` | ``AUI_MGR_HINT_FADE`` | ``AUI_MGR_NO_VENETIAN_BLINDS_FADE``
 
@@ -4239,7 +4055,6 @@ class AuiManager(wx.EvtHandler):
         self.Bind(auibook.EVT_AUINOTEBOOK_PAGE_CLOSE, self.OnTabPageClose)
         self.Bind(auibook.EVT_AUINOTEBOOK_PAGE_CHANGED, self.OnTabSelected)
 
-
     def CreateFloatingFrame(self, parent, pane_info):
         """
         Creates a floating frame for the windows.
@@ -4249,7 +4064,6 @@ class AuiManager(wx.EvtHandler):
         """
 
         return AuiFloatingFrame(parent, self, pane_info)
-
 
     def CanDockPanel(self, p):
         """
@@ -4266,7 +4080,6 @@ class AuiManager(wx.EvtHandler):
         # don't dock the window
         return not (wx.GetKeyState(wx.WXK_CONTROL) or wx.GetKeyState(wx.WXK_ALT))
 
-
     def GetPaneByWidget(self, window):
         """
         This version of :meth:`GetPane` looks up a pane based on a 'pane window'.
@@ -4282,7 +4095,6 @@ class AuiManager(wx.EvtHandler):
 
         return NonePaneInfo
 
-
     def GetPaneByName(self, name):
         """
         This version of :meth:`GetPane` looks up a pane based on a 'pane name'.
@@ -4297,7 +4109,6 @@ class AuiManager(wx.EvtHandler):
                 return p
 
         return NonePaneInfo
-
 
     def GetPane(self, item):
         """
@@ -4316,12 +4127,10 @@ class AuiManager(wx.EvtHandler):
         else:
             return self.GetPaneByWidget(item)
 
-
     def GetAllPanes(self):
         """ Returns a reference to all the pane info structures. """
 
         return self._panes
-
 
     def ShowPane(self, window, show):
         """
@@ -4354,7 +4163,6 @@ class AuiManager(wx.EvtHandler):
 
             self.Update()
 
-
     def HitTest(self, x, y):
         """
         This is an internal function which determines
@@ -4386,7 +4194,6 @@ class AuiManager(wx.EvtHandler):
 
         return result
 
-
     def PaneHitTest(self, panes, pt):
         """
         Similar to :meth:`HitTest`, but it checks in which :class:`AuiManager` rectangle the
@@ -4401,7 +4208,6 @@ class AuiManager(wx.EvtHandler):
                 return paneInfo
 
         return NonePaneInfo
-
 
     # SetAGWFlags() and GetAGWFlags() allow the owner to set various
     # options which are global to AuiManager
@@ -4451,7 +4257,6 @@ class AuiManager(wx.EvtHandler):
         if self._hint_window and agwFlags & AUI_MGR_RECTANGLE_HINT == 0:
             self.CreateHintWindow()
 
-
     def GetAGWFlags(self):
         """
         Returns the current manager's flags.
@@ -4460,7 +4265,6 @@ class AuiManager(wx.EvtHandler):
         """
 
         return self._agwFlags
-
 
     def SetManagedWindow(self, managed_window):
         """
@@ -4505,12 +4309,10 @@ class AuiManager(wx.EvtHandler):
             self.AddPane(client_window, AuiPaneInfo().Name("mdiclient").
                          CenterPane().PaneBorder(False))
 
-
     def GetManagedWindow(self):
         """ Returns the window being managed by :class:`AuiManager`. """
 
         return self._frame
-
 
     def SetFrame(self, managed_window):
         """
@@ -4528,7 +4330,6 @@ class AuiManager(wx.EvtHandler):
         DeprecationWarning("This method is deprecated, use SetManagedWindow instead.")
         return self.SetManagedWindow(managed_window)
 
-
     def GetFrame(self):
         """
         Returns the window being managed by :class:`AuiManager`.
@@ -4539,7 +4340,6 @@ class AuiManager(wx.EvtHandler):
 
         DeprecationWarning("This method is deprecated, use GetManagedWindow instead.")
         return self._frame
-
 
     def CreateGuideWindows(self):
         """ Creates the VS2005 HUD guide windows. """
@@ -4557,14 +4357,12 @@ class AuiManager(wx.EvtHandler):
         self._guides.append(AuiDockingGuideInfo().Centre().
                             Host(AuiCenterDockingGuide(self._frame)))
 
-
     def DestroyGuideWindows(self):
         """ Destroys the VS2005 HUD guide windows. """
         for guide in self._guides:
             if guide.host:
                 guide.host.Destroy()
         self._guides = []
-
 
     def CreateHintWindow(self):
         """ Creates the standard wxAUI hint window. """
@@ -4574,14 +4372,12 @@ class AuiManager(wx.EvtHandler):
         self._hint_window = AuiDockingHintWindow(self._frame)
         self._hint_window.SetBlindMode(self._agwFlags)
 
-
     def DestroyHintWindow(self):
         """ Destroys the standard wxAUI hint window. """
 
         if self._hint_window:
             self._hint_window.Destroy()
             self._hint_window = None
-
 
     def UnInit(self):
         """
@@ -4603,7 +4399,6 @@ class AuiManager(wx.EvtHandler):
                 if isinstance(handler, AuiManager):
                     klass.RemoveEventHandler(handler)
 
-
     def OnClose(self, event):
         """Called when the managed window is closed. Makes sure that :meth:`UnInit`
         is called.
@@ -4613,8 +4408,7 @@ class AuiManager(wx.EvtHandler):
         if event.GetEventObject() == self._frame:
             wx.CallAfter(self.UnInit)
 
-
-    def OnDestroy(self, event) :
+    def OnDestroy(self, event):
         """Called when the managed window is destroyed. Makes sure that :meth:`UnInit`
         is called.
         """
@@ -4622,12 +4416,10 @@ class AuiManager(wx.EvtHandler):
         if self._frame == event.GetEventObject():
             self.UnInit()
 
-
     def GetArtProvider(self):
         """ Returns the current art provider being used. """
 
         return self._art
-
 
     def ProcessMgrEvent(self, event):
         """
@@ -4642,7 +4434,6 @@ class AuiManager(wx.EvtHandler):
                 return
 
         self.ProcessEvent(event)
-
 
     def FireEvent(self, evtType, pane, canVeto=False):
         """
@@ -4659,7 +4450,6 @@ class AuiManager(wx.EvtHandler):
         self.ProcessMgrEvent(event)
 
         return event
-
 
     def CanUseModernDockArt(self):
         """
@@ -4678,7 +4468,6 @@ class AuiManager(wx.EvtHandler):
             return False
 
         return True
-
 
     def SetArtProvider(self, art_provider):
         """
@@ -4701,7 +4490,6 @@ class AuiManager(wx.EvtHandler):
             if pane.IsFloating() and pane.frame:
                 pane.frame._mgr.SetArtProvider(art_provider)
                 pane.frame._mgr.Update()
-
 
     def AddPane(self, window, arg1=None, arg2=None, target=None):
         """
@@ -4739,7 +4527,6 @@ class AuiManager(wx.EvtHandler):
             else:
                 return self.AddPane1(window, arg1)
 
-
     def AddPane1(self, window, pane_info):
         """ See comments on :meth:`AddPane`. """
 
@@ -4755,7 +4542,7 @@ class AuiManager(wx.EvtHandler):
         # bug in the library user's application
         already_exists = False
         if pane_info.name != "" and self.GetPane(pane_info.name).IsOk():
-            warnings.warn("A pane with the name '%s' already exists in the manager!"%pane_info.name)
+            warnings.warn("A pane with the name '%s' already exists in the manager!" % pane_info.name)
             already_exists = True
 
         # if the new pane is docked then we should undo maximize
@@ -4835,7 +4622,6 @@ class AuiManager(wx.EvtHandler):
 
         return True
 
-
     def AddPane2(self, window, direction, caption):
         """ See comments on :meth:`AddPane`. """
 
@@ -4855,7 +4641,6 @@ class AuiManager(wx.EvtHandler):
 
         return self.AddPane(window, pinfo)
 
-
     def AddPane3(self, window, pane_info, drop_pos):
         """ See comments on :meth:`AddPane`. """
 
@@ -4869,7 +4654,6 @@ class AuiManager(wx.EvtHandler):
         self._panes[indx] = pane
 
         return True
-
 
     def AddPane4(self, window, pane_info, target):
         """ See comments on :meth:`AddPane`. """
@@ -4895,7 +4679,6 @@ class AuiManager(wx.EvtHandler):
         self.UpdateNotebook()
 
         return True
-
 
     def InsertPane(self, window, pane_info, insert_level=AUI_INSERT_PANE):
         """
@@ -4960,7 +4743,6 @@ class AuiManager(wx.EvtHandler):
 
         return True
 
-
     def DetachPane(self, window):
         """
         Tells the :class:`AuiManager` to stop managing the pane specified
@@ -5015,7 +4797,6 @@ class AuiManager(wx.EvtHandler):
 
         return False
 
-
     def ClosePane(self, pane_info):
         """
         Destroys or hides the pane depending on its flags.
@@ -5065,7 +4846,6 @@ class AuiManager(wx.EvtHandler):
                 pane_info.window.Reparent(self._frame)
             pane_info.Dock().Hide()
 
-
         # now we need to either destroy or hide the pane
         to_destroy = 0
         if pane_info.IsDestroyOnClose():
@@ -5080,7 +4860,7 @@ class AuiManager(wx.EvtHandler):
         if pane_info.IsNotebookControl():
 
             notebook = self._notebooks[pane_info.notebook_id]
-            for idx in range(notebook.GetPageCount()-1, -1, -1):
+            for idx in range(notebook.GetPageCount() - 1, -1, -1):
                 window = notebook.GetPage(idx)
                 info = self.GetPane(window)
                 # close page if its IsDestroyOnClose flag is set
@@ -5129,7 +4909,6 @@ class AuiManager(wx.EvtHandler):
         if pane_info.window and not pane_info.window.IsShown():
             pane_info.window.Show(True)
 
-
     def SavePreviousDockSizes(self, pane_info):
         """
         Stores the previous dock sizes, to be used in a "restore" action later.
@@ -5143,7 +4922,6 @@ class AuiManager(wx.EvtHandler):
                     p.previousDockSize = d.size
                     if pane_info is not p:
                         p.SetFlag(p.needsRestore, True)
-
 
     def RestorePane(self, pane_info):
         """
@@ -5168,7 +4946,6 @@ class AuiManager(wx.EvtHandler):
         if pane_info.window and not pane_info.window.IsShown():
             pane_info.window.Show(True)
 
-
     def RestoreMaximizedPane(self):
         """ Restores the current maximized pane (if any). """
 
@@ -5177,7 +4954,6 @@ class AuiManager(wx.EvtHandler):
             if p.IsMaximized():
                 self.RestorePane(p)
                 break
-
 
     def ActivatePane(self, window):
         """
@@ -5197,7 +4973,6 @@ class AuiManager(wx.EvtHandler):
             self.RefreshCaptions()
             self.FireEvent(wxEVT_AUI_PANE_ACTIVATED, window, canVeto=False)
 
-
     def CreateNotebook(self):
         """
         Creates an automatic :class:`~wx.lib.agw.aui.auibook.AuiNotebook` when a pane is docked on
@@ -5213,7 +4988,6 @@ class AuiManager(wx.EvtHandler):
 
         return notebook
 
-
     def SetAutoNotebookTabArt(self, art):
         """
         Sets the default tab art provider for automatic notebooks.
@@ -5228,12 +5002,10 @@ class AuiManager(wx.EvtHandler):
 
         self._autoNBTabArt = art
 
-
     def GetAutoNotebookTabArt(self):
         """ Returns the default tab art provider for automatic notebooks. """
 
         return self._autoNBTabArt
-
 
     def SetAutoNotebookStyle(self, agwStyle):
         """
@@ -5280,7 +5052,6 @@ class AuiManager(wx.EvtHandler):
 
         self._autoNBStyle = agwStyle
 
-
     def GetAutoNotebookStyle(self):
         """
         Returns the default AGW-specific window style for automatic notebooks.
@@ -5289,7 +5060,6 @@ class AuiManager(wx.EvtHandler):
         """
 
         return self._autoNBStyle
-
 
     def SavePaneInfo(self, pane):
         """
@@ -5303,27 +5073,26 @@ class AuiManager(wx.EvtHandler):
         result = "name=" + EscapeDelimiters(pane.name) + ";"
         result += "caption=" + EscapeDelimiters(pane.caption) + ";"
 
-        result += "state=%u;"%pane.state
-        result += "dir=%d;"%pane.dock_direction
-        result += "layer=%d;"%pane.dock_layer
-        result += "row=%d;"%pane.dock_row
-        result += "pos=%d;"%pane.dock_pos
-        result += "prop=%d;"%pane.dock_proportion
-        result += "bestw=%d;"%pane.best_size.x
-        result += "besth=%d;"%pane.best_size.y
-        result += "minw=%d;"%pane.min_size.x
-        result += "minh=%d;"%pane.min_size.y
-        result += "maxw=%d;"%pane.max_size.x
-        result += "maxh=%d;"%pane.max_size.y
-        result += "floatx=%d;"%pane.floating_pos.x
-        result += "floaty=%d;"%pane.floating_pos.y
-        result += "floatw=%d;"%pane.floating_size.x
-        result += "floath=%d;"%pane.floating_size.y
-        result += "notebookid=%d;"%pane.notebook_id
-        result += "transparent=%d"%pane.transparent
+        result += "state=%u;" % pane.state
+        result += "dir=%d;" % pane.dock_direction
+        result += "layer=%d;" % pane.dock_layer
+        result += "row=%d;" % pane.dock_row
+        result += "pos=%d;" % pane.dock_pos
+        result += "prop=%d;" % pane.dock_proportion
+        result += "bestw=%d;" % pane.best_size.x
+        result += "besth=%d;" % pane.best_size.y
+        result += "minw=%d;" % pane.min_size.x
+        result += "minh=%d;" % pane.min_size.y
+        result += "maxw=%d;" % pane.max_size.x
+        result += "maxh=%d;" % pane.max_size.y
+        result += "floatx=%d;" % pane.floating_pos.x
+        result += "floaty=%d;" % pane.floating_pos.y
+        result += "floatw=%d;" % pane.floating_size.x
+        result += "floath=%d;" % pane.floating_size.y
+        result += "notebookid=%d;" % pane.notebook_id
+        result += "transparent=%d" % pane.transparent
 
         return result
-
 
     def LoadPaneInfo(self, pane_part, pane):
         """
@@ -5405,7 +5174,6 @@ class AuiManager(wx.EvtHandler):
 
         return pane
 
-
     def SavePerspective(self):
         """
         Saves the entire user interface layout into an encoded string, which can then
@@ -5421,12 +5189,11 @@ class AuiManager(wx.EvtHandler):
             result += self.SavePaneInfo(pane) + "|"
 
         for dock in self._docks:
-            result = result + ("dock_size(%d,%d,%d)=%d|")%(dock.dock_direction,
-                                                           dock.dock_layer,
-                                                           dock.dock_row,
-                                                           dock.size)
+            result = result + ("dock_size(%d,%d,%d)=%d|") % (dock.dock_direction,
+                                                             dock.dock_layer,
+                                                             dock.dock_row,
+                                                             dock.size)
         return result
-
 
     def LoadPerspective(self, layout, update=True, restorecaption=False):
         """
@@ -5448,13 +5215,13 @@ class AuiManager(wx.EvtHandler):
         #    'layout2' = wxAUI 0.9.2 (wxWidgets 2.8)
         index = input.find("|")
         part = input[0:index].strip()
-        input = input[index+1:]
+        input = input[index + 1:]
 
         if part != "layout2":
             return False
 
         # mark all panes currently managed as docked and hidden
-        saveCapt = {} # see restorecaption param
+        saveCapt = {}  # see restorecaption param
         for pane in self._panes:
 
             # dock the notebook pages
@@ -5483,7 +5250,7 @@ class AuiManager(wx.EvtHandler):
             pane = AuiPaneInfo()
             index = input.find("|")
             pane_part = input[0:index].strip()
-            input = input[index+1:]
+            input = input[index + 1:]
 
             # if the string is empty, we're done parsing
             if pane_part == "":
@@ -5492,10 +5259,10 @@ class AuiManager(wx.EvtHandler):
             if pane_part[0:9] == "dock_size":
                 index = pane_part.find("=")
                 val_name = pane_part[0:index]
-                value = pane_part[index+1:]
+                value = pane_part[index + 1:]
 
                 index = val_name.find("(")
-                piece = val_name[index+1:]
+                piece = val_name[index + 1:]
                 index = piece.find(")")
                 piece = piece[0:index]
 
@@ -5556,7 +5323,6 @@ class AuiManager(wx.EvtHandler):
 
         return True
 
-
     def GetPanePositionsAndSizes(self, dock):
         """
         Returns all the panes positions and sizes in a dock.
@@ -5590,7 +5356,7 @@ class AuiManager(wx.EvtHandler):
             size = 0
 
             if pane.HasBorder():
-                size += pane_border_size*2
+                size += pane_border_size * 2
 
             if dock.IsHorizontal():
                 if pane.HasGripper() and not pane.HasGripperTop():
@@ -5617,8 +5383,8 @@ class AuiManager(wx.EvtHandler):
         if action_pane == -1:
             return positions, sizes
 
-        for pane_i in range(action_pane-1, -1, -1):
-            amount = positions[pane_i+1] - (positions[pane_i] + sizes[pane_i])
+        for pane_i in range(action_pane - 1, -1, -1):
+            amount = positions[pane_i + 1] - (positions[pane_i] + sizes[pane_i])
             if amount >= 0:
                 pass
             else:
@@ -5638,7 +5404,6 @@ class AuiManager(wx.EvtHandler):
 
         return positions, sizes
 
-
     def LayoutAddPane(self, cont, dock, pane, uiparts, spacer_only):
         """
         Adds a pane into the existing layout (in an existing dock).
@@ -5650,7 +5415,7 @@ class AuiManager(wx.EvtHandler):
         :param bool `spacer_only`: whether to add a simple spacer or a real window.
         """
 
-        #sizer_item = wx.SizerItem()
+        # sizer_item = wx.SizerItem()
         caption_size = self._art.GetMetric(AUI_DOCKART_CAPTION_SIZE)
         gripper_size = self._art.GetMetric(AUI_DOCKART_GRIPPER_SIZE)
         pane_border_size = self._art.GetMetric(AUI_DOCKART_PANE_BORDER_SIZE)
@@ -5689,7 +5454,7 @@ class AuiManager(wx.EvtHandler):
             uiparts.append(part)
 
         button_count = len(pane.buttons)
-        button_width_total = button_count*pane_button_size
+        button_width_total = button_count * pane_button_size
         if button_count >= 1:
             button_width_total += 3
 
@@ -5701,7 +5466,7 @@ class AuiManager(wx.EvtHandler):
 
             # add pane buttons to the caption
             dummy_parts = []
-            for btn_id in range(len(pane.buttons)-1, -1, -1):
+            for btn_id in range(len(pane.buttons) - 1, -1, -1):
                 sizer_item = caption_sizer.Add((caption_size, pane_button_size), 0, wx.EXPAND)
                 part = AuiDockUIPart()
                 part.type = AuiDockUIPart.typePaneButton
@@ -5805,7 +5570,7 @@ class AuiManager(wx.EvtHandler):
                 pane_proportion = 0
 
         if min_size != wx.Size(-1, -1):
-            vert_pane_sizer.SetItemMinSize(len(vert_pane_sizer.GetChildren())-1, (min_size.x, min_size.y))
+            vert_pane_sizer.SetItemMinSize(len(vert_pane_sizer.GetChildren()) - 1, (min_size.x, min_size.y))
 
         # add the vertical/horizontal sizer (caption, pane window) to the
         # horizontal sizer (gripper, vertical sizer)
@@ -5830,7 +5595,6 @@ class AuiManager(wx.EvtHandler):
 
         return uiparts
 
-
     def LayoutAddDock(self, cont, dock, uiparts, spacer_only):
         """
         Adds a dock into the existing layout.
@@ -5841,7 +5605,7 @@ class AuiManager(wx.EvtHandler):
         :param bool `spacer_only`: whether to add a simple spacer or a real window.
         """
 
-#        sizer_item = wx.SizerItem()
+        #        sizer_item = wx.SizerItem()
         part = AuiDockUIPart()
 
         sash_size = self._art.GetMetric(AUI_DOCKART_SASH_SIZE)
@@ -5849,8 +5613,7 @@ class AuiManager(wx.EvtHandler):
 
         # resizable bottom and right docks have a sash before them
         if not self._has_maximized and not dock.fixed and \
-           dock.dock_direction in [AUI_DOCK_BOTTOM, AUI_DOCK_RIGHT]:
-
+                dock.dock_direction in [AUI_DOCK_BOTTOM, AUI_DOCK_RIGHT]:
             sizer_item = cont.Add((sash_size, sash_size), 0, wx.EXPAND)
 
             part.type = AuiDockUIPart.typeDockSizer
@@ -5897,7 +5660,7 @@ class AuiManager(wx.EvtHandler):
                     part.dock = dock
                     part.pane = None
                     part.button = None
-                    part.orientation = (orientation==wx.HORIZONTAL and \
+                    part.orientation = (orientation == wx.HORIZONTAL and \
                                         [wx.VERTICAL] or [wx.HORIZONTAL])[0]
                     part.cont_sizer = dock_sizer
                     part.sizer_item = sizer_item
@@ -5937,9 +5700,9 @@ class AuiManager(wx.EvtHandler):
                     part = AuiDockUIPart()
                     part.type = AuiDockUIPart.typePaneSizer
                     part.dock = dock
-                    part.pane = dock.panes[pane_i-1]
+                    part.pane = dock.panes[pane_i - 1]
                     part.button = None
-                    part.orientation = (orientation==wx.HORIZONTAL and \
+                    part.orientation = (orientation == wx.HORIZONTAL and \
                                         [wx.VERTICAL] or [wx.HORIZONTAL])[0]
                     part.cont_sizer = dock_sizer
                     part.sizer_item = sizer_item
@@ -5969,8 +5732,7 @@ class AuiManager(wx.EvtHandler):
 
         #  top and left docks have a sash after them
         if not self._has_maximized and not dock.fixed and \
-           dock.dock_direction in [AUI_DOCK_TOP, AUI_DOCK_LEFT]:
-
+                dock.dock_direction in [AUI_DOCK_TOP, AUI_DOCK_LEFT]:
             sizer_item = cont.Add((sash_size, sash_size), 0, wx.EXPAND)
 
             part = AuiDockUIPart()
@@ -5984,7 +5746,6 @@ class AuiManager(wx.EvtHandler):
             uiparts.append(part)
 
         return uiparts
-
 
     def LayoutAll(self, panes, docks, uiparts, spacer_only=False, oncheck=True):
         """
@@ -6055,8 +5816,8 @@ class AuiManager(wx.EvtHandler):
                         frameRect = GetInternalFrameRect(self._frame, self._docks)
 
                         # set max size allowing for sashes and absolute minimum
-                        maxsize = frameRect[2:][isHor] - sum(sizes) - (len(sizes)*10) - (sashSize*len(sizes))
-                        dock.size = min(p.previousDockSize,maxsize)
+                        maxsize = frameRect[2:][isHor] - sum(sizes) - (len(sizes) * 10) - (sashSize * len(sizes))
+                        dock.size = min(p.previousDockSize, maxsize)
 
                     else:
                         dock.size = 0
@@ -6094,8 +5855,8 @@ class AuiManager(wx.EvtHandler):
             # dock position (dock_pos), in ascending order
             dock_pane_count = len(dock.panes)
             if dock_pane_count > 1:
-                #~ dock.panes.sort(PaneSortFunc)
-                dock.panes.sort(key = lambda pane: pane.dock_pos)
+                # ~ dock.panes.sort(PaneSortFunc)
+                dock.panes.sort(key=lambda pane: pane.dock_pos)
 
             # for newly created docks, set up their initial size
             if dock.size == 0:
@@ -6115,7 +5876,7 @@ class AuiManager(wx.EvtHandler):
                 # if at least one pane inside the dock has a pane border
                 for pane in dock.panes:
                     if pane.HasBorder():
-                        size = size + pane_border_size*2
+                        size = size + pane_border_size * 2
                         break
 
                 # if pane is on the top or bottom, add the caption height,
@@ -6133,8 +5894,8 @@ class AuiManager(wx.EvtHandler):
 
                 # new dock's size may not be more than the dock constraint
                 # parameter specifies.  See SetDockSizeConstraint()
-                max_dock_x_size = int(self._dock_constraint_x*float(cli_size.x))
-                max_dock_y_size = int(self._dock_constraint_y*float(cli_size.y))
+                max_dock_x_size = int(self._dock_constraint_x * float(cli_size.x))
+                max_dock_y_size = int(self._dock_constraint_y * float(cli_size.y))
                 if tuple(cli_size) <= tuple(wx.Size(20, 20)):
                     max_dock_x_size = 10000
                     max_dock_y_size = 10000
@@ -6171,7 +5932,7 @@ class AuiManager(wx.EvtHandler):
                             dock_min_size = pane.min_size.x
 
             if plus_border:
-                dock_min_size += pane_border_size*2
+                dock_min_size += pane_border_size * 2
             if plus_caption and dock.IsHorizontal():
                 dock_min_size += caption_size
             if plus_caption_left and dock.IsVertical():
@@ -6235,8 +5996,8 @@ class AuiManager(wx.EvtHandler):
                 self._docks[ii] = dock
 
         # shrink docks if needed
-##        docks = self.SmartShrink(docks, AUI_DOCK_TOP)
-##        docks = self.SmartShrink(docks, AUI_DOCK_LEFT)
+        ##        docks = self.SmartShrink(docks, AUI_DOCK_TOP)
+        ##        docks = self.SmartShrink(docks, AUI_DOCK_LEFT)
 
         if oncheck:
             self._docks = docks
@@ -6259,7 +6020,7 @@ class AuiManager(wx.EvtHandler):
         if oncheck:
             docks = self._docks
 
-        for layer in range(max_layer+1):
+        for layer in range(max_layer + 1):
             # find any docks in this layer
             arr = FindDocks(docks, -1, layer, -1)
             # if there aren't any, skip to the next layer
@@ -6294,7 +6055,7 @@ class AuiManager(wx.EvtHandler):
                 arr = FindDocks(docks, AUI_DOCK_CENTER, -1, -1)
                 if arr:
                     for row in arr:
-                       uiparts = self.LayoutAddDock(middle, row, uiparts, spacer_only)
+                        uiparts = self.LayoutAddDock(middle, row, uiparts, spacer_only)
 
                 elif not self._has_maximized:
                     # there are no center docks, add a background area
@@ -6321,7 +6082,7 @@ class AuiManager(wx.EvtHandler):
             # find any bottom docks in this layer
             arr = FindDocks(docks, AUI_DOCK_BOTTOM, layer, -1, reverse=True)
             for row in arr:
-                    uiparts = self.LayoutAddDock(cont, row, uiparts, spacer_only)
+                uiparts = self.LayoutAddDock(cont, row, uiparts, spacer_only)
 
         if not cont:
             # no sizer available, because there are no docks,
@@ -6348,7 +6109,6 @@ class AuiManager(wx.EvtHandler):
         else:
             return container, panes, docks, uiparts
 
-
     def SetDockSizeConstraint(self, width_pct, height_pct):
         """
         When a user creates a new dock by dragging a window into a docked position,
@@ -6370,7 +6130,6 @@ class AuiManager(wx.EvtHandler):
         self._dock_constraint_x = max(0.0, min(1.0, width_pct))
         self._dock_constraint_y = max(0.0, min(1.0, height_pct))
 
-
     def GetDockSizeConstraint(self):
         """
         Returns the current dock constraint values.
@@ -6379,7 +6138,6 @@ class AuiManager(wx.EvtHandler):
         """
 
         return self._dock_constraint_x, self._dock_constraint_y
-
 
     def Update(self):
         if '__WXGTK__' in wx.PlatformInfo:
@@ -6492,7 +6250,7 @@ class AuiManager(wx.EvtHandler):
                     # the dragging is happening right now, then the floating
                     # window should have this style by default
                     if self._action in [actionDragFloatingPane, actionDragToolbarPane] and \
-                       self._agwFlags & AUI_MGR_TRANSPARENT_DRAG:
+                            self._agwFlags & AUI_MGR_TRANSPARENT_DRAG:
                         frame.SetTransparent(150)
 
                     frame.SetPaneWindow(p)
@@ -6584,8 +6342,6 @@ class AuiManager(wx.EvtHandler):
         if not self._masterManager:
             e = self.FireEvent(wxEVT_AUI_PERSPECTIVE_CHANGED, None, canVeto=False)
 
-
-
     def UpdateNotebook(self):
         """ Updates the automatic :class:`~wx.lib.agw.aui.auibook.AuiNotebook` in the layout (if any exists). """
 
@@ -6670,7 +6426,7 @@ class AuiManager(wx.EvtHandler):
 
         # Delete empty notebooks, and convert notebooks with 1 page to
         # normal panes...
-        remap_ids = [-1]*len(self._notebooks)
+        remap_ids = [-1] * len(self._notebooks)
         nb_idx = 0
 
         for nb, notebook in enumerate(self._notebooks):
@@ -6771,7 +6527,6 @@ class AuiManager(wx.EvtHandler):
 
                     # todo: remove close
 
-
     def SmartShrink(self, docks, direction):
         """
         Used to intelligently shrink the docks' size (if needed).
@@ -6833,7 +6588,6 @@ class AuiManager(wx.EvtHandler):
 
         return docks
 
-
     def UpdateDockingGuides(self, paneInfo):
         """
         Updates the docking guide windows positions and appearance.
@@ -6858,32 +6612,32 @@ class AuiManager(wx.EvtHandler):
             direction = guide.dock_direction
 
             if direction == AUI_DOCK_LEFT:
-                pt.x = frameRect.x + guide_size.x / 2 + 16
-                pt.y = frameRect.y + frameRect.height / 2
+                pt.x = frameRect.x + guide_size.x // 2 + 16
+                pt.y = frameRect.y + frameRect.height // 2
 
             elif direction == AUI_DOCK_TOP:
-                pt.x = frameRect.x + frameRect.width / 2
-                pt.y = frameRect.y + guide_size.y / 2 + 16
+                pt.x = frameRect.x + frameRect.width // 2
+                pt.y = frameRect.y + guide_size.y // 2 + 16
 
             elif direction == AUI_DOCK_RIGHT:
-                pt.x = frameRect.x + frameRect.width - guide_size.x / 2 - 16
-                pt.y = frameRect.y + frameRect.height / 2
+                pt.x = frameRect.x + frameRect.width - guide_size.x // 2 - 16
+                pt.y = frameRect.y + frameRect.height // 2
 
             elif direction == AUI_DOCK_BOTTOM:
-                pt.x = frameRect.x + frameRect.width / 2
-                pt.y = frameRect.y + frameRect.height - guide_size.y / 2 - 16
+                pt.x = frameRect.x + frameRect.width // 2
+                pt.y = frameRect.y + frameRect.height - guide_size.y // 2 - 16
 
             elif direction == AUI_DOCK_CENTER:
                 rc = paneInfo.window.GetScreenRect()
-                pt.x = rc.x + rc.width / 2
-                pt.y = rc.y + rc.height / 2
+                pt.x = rc.x + rc.width // 2
+                pt.y = rc.y + rc.height // 2
                 if paneInfo.HasCaption():
-                    pt.y -= captionSize / 2
+                    pt.y -= captionSize // 2
                 elif paneInfo.HasCaptionLeft():
-                    pt.x -= captionSize / 2
+                    pt.x -= captionSize // 2
 
             # guide will be centered around point 'pt'
-            targetPosition = wx.Point(pt.x - guide_size.x / 2, pt.y - guide_size.y / 2)
+            targetPosition = wx.Point(pt.x - guide_size.x // 2, pt.y - guide_size.y // 2)
 
             if guide.host.GetPosition() != targetPosition:
                 guide.host.Move(targetPosition)
@@ -6897,7 +6651,6 @@ class AuiManager(wx.EvtHandler):
                 guide.host.UpdateDockGuide(mousePos)
 
         paneInfo.window.Lower()
-
 
     def DoFrameLayout(self):
         """
@@ -6943,7 +6696,6 @@ class AuiManager(wx.EvtHandler):
             if part.type == AuiDockUIPart.typePane:
                 part.pane.rect = part.rect
 
-
     def GetPanePart(self, wnd):
         """
         Looks up the pane border UI part of the
@@ -6955,16 +6707,15 @@ class AuiManager(wx.EvtHandler):
 
         for part in self._uiparts:
             if part.type == AuiDockUIPart.typePaneBorder and \
-               part.pane and part.pane.window == wnd:
+                    part.pane and part.pane.window == wnd:
                 return part
 
         for part in self._uiparts:
             if part.type == AuiDockUIPart.typePane and \
-               part.pane and part.pane.window == wnd:
+                    part.pane and part.pane.window == wnd:
                 return part
 
         return None
-
 
     def GetDockPixelOffset(self, test):
         """
@@ -6999,8 +6750,8 @@ class AuiManager(wx.EvtHandler):
 
         for dock in docks:
             if test.dock_direction == dock.dock_direction and \
-               test.dock_layer == dock.dock_layer and  \
-               test.dock_row == dock.dock_row:
+                    test.dock_layer == dock.dock_layer and \
+                    test.dock_row == dock.dock_row:
 
                 if dock.IsVertical():
                     return dock.rect.y
@@ -7008,7 +6759,6 @@ class AuiManager(wx.EvtHandler):
                     return dock.rect.x
 
         return 0
-
 
     def GetPartnerDock(self, dock):
         """
@@ -7044,7 +6794,6 @@ class AuiManager(wx.EvtHandler):
 
         return None
 
-
     def GetPartnerPane(self, dock, pane):
         """
         Returns the partner pane for the input pane. They both need to live
@@ -7063,7 +6812,6 @@ class AuiManager(wx.EvtHandler):
                 return tmpPane
 
         return None
-
 
     def GetTotalPixSizeAndProportion(self, dock):
         """
@@ -7090,15 +6838,14 @@ class AuiManager(wx.EvtHandler):
             else:
                 totalPixsize += tmpPane.rect.height
 
-##            if tmpPane.min_size.IsFullySpecified():
-##
-##                if dock.IsHorizontal():
-##                    totalPixsize -= tmpPane.min_size.x
-##                else:
-##                    totalPixsize -= tmpPane.min_size.y
+        ##            if tmpPane.min_size.IsFullySpecified():
+        ##
+        ##                if dock.IsHorizontal():
+        ##                    totalPixsize -= tmpPane.min_size.x
+        ##                else:
+        ##                    totalPixsize -= tmpPane.min_size.y
 
         return totalPixsize, totalProportion
-
 
     def GetOppositeDockTotalSize(self, docks, direction):
         """
@@ -7129,7 +6876,7 @@ class AuiManager(wx.EvtHandler):
 
             for tmpPane in tmpDock.panes:
 
-                minSize = pane_border_size*2 - sash_size
+                minSize = pane_border_size * 2 - sash_size
 
                 if vertical:
                     minSize += tmpPane.min_size.y + caption_size
@@ -7153,7 +6900,6 @@ class AuiManager(wx.EvtHandler):
 
         return result
 
-
     def CalculateDockSizerLimits(self, dock):
         """
         Calculates the minimum and maximum sizes allowed for the input dock.
@@ -7170,9 +6916,8 @@ class AuiManager(wx.EvtHandler):
         for tmpDock in docks:
 
             if tmpDock.dock_direction == dock.dock_direction and \
-               tmpDock.dock_layer == dock.dock_layer and \
-               tmpDock.dock_row == dock.dock_row:
-
+                    tmpDock.dock_layer == dock.dock_layer and \
+                    tmpDock.dock_row == dock.dock_row:
                 tmpDock.size = 1
                 break
 
@@ -7192,9 +6937,8 @@ class AuiManager(wx.EvtHandler):
 
         for tmpDock in docks:
             if tmpDock.dock_direction == dock.dock_direction and \
-               tmpDock.dock_layer == dock.dock_layer and \
-               tmpDock.dock_row == dock.dock_row:
-
+                    tmpDock.dock_layer == dock.dock_layer and \
+                    tmpDock.dock_row == dock.dock_row:
                 new_dock = tmpDock
                 break
 
@@ -7248,7 +6992,6 @@ class AuiManager(wx.EvtHandler):
             maxPix = new_dock.rect.y - sash_size
 
         return minPix, maxPix
-
 
     def CalculatePaneSizerLimits(self, dock, pane):
         """
@@ -7309,7 +7052,6 @@ class AuiManager(wx.EvtHandler):
 
         return minPix, maxPix
 
-
     def CheckMovableSizer(self, part):
         """
         Checks if a UI part can be actually resized.
@@ -7320,8 +7062,7 @@ class AuiManager(wx.EvtHandler):
         # a dock may not be resized if it has a single
         # pane which is not resizable
         if part.type == AuiDockUIPart.typeDockSizer and part.dock and \
-           len(part.dock.panes) == 1 and part.dock.panes[0].IsFixed():
-
+                len(part.dock.panes) == 1 and part.dock.panes[0].IsFixed():
             return False
 
         if part.pane:
@@ -7333,7 +7074,6 @@ class AuiManager(wx.EvtHandler):
                 return False
 
         return True
-
 
     def PaneFromTabEvent(self, event):
         """
@@ -7364,7 +7104,6 @@ class AuiManager(wx.EvtHandler):
                     return self.GetPane(window)
 
         return NonePaneInfo
-
 
     def OnTabBeginDrag(self, event):
         """
@@ -7473,7 +7212,6 @@ class AuiManager(wx.EvtHandler):
             else:
                 event.Skip()
 
-
     def OnTabSelected(self, event):
         """
         Handles the ``EVT_AUINOTEBOOK_PAGE_CHANGED`` event.
@@ -7496,12 +7234,10 @@ class AuiManager(wx.EvtHandler):
             if paneInfo.IsOk():
                 notebookRoot = GetNotebookRoot(self._panes, paneInfo.notebook_id)
                 if notebookRoot:
-
                     notebookRoot.Caption(paneInfo.caption)
                     self.RefreshCaptions()
 
         event.Skip()
-
 
     def GetNotebooks(self):
         """ Returns all the automatic :class:`~wx.lib.agw.aui.auibook.AuiNotebook` in the :class:`AuiManager`. """
@@ -7511,7 +7247,6 @@ class AuiManager(wx.EvtHandler):
 
         return self._notebooks
 
-
     def SetMasterManager(self, manager):
         """
         Sets the master manager for an automatic :class:`~wx.lib.agw.aui.auibook.AuiNotebook`.
@@ -7520,7 +7255,6 @@ class AuiManager(wx.EvtHandler):
         """
 
         self._masterManager = manager
-
 
     def ProcessDockResult(self, target, new_pos):
         """
@@ -7551,7 +7285,6 @@ class AuiManager(wx.EvtHandler):
                 self.SwitchToolBarOrientation(target)
 
         return allowed, target
-
 
     def SwitchToolBarOrientation(self, pane):
         """
@@ -7593,7 +7326,6 @@ class AuiManager(wx.EvtHandler):
 
         return pane
 
-
     def DoDrop(self, docks, panes, target, pt, offset=wx.Point(0, 0)):
         """
         This is an important function. It basically takes a mouse position,
@@ -7614,7 +7346,6 @@ class AuiManager(wx.EvtHandler):
             return self.DoDropFloatingPane(docks, panes, target, pt)
         else:
             return self.DoDropNonFloatingPane(docks, panes, target, pt)
-
 
     def CopyTarget(self, target):
         """
@@ -7649,7 +7380,6 @@ class AuiManager(wx.EvtHandler):
         drop.minimize_target = target.minimize_target
 
         return drop
-
 
     def DoDropToolbar(self, docks, panes, target, pt, offset):
         """
@@ -7703,7 +7433,7 @@ class AuiManager(wx.EvtHandler):
                     Position(pt.x - self.GetDockPixelOffset(drop) - offset.x)
 
             if not target.IsFloating() and safeRect.Contains(pt) and \
-               target.dock_direction != drop.dock_direction:
+                    target.dock_direction != drop.dock_direction:
                 return False, target
 
             return self.ProcessDockResult(target, drop)
@@ -7730,7 +7460,7 @@ class AuiManager(wx.EvtHandler):
         if not dock.fixed or dock.dock_direction == AUI_DOCK_CENTER:
 
             if (self._agwFlags & AUI_MGR_ALLOW_FLOATING and drop.IsFloatable()) or \
-               dock.dock_direction not in [AUI_DOCK_CENTER, AUI_DOCK_NONE]:
+                    dock.dock_direction not in [AUI_DOCK_CENTER, AUI_DOCK_NONE]:
                 if drop.IsFloatable():
                     drop.Float()
 
@@ -7748,7 +7478,7 @@ class AuiManager(wx.EvtHandler):
             Row(dock.dock_row).Position(dockDropOffset)
 
         if (pt.y <= dock.rect.GetTop() + 2 and dock.IsHorizontal()) or \
-           (pt.x <= dock.rect.GetLeft() + 2 and dock.IsVertical()):
+                (pt.x <= dock.rect.GetLeft() + 2 and dock.IsVertical()):
 
             if dock.dock_direction in [AUI_DOCK_TOP, AUI_DOCK_LEFT]:
                 row = drop.dock_row
@@ -7756,15 +7486,15 @@ class AuiManager(wx.EvtHandler):
                 drop.dock_row = row
 
             else:
-                panes = DoInsertDockRow(panes, dock.dock_direction, dock.dock_layer, dock.dock_row+1)
+                panes = DoInsertDockRow(panes, dock.dock_direction, dock.dock_layer, dock.dock_row + 1)
                 drop.dock_row = dock.dock_row + 1
 
         if (pt.y >= dock.rect.GetBottom() - 2 and dock.IsHorizontal()) or \
-           (pt.x >= dock.rect.GetRight() - 2 and dock.IsVertical()):
+                (pt.x >= dock.rect.GetRight() - 2 and dock.IsVertical()):
 
             if dock.dock_direction in [AUI_DOCK_TOP, AUI_DOCK_LEFT]:
-                panes = DoInsertDockRow(panes, dock.dock_direction, dock.dock_layer, dock.dock_row+1)
-                drop.dock_row = dock.dock_row+1
+                panes = DoInsertDockRow(panes, dock.dock_direction, dock.dock_layer, dock.dock_row + 1)
+                drop.dock_row = dock.dock_row + 1
 
             else:
                 row = drop.dock_row
@@ -7772,11 +7502,10 @@ class AuiManager(wx.EvtHandler):
                 drop.dock_row = row
 
         if not target.IsFloating() and safeRect.Contains(pt) and \
-           target.dock_direction != drop.dock_direction:
+                target.dock_direction != drop.dock_direction:
             return False, target
 
         return self.ProcessDockResult(target, drop)
-
 
     def DoDropFloatingPane(self, docks, panes, target, pt):
         """
@@ -7800,7 +7529,7 @@ class AuiManager(wx.EvtHandler):
 
         # search the dock guides.
         # reverse order to handle the center first.
-        for i in range(len(self._guides)-1, -1, -1):
+        for i in range(len(self._guides) - 1, -1, -1):
             guide = self._guides[i]
 
             # do hit testing on the guide
@@ -7809,7 +7538,7 @@ class AuiManager(wx.EvtHandler):
             if dir == -1:  # point was outside of the dock guide
                 continue
 
-            if dir == wx.ALL:   # target is a single dock guide
+            if dir == wx.ALL:  # target is a single dock guide
                 return self.DoDropLayer(docks, target, guide.dock_direction)
 
             elif dir == wx.CENTER:
@@ -7820,7 +7549,6 @@ class AuiManager(wx.EvtHandler):
                     continue
 
                 if not paneInfo.HasNotebook():
-
                     # Add a new notebook pane with the original as a tab...
                     self.CreateNotebookBase(panes, paneInfo)
 
@@ -7851,8 +7579,8 @@ class AuiManager(wx.EvtHandler):
 
                 if insert_dir == AUI_DOCK_LEFT:
 
-                    drop_pane = (dir == wx.UP   or dir == wx.DOWN)
-                    drop_row  = (dir == wx.LEFT or dir == wx.RIGHT)
+                    drop_pane = (dir == wx.UP or dir == wx.DOWN)
+                    drop_row = (dir == wx.LEFT or dir == wx.RIGHT)
                     if dir == wx.RIGHT:
                         insert_row += 1
                     elif dir == wx.DOWN:
@@ -7860,8 +7588,8 @@ class AuiManager(wx.EvtHandler):
 
                 elif insert_dir == AUI_DOCK_RIGHT:
 
-                    drop_pane = (dir == wx.UP   or dir == wx.DOWN)
-                    drop_row  = (dir == wx.LEFT or dir == wx.RIGHT)
+                    drop_pane = (dir == wx.UP or dir == wx.DOWN)
+                    drop_row = (dir == wx.LEFT or dir == wx.RIGHT)
                     if dir == wx.LEFT:
                         insert_row += 1
                     elif dir == wx.DOWN:
@@ -7870,7 +7598,7 @@ class AuiManager(wx.EvtHandler):
                 elif insert_dir == AUI_DOCK_TOP:
 
                     drop_pane = (dir == wx.LEFT or dir == wx.RIGHT)
-                    drop_row  = (dir == wx.UP   or dir == wx.DOWN)
+                    drop_row = (dir == wx.UP or dir == wx.DOWN)
                     if dir == wx.DOWN:
                         insert_row += 1
                     elif dir == wx.RIGHT:
@@ -7879,7 +7607,7 @@ class AuiManager(wx.EvtHandler):
                 elif insert_dir == AUI_DOCK_BOTTOM:
 
                     drop_pane = (dir == wx.LEFT or dir == wx.RIGHT)
-                    drop_row  = (dir == wx.UP   or dir == wx.DOWN)
+                    drop_row = (dir == wx.UP or dir == wx.DOWN)
                     if dir == wx.UP:
                         insert_row += 1
                     elif dir == wx.RIGHT:
@@ -7897,7 +7625,6 @@ class AuiManager(wx.EvtHandler):
             return True, target
 
         return False, target
-
 
     def DoDropNonFloatingPane(self, docks, panes, target, pt):
         """
@@ -7947,59 +7674,58 @@ class AuiManager(wx.EvtHandler):
         direction = part.pane.dock_direction
 
         if direction == AUI_DOCK_TOP:
-            if pt.y >= part.rect.y and pt.y < part.rect.y+auiInsertRowPixels:
+            if pt.y >= part.rect.y and pt.y < part.rect.y + auiInsertRowPixels:
                 insert_dock_row = True
 
         elif direction == AUI_DOCK_BOTTOM:
-            if pt.y > part.rect.y+part.rect.height-auiInsertRowPixels and \
-               pt.y <= part.rect.y + part.rect.height:
+            if pt.y > part.rect.y + part.rect.height - auiInsertRowPixels and \
+                    pt.y <= part.rect.y + part.rect.height:
                 insert_dock_row = True
 
         elif direction == AUI_DOCK_LEFT:
-            if pt.x >= part.rect.x and pt.x < part.rect.x+auiInsertRowPixels:
+            if pt.x >= part.rect.x and pt.x < part.rect.x + auiInsertRowPixels:
                 insert_dock_row = True
 
         elif direction == AUI_DOCK_RIGHT:
-            if pt.x > part.rect.x+part.rect.width-auiInsertRowPixels and \
-               pt.x <= part.rect.x+part.rect.width:
+            if pt.x > part.rect.x + part.rect.width - auiInsertRowPixels and \
+                    pt.x <= part.rect.x + part.rect.width:
                 insert_dock_row = True
 
         elif direction == AUI_DOCK_CENTER:
 
-                # "new row pixels" will be set to the default, but
-                # must never exceed 20% of the window size
-                new_row_pixels_x = auiNewRowPixels
-                new_row_pixels_y = auiNewRowPixels
+            # "new row pixels" will be set to the default, but
+            # must never exceed 20% of the window size
+            new_row_pixels_x = auiNewRowPixels
+            new_row_pixels_y = auiNewRowPixels
 
-                if new_row_pixels_x > (part.rect.width*20)/100:
-                    new_row_pixels_x = (part.rect.width*20)/100
+            if new_row_pixels_x > (part.rect.width * 20) // 100:
+                new_row_pixels_x = (part.rect.width * 20) // 100
 
-                if new_row_pixels_y > (part.rect.height*20)/100:
-                    new_row_pixels_y = (part.rect.height*20)/100
+            if new_row_pixels_y > (part.rect.height * 20) // 100:
+                new_row_pixels_y = (part.rect.height * 20) // 100
 
-                # determine if the mouse pointer is in a location that
-                # will cause a new row to be inserted.  The hot spot positions
-                # are along the borders of the center pane
+            # determine if the mouse pointer is in a location that
+            # will cause a new row to be inserted.  The hot spot positions
+            # are along the borders of the center pane
 
-                insert_layer = 0
-                insert_dock_row = True
-                pr = part.rect
+            insert_layer = 0
+            insert_dock_row = True
+            pr = part.rect
 
-                if pt.x >= pr.x and pt.x < pr.x + new_row_pixels_x:
-                    insert_dir = AUI_DOCK_LEFT
-                elif pt.y >= pr.y and pt.y < pr.y + new_row_pixels_y:
-                    insert_dir = AUI_DOCK_TOP
-                elif pt.x >= pr.x + pr.width - new_row_pixels_x and pt.x < pr.x + pr.width:
-                    insert_dir = AUI_DOCK_RIGHT
-                elif pt.y >= pr.y+ pr.height - new_row_pixels_y and pt.y < pr.y + pr.height:
-                    insert_dir = AUI_DOCK_BOTTOM
-                else:
-                    return False, target
+            if pt.x >= pr.x and pt.x < pr.x + new_row_pixels_x:
+                insert_dir = AUI_DOCK_LEFT
+            elif pt.y >= pr.y and pt.y < pr.y + new_row_pixels_y:
+                insert_dir = AUI_DOCK_TOP
+            elif pt.x >= pr.x + pr.width - new_row_pixels_x and pt.x < pr.x + pr.width:
+                insert_dir = AUI_DOCK_RIGHT
+            elif pt.y >= pr.y + pr.height - new_row_pixels_y and pt.y < pr.y + pr.height:
+                insert_dir = AUI_DOCK_BOTTOM
+            else:
+                return False, target
 
-                insert_row = GetMaxRow(panes, insert_dir, insert_layer) + 1
+            insert_row = GetMaxRow(panes, insert_dir, insert_layer) + 1
 
         if insert_dock_row:
-
             panes = DoInsertDockRow(panes, insert_dir, insert_layer, insert_row)
             drop.Dock().Direction(insert_dir).Layer(insert_layer). \
                 Row(insert_row).Position(0)
@@ -8023,8 +7749,7 @@ class AuiManager(wx.EvtHandler):
 
         # if we are in the top/left part of the pane,
         # insert the pane before the pane being hovered over
-        if offset <= size/2:
-
+        if offset <= size // 2:
             drop_position = part.pane.dock_pos
             panes = DoInsertPane(panes,
                                  part.pane.dock_direction,
@@ -8034,23 +7759,20 @@ class AuiManager(wx.EvtHandler):
 
         # if we are in the bottom/right part of the pane,
         # insert the pane before the pane being hovered over
-        if offset > size/2:
-
-            drop_position = part.pane.dock_pos+1
+        if offset > size // 2:
+            drop_position = part.pane.dock_pos + 1
             panes = DoInsertPane(panes,
                                  part.pane.dock_direction,
                                  part.pane.dock_layer,
                                  part.pane.dock_row,
-                                 part.pane.dock_pos+1)
-
+                                 part.pane.dock_pos + 1)
 
         drop.Dock(). \
-                     Direction(part.dock.dock_direction). \
-                     Layer(part.dock.dock_layer).Row(part.dock.dock_row). \
-                     Position(drop_position)
+            Direction(part.dock.dock_direction). \
+            Layer(part.dock.dock_layer).Row(part.dock.dock_row). \
+            Position(drop_position)
 
         return self.ProcessDockResult(target, drop)
-
 
     def DoDropLayer(self, docks, target, dock_direction):
         """
@@ -8090,10 +7812,8 @@ class AuiManager(wx.EvtHandler):
         else:
             return False, target
 
-
         drop.Dock().Layer(drop_new_layer)
         return self.ProcessDockResult(target, drop)
-
 
     def DoDropPane(self, panes, target, dock_direction, dock_layer, dock_row, dock_pos):
         """
@@ -8113,7 +7833,6 @@ class AuiManager(wx.EvtHandler):
         drop.Dock().Direction(dock_direction).Layer(dock_layer).Row(dock_row).Position(dock_pos)
         return self.ProcessDockResult(target, drop)
 
-
     def DoDropRow(self, panes, target, dock_direction, dock_layer, dock_row):
         """
         Insert a row in the interface before dropping.
@@ -8130,7 +7849,6 @@ class AuiManager(wx.EvtHandler):
 
         drop.Dock().Direction(dock_direction).Layer(dock_layer).Row(dock_row).Position(0)
         return self.ProcessDockResult(target, drop)
-
 
     def ShowHint(self, rect):
         """
@@ -8177,9 +7895,9 @@ class AuiManager(wx.EvtHandler):
             screendc.SetBrush(brush)
             screendc.SetPen(wx.TRANSPARENT_PEN)
             screendc.DrawRectangle(rect.x, rect.y, 5, rect.height)
-            screendc.DrawRectangle(rect.x+5, rect.y, rect.width-10, 5)
-            screendc.DrawRectangle(rect.x+rect.width-5, rect.y, 5, rect.height)
-            screendc.DrawRectangle(rect.x+5, rect.y+rect.height-5, rect.width-10, 5)
+            screendc.DrawRectangle(rect.x + 5, rect.y, rect.width - 10, 5)
+            screendc.DrawRectangle(rect.x + rect.width - 5, rect.y, 5, rect.height)
+            screendc.DrawRectangle(rect.x + 5, rect.y + rect.height - 5, rect.width - 10, 5)
             RefreshDockingGuides(self._guides)
 
             return
@@ -8200,12 +7918,11 @@ class AuiManager(wx.EvtHandler):
         if self._action == actionDragFloatingPane and self._action_window:
             self._action_window.SetFocus()
 
-        if self._hint_fadeamt != self._hint_fademax: #  Only fade if we need to
+        if self._hint_fadeamt != self._hint_fademax:  # Only fade if we need to
             # start fade in timer
             self._hint_fadetimer.Start(5)
 
         self._last_hint = wx.Rect(*rect)
-
 
     def HideHint(self):
         """ Hides a transparent window hint if there is one. """
@@ -8216,7 +7933,6 @@ class AuiManager(wx.EvtHandler):
 
         self._hint_fadetimer.Stop()
         self._last_hint = wx.Rect()
-
 
     def IsPaneButtonVisible(self, part):
         """
@@ -8229,12 +7945,11 @@ class AuiManager(wx.EvtHandler):
 
         for temp_part in self._uiparts:
             if temp_part.pane == part.pane and \
-               temp_part.type == AuiDockUIPart.typeCaption:
+                    temp_part.type == AuiDockUIPart.typeCaption:
                 captionRect = temp_part.rect
                 break
 
         return captionRect.Contains(part.rect)
-
 
     def DrawPaneButton(self, dc, part, pt):
         """
@@ -8260,7 +7975,6 @@ class AuiManager(wx.EvtHandler):
         self._art.DrawPaneButton(dc, self._frame, part.button.button_id,
                                  state, part.rect, part.pane)
 
-
     def RefreshButton(self, part):
         """
         Refreshes a pane button in the caption.
@@ -8273,7 +7987,6 @@ class AuiManager(wx.EvtHandler):
         self._frame.Refresh(True, rect)
         self._frame.Update()
 
-
     def RefreshCaptions(self):
         """ Refreshes all pane captions. """
 
@@ -8281,7 +7994,6 @@ class AuiManager(wx.EvtHandler):
             if part.type == AuiDockUIPart.typeCaption:
                 self._frame.Refresh(True, part.rect)
                 self._frame.Update()
-
 
     def CalculateHintRect(self, pane_window, pt, offset):
         """
@@ -8351,14 +8063,14 @@ class AuiManager(wx.EvtHandler):
         if hint.IsNotebookPage():
             id = hint.notebook_id
             for pane in panes:
-                if pane.IsNotebookControl() and pane.notebook_id==id:
+                if pane.IsNotebookControl() and pane.notebook_id == id:
                     sought = pane.name
                     break
 
         for part in uiparts:
             if part.pane and part.pane.name == sought:
                 rect.Union(wx.Rect(part.sizer_item.GetPosition(),
-                                     part.sizer_item.GetSize()))
+                                   part.sizer_item.GetSize()))
 
         sizer.Destroy()
 
@@ -8378,7 +8090,6 @@ class AuiManager(wx.EvtHandler):
             rect.x -= rect.GetWidth()
 
         return rect
-
 
     def DrawHintRect(self, pane_window, pt, offset):
         """
@@ -8401,7 +8112,6 @@ class AuiManager(wx.EvtHandler):
             self.ShowHint(rect)
             self._hint_rect = wx.Rect(*rect)
 
-
     def GetPartSizerRect(self, uiparts):
         """
         Returns the rectangle surrounding the specified UI parts.
@@ -8414,10 +8124,9 @@ class AuiManager(wx.EvtHandler):
         for part in self._uiparts:
             if part.pane and part.pane.name == "__HINT__":
                 rect.Union(wx.Rect(part.sizer_item.GetPosition(),
-                                     part.sizer_item.GetSize()))
+                                   part.sizer_item.GetSize()))
 
         return rect
-
 
     def GetAttributes(self, pane):
         """
@@ -8435,7 +8144,6 @@ class AuiManager(wx.EvtHandler):
                       pane.transparent, pane.snapped, pane.minimize_mode, pane.minimize_target])
 
         return attrs
-
 
     def SetAttributes(self, pane, attrs):
         """
@@ -8471,7 +8179,6 @@ class AuiManager(wx.EvtHandler):
 
         return pane
 
-
     def OnFloatingPaneResized(self, wnd, size):
         """
         Handles the resizing of a floating pane.
@@ -8492,7 +8199,6 @@ class AuiManager(wx.EvtHandler):
             self._panes[indx] = pane
             if pane.IsSnappable():
                 self.SnapPane(pane, pane.floating_pos, pane.floating_size, True)
-
 
     def OnFloatingPaneClosed(self, wnd, event):
         """
@@ -8525,7 +8231,6 @@ class AuiManager(wx.EvtHandler):
             if check.IsOk():
                 self.ClosePane(pane)
 
-
     def OnFloatingPaneActivated(self, wnd):
         """
         Handles the activation event of a floating pane.
@@ -8541,7 +8246,6 @@ class AuiManager(wx.EvtHandler):
             ret, self._panes = SetActivePane(self._panes, wnd)
             self.RefreshCaptions()
             self.FireEvent(wxEVT_AUI_PANE_ACTIVATED, wnd, canVeto=False)
-
 
     def OnFloatingPaneMoved(self, wnd, eventOrPt):
         """
@@ -8566,7 +8270,6 @@ class AuiManager(wx.EvtHandler):
         pane_size = pane.floating_size
 
         self.SnapPane(pane, pane_pos, pane_size, False)
-
 
     def SnapPane(self, pane, pane_pos, pane_size, toSnap=False):
         """
@@ -8594,13 +8297,13 @@ class AuiManager(wx.EvtHandler):
                 diff = wnd_pos.x - (pane_pos.x + pane_size.x)
                 if -snapX <= diff <= snapX:
                     pane.snapped = wx.LEFT
-                    pane.floating_pos = wx.Point(wnd_pos.x-pane_size.x, pane_pos.y)
+                    pane.floating_pos = wx.Point(wnd_pos.x - pane_size.x, pane_pos.y)
             elif pane.IsTopSnappable():
                 # Check if we can snap to the top
                 diff = wnd_pos.y - (pane_pos.y + pane_size.y)
                 if -snapY <= diff <= snapY:
                     pane.snapped = wx.TOP
-                    pane.floating_pos = wx.Point(pane_pos.x, wnd_pos.y-pane_size.y)
+                    pane.floating_pos = wx.Point(pane_pos.x, wnd_pos.y - pane_size.y)
             elif pane.IsRightSnappable():
                 # Check if we can snap to the right
                 diff = pane_pos.x - (wnd_pos.x + wnd_size.x)
@@ -8615,7 +8318,6 @@ class AuiManager(wx.EvtHandler):
                     pane.floating_pos = wx.Point(pane_pos.x, wnd_pos.y + wnd_size.y)
 
         self.RepositionPane(pane, wnd_pos, wnd_size)
-
 
     def RepositionPane(self, pane, wnd_pos, wnd_size):
         """
@@ -8645,7 +8347,6 @@ class AuiManager(wx.EvtHandler):
                 self._from_move = True
                 pane.frame.SetPosition(pane.floating_pos)
                 self._from_move = False
-
 
     def OnGripperClicked(self, pane_window, start, offset):
         """
@@ -8698,7 +8399,6 @@ class AuiManager(wx.EvtHandler):
             if paneInfo.IsToolbar():
                 self._frame.SetCursor(wx.Cursor(wx.CURSOR_SIZING))
 
-
     def OnRender(self, event):
         """
         Draws all of the pane captions, sashes, backgrounds, captions, grippers, pane borders and buttons.
@@ -8731,7 +8431,6 @@ class AuiManager(wx.EvtHandler):
                                      not part.sizer_item.IsSpacer() and \
                                      not part.sizer_item.IsSizer()) or \
                                     not part.sizer_item.IsShown()):
-
                 continue
 
             ptype = part.type
@@ -8753,7 +8452,6 @@ class AuiManager(wx.EvtHandler):
 
             elif ptype == AuiDockUIPart.typePaneButton:
                 self.DrawPaneButton(dc, part, point)
-
 
     def Repaint(self, dc=None):
         """
@@ -8784,7 +8482,6 @@ class AuiManager(wx.EvtHandler):
         # Render all the items
         self.Render(dc)
 
-
     def Render(self, dc):
         """
         Fires a render event, which is normally handled by :meth:`OnRender`. This allows the
@@ -8802,7 +8499,6 @@ class AuiManager(wx.EvtHandler):
         e.SetDC(dc)
         self.ProcessMgrEvent(e)
 
-
     def OnCaptionDoubleClicked(self, pane_window):
         """
         Handles the mouse double click on the pane caption.
@@ -8816,7 +8512,7 @@ class AuiManager(wx.EvtHandler):
             raise Exception("Pane window not found")
 
         if not paneInfo.IsFloatable() or not paneInfo.IsDockable() or \
-           self._agwFlags & AUI_MGR_ALLOW_FLOATING == 0:
+                self._agwFlags & AUI_MGR_ALLOW_FLOATING == 0:
             return
 
         indx = self._panes.index(paneInfo)
@@ -8870,7 +8566,6 @@ class AuiManager(wx.EvtHandler):
             pane_rect = paneInfo.window.GetScreenRect()
             self.AnimateDocking(win_rect, pane_rect)
 
-
     def OnPaint(self, event):
         """
         Handles the ``wx.EVT_PAINT`` event for :class:`AuiManager`.
@@ -8880,7 +8575,6 @@ class AuiManager(wx.EvtHandler):
 
         dc = wx.PaintDC(self._frame)
         self.Repaint(dc)
-
 
     def OnEraseBackground(self, event):
         """
@@ -8894,7 +8588,6 @@ class AuiManager(wx.EvtHandler):
 
         if wx.Platform == "__WXMAC__":
             event.Skip()
-
 
     def OnSize(self, event):
         """
@@ -8917,7 +8610,7 @@ class AuiManager(wx.EvtHandler):
                 self.Repaint()
 
             if isinstance(self._frame, wx.MDIParentFrame) or isinstance(self._frame, tabmdi.AuiMDIClientWindow) \
-               or isinstance(self._frame, tabmdi.AuiMDIParentFrame):
+                    or isinstance(self._frame, tabmdi.AuiMDIParentFrame):
                 # for MDI parent frames, this event must not
                 # be "skipped".  In other words, the parent frame
                 # must not be allowed to resize the client window
@@ -8929,7 +8622,6 @@ class AuiManager(wx.EvtHandler):
 
         # For the snap to screen...
         self.OnMove(None)
-
 
     def OnFindManager(self, event):
         """
@@ -8949,8 +8641,7 @@ class AuiManager(wx.EvtHandler):
 
         # if no, it must be us
         if not event.GetManager():
-           event.SetManager(self)
-
+            event.SetManager(self)
 
     def OnSetCursor(self, event):
         """
@@ -8978,7 +8669,6 @@ class AuiManager(wx.EvtHandler):
                 cursor = wx.Cursor(wx.CURSOR_SIZING)
 
         event.SetCursor(cursor)
-
 
     def UpdateButtonOnScreen(self, button_ui_part, event):
         """
@@ -9015,10 +8705,9 @@ class AuiManager(wx.EvtHandler):
 
         if hit_test.pane:
             self._art.DrawPaneButton(cdc, self._frame,
-                      button_ui_part.button.button_id,
-                      state,
-                      button_ui_part.rect, hit_test.pane)
-
+                                     button_ui_part.button.button_id,
+                                     state,
+                                     button_ui_part.rect, hit_test.pane)
 
     def OnLeftDown(self, event):
         """
@@ -9050,7 +8739,7 @@ class AuiManager(wx.EvtHandler):
 
             # draw the resize hint
             rect = wx.Rect(self._frame.ClientToScreen(part.rect.GetPosition()),
-                             part.rect.GetSize())
+                           part.rect.GetSize())
 
             self._action_rect = wx.Rect(*rect)
 
@@ -9090,7 +8779,6 @@ class AuiManager(wx.EvtHandler):
         if wx.Platform != "__WXMAC__":
             event.Skip()
 
-
     def OnLeftDClick(self, event):
         """
         Handles the ``wx.EVT_LEFT_DCLICK`` event for :class:`AuiManager`.
@@ -9120,7 +8808,6 @@ class AuiManager(wx.EvtHandler):
 
         event.Skip()
 
-
     def DoEndResizeAction(self, event):
         """
         Ends a resize action, or for live update, resizes the sash.
@@ -9132,7 +8819,6 @@ class AuiManager(wx.EvtHandler):
         screenPt = self._frame.ClientToScreen(clientPt)
 
         return self.RestrictResize(clientPt, screenPt, createDC=False)
-
 
     def RestrictResize(self, clientPt, screenPt, createDC):
         """ Common method between :meth:`DoEndResizeAction` and :meth:`OnLeftUp_Resize`. """
@@ -9214,13 +8900,12 @@ class AuiManager(wx.EvtHandler):
 
             # adjust for the surplus
             while (oldPixsize > 0 and totalPixsize > 10 and \
-                  oldPixsize*totalProportion/totalPixsize < pane.dock_proportion):
-
+                   oldPixsize * totalProportion // totalPixsize < pane.dock_proportion):
                 totalPixsize -= 1
 
             # calculate the new proportion of the pane
 
-            newProportion = newPixsize*totalProportion/totalPixsize
+            newProportion = newPixsize * totalProportion // totalPixsize
             newProportion = Clip(newProportion, 1, totalProportion)
             deltaProp = newProportion - pane.dock_proportion
 
@@ -9237,7 +8922,6 @@ class AuiManager(wx.EvtHandler):
 
         return True
 
-
     def OnLeftUp(self, event):
         """
         Handles the ``wx.EVT_LEFT_UP`` event for :class:`AuiManager`.
@@ -9246,9 +8930,9 @@ class AuiManager(wx.EvtHandler):
         """
 
         if self._action == actionResize:
-##            self._frame.Freeze()
+            ##            self._frame.Freeze()
             self.OnLeftUp_Resize(event)
-##            self._frame.Thaw()
+        ##            self._frame.Thaw()
 
         elif self._action == actionClickButton:
             self.OnLeftUp_ClickButton(event)
@@ -9272,7 +8956,6 @@ class AuiManager(wx.EvtHandler):
             pass
 
         self._action = actionNone
-
 
     def OnMotion(self, event):
         """
@@ -9299,7 +8982,6 @@ class AuiManager(wx.EvtHandler):
         else:
             self.OnMotion_Other(event)
 
-
     def OnLeaveWindow(self, event):
         """
         Handles the ``wx.EVT_LEAVE_WINDOW`` event for :class:`AuiManager`.
@@ -9310,7 +8992,6 @@ class AuiManager(wx.EvtHandler):
         if self._hover_button:
             self.RefreshButton(self._hover_button)
             self._hover_button = None
-
 
     def OnCaptureLost(self, event):
         """
@@ -9323,7 +9004,6 @@ class AuiManager(wx.EvtHandler):
         if self._action != actionNone:
             self._action = actionNone
             self.HideHint()
-
 
     def OnHintFadeTimer(self, event):
         """
@@ -9338,7 +9018,6 @@ class AuiManager(wx.EvtHandler):
 
         self._hint_fadeamt += 4
         self._hint_window.SetTransparent(self._hint_fadeamt)
-
 
     def OnMove(self, event):
         """
@@ -9362,7 +9041,6 @@ class AuiManager(wx.EvtHandler):
                 if pane.IsFloating() and pane.IsShown():
                     self.SnapPane(pane, pane.floating_pos, pane.floating_size, True)
 
-
     def OnSysColourChanged(self, event):
         """
         Handles the ``wx.EVT_SYS_COLOUR_CHANGED`` event for :class:`AuiManager`.
@@ -9378,7 +9056,6 @@ class AuiManager(wx.EvtHandler):
         if self._frame:
             self.Update()
             self._frame.Refresh()
-
 
     def OnChildFocus(self, event):
         """
@@ -9406,7 +9083,6 @@ class AuiManager(wx.EvtHandler):
 
         event.Skip()
 
-
     def OnMotion_ClickCaption(self, event):
         """
         Sub-handler for the :meth:`OnMotion` event.
@@ -9426,7 +9102,6 @@ class AuiManager(wx.EvtHandler):
         # we need to check if the mouse is now being dragged
         if not (abs(clientPt.x - self._action_start.x) > drag_x_threshold or \
                 abs(clientPt.y - self._action_start.y) > drag_y_threshold):
-
             return
 
         # dragged -- we need to change the mouse action to 'drag'
@@ -9477,10 +9152,10 @@ class AuiManager(wx.EvtHandler):
             # caption is bigger than the width of the floating frame itself, so
             # in that case we need to set the action offset to a sensible value
             frame_size = self._action_pane.frame.GetSize()
-            if self._action_offset.x > frame_size.x * 2 / 3:
-                self._action_offset.x = frame_size.x / 2
-            if self._action_offset.y > frame_size.y * 2 / 3:
-                self._action_offset.y = frame_size.y / 2
+            if self._action_offset.x > frame_size.x * 2 // 3:
+                self._action_offset.x = frame_size.x // 2
+            if self._action_offset.y > frame_size.y * 2 // 3:
+                self._action_offset.y = frame_size.y // 2
 
             self.OnMotion_DragFloatingPane(event)
             if wx.Platform != "__WXGTK__":
@@ -9491,7 +9166,6 @@ class AuiManager(wx.EvtHandler):
         elif self._action_pane.IsMovable():
             self._action = actionDragMovablePane
             self._action_window = self._action_pane.window
-
 
     def OnMotion_Resize(self, event):
         """
@@ -9549,7 +9223,6 @@ class AuiManager(wx.EvtHandler):
             DrawResizeHint(dc, hintrect)
             self._action_rect = wx.Rect(*hintrect)
 
-
     def OnLeftUp_Resize(self, event):
         """
         Sub-handler for the :meth:`OnLeftUp` event.
@@ -9575,7 +9248,6 @@ class AuiManager(wx.EvtHandler):
 
         return self.RestrictResize(clientPt, screenPt, createDC=True)
 
-
     def OnLeftUp_ClickButton(self, event):
         """
         Sub-handler for the :meth:`OnLeftUp` event.
@@ -9590,14 +9262,12 @@ class AuiManager(wx.EvtHandler):
 
             # make sure we're still over the item that was originally clicked
             if self._action_part == self.HitTest(*event.GetPosition()):
-
                 # fire button-click event
                 e = AuiManagerEvent(wxEVT_AUI_PANE_BUTTON)
                 e.SetManager(self)
                 e.SetPane(self._action_part.pane)
                 e.SetButton(self._action_part.button.button_id)
                 self.ProcessMgrEvent(e)
-
 
     def CheckPaneMove(self, pane):
         """
@@ -9620,12 +9290,11 @@ class AuiManager(wx.EvtHandler):
         # skip if moving too fast to avoid massive redraws and
         # jumping hint windows
         if abs(win_rect.x - self._last_rect.x) > 10 or \
-           abs(win_rect.y - self._last_rect.y) > 10:
+                abs(win_rect.y - self._last_rect.y) > 10:
             self._last_rect = wx.Rect(*win_rect)
             return False
 
         return True
-
 
     def OnMotion_DragFloatingPane(self, eventOrPt):
         """
@@ -9654,8 +9323,6 @@ class AuiManager(wx.EvtHandler):
         if pane.IsFloating():
             diff = pane.floating_pos - (screenPt - self._action_offset)
             pane.floating_pos = screenPt - self._action_offset
-        else:
-            diff = wx.Point()
 
         framePos = pane.floating_pos
 
@@ -9663,7 +9330,8 @@ class AuiManager(wx.EvtHandler):
         if pane.frame:
 
             if diff.x != 0 or diff.y != 0:
-                if wx.Platform == "__WXMSW__" and (self._agwFlags & AUI_MGR_TRANSPARENT_DRAG) == 0: # and not self.CheckPaneMove(pane):
+                if wx.Platform == "__WXMSW__" and (
+                        self._agwFlags & AUI_MGR_TRANSPARENT_DRAG) == 0:  # and not self.CheckPaneMove(pane):
                     # return
                     # HACK: Terrible hack on wxMSW (!)
                     pane.frame.SetTransparent(254)
@@ -9712,7 +9380,6 @@ class AuiManager(wx.EvtHandler):
 
         wx.CallAfter(self.DrawHintRect, pane.window, clientPt, action_offset)
 
-
     def OnMotion_DragMovablePane(self, eventOrPt):
         """
         Sub-handler for the :meth:`OnMotion` event.
@@ -9735,7 +9402,6 @@ class AuiManager(wx.EvtHandler):
 
         # Reduces flicker.
         self._frame.Update()
-
 
     def OnLeftUp_DragFloatingPane(self, eventOrPt):
         """
@@ -9811,7 +9477,6 @@ class AuiManager(wx.EvtHandler):
         self.HideHint()
         ShowDockingGuides(self._guides, False)
 
-
     def OnLeftUp_DragMovablePane(self, event):
         """
         Sub-handler for the :meth:`OnLeftUp` event.
@@ -9833,7 +9498,7 @@ class AuiManager(wx.EvtHandler):
             pt = event.GetPosition()
             # do the drop calculation
             indx = self._panes.index(paneInfo)
-            ret, paneInfo = self.DoDrop(self._docks, self._panes, paneInfo, pt, wx.Point(0,0))
+            ret, paneInfo = self.DoDrop(self._docks, self._panes, paneInfo, pt, wx.Point(0, 0))
 
             if ret:
                 e = self.FireEvent(wxEVT_AUI_PANE_DOCKING, paneInfo, canVeto=True)
@@ -9864,7 +9529,6 @@ class AuiManager(wx.EvtHandler):
         self._action = actionNone
         self._frame.ReleaseMouse()
         self._action_window = None
-
 
     def OnMotion_DragToolbarPane(self, eventOrPt):
         """
@@ -9902,7 +9566,8 @@ class AuiManager(wx.EvtHandler):
 
         # move the pane window
         if pane.frame:
-            if wx.Platform == "__WXMSW__" and (self._agwFlags & AUI_MGR_TRANSPARENT_DRAG) == 0: # and not self.CheckPaneMove(pane):
+            if wx.Platform == "__WXMSW__" and (
+                    self._agwFlags & AUI_MGR_TRANSPARENT_DRAG) == 0:  # and not self.CheckPaneMove(pane):
                 # return
                 # HACK: Terrible hack on wxMSW (!)
                 pane.frame.SetTransparent(254)
@@ -9925,7 +9590,6 @@ class AuiManager(wx.EvtHandler):
             self._action = actionNone
             self.OnLeftUp_DragToolbarPane(eventOrPt)
 
-
     def OnMotion_Other(self, event):
         """
         Sub-handler for the :meth:`OnMotion` event.
@@ -9936,7 +9600,7 @@ class AuiManager(wx.EvtHandler):
         part = self.HitTest(*event.GetPosition())
 
         if part and part.type == AuiDockUIPart.typePaneButton \
-           and self.IsPaneButtonVisible(part):
+                and self.IsPaneButtonVisible(part):
             if part != self._hover_button:
 
                 if self._hover_button:
@@ -9953,7 +9617,6 @@ class AuiManager(wx.EvtHandler):
                 event.Skip()
 
             self._hover_button = None
-
 
     def OnLeftUp_DragToolbarPane(self, eventOrPt):
         """
@@ -9993,7 +9656,6 @@ class AuiManager(wx.EvtHandler):
 
         pane.state &= ~AuiPaneInfo.actionPane
         self.Update()
-
 
     def OnPaneButton(self, event):
         """
@@ -10055,7 +9717,6 @@ class AuiManager(wx.EvtHandler):
             self.ProcessMgrEvent(e)
 
             if not e.GetVeto():
-
                 self.MaximizePane(pane)
                 self.Update()
 
@@ -10068,7 +9729,6 @@ class AuiManager(wx.EvtHandler):
             self.ProcessMgrEvent(e)
 
             if not e.GetVeto():
-
                 self.RestorePane(pane)
                 self.Update()
 
@@ -10083,7 +9743,6 @@ class AuiManager(wx.EvtHandler):
                 e = self.FireEvent(wxEVT_AUI_PANE_FLOATED, pane, canVeto=False)
 
             self.Update()
-
 
     def MinimizePane(self, paneInfo, mgrUpdate=True):
         """
@@ -10200,7 +9859,7 @@ class AuiManager(wx.EvtHandler):
                 target = paneInfo.name
 
             minimize_toolbar.AddSimpleTool(ID_RESTORE_FRAME, paneInfo.caption, restore_bitmap,
-                                           _(six.u("Restore %s"))%paneInfo.caption, target=target)
+                                           _(six.u("Restore %s")) % paneInfo.caption, target=target)
             minimize_toolbar.SetAuiManager(self)
             minimize_toolbar.Realize()
             toolpanelname = paneInfo.name + "_min"
@@ -10212,27 +9871,27 @@ class AuiManager(wx.EvtHandler):
 
                 if dockDirection == AUI_DOCK_TOP:
                     self.AddPane(minimize_toolbar, AuiPaneInfo(). \
-                        Name(toolpanelname).Caption(paneInfo.caption). \
-                        ToolbarPane().Top().BottomDockable(False). \
-                        LeftDockable(False).RightDockable(False).DestroyOnClose())
+                                 Name(toolpanelname).Caption(paneInfo.caption). \
+                                 ToolbarPane().Top().BottomDockable(False). \
+                                 LeftDockable(False).RightDockable(False).DestroyOnClose())
 
                 elif dockDirection == AUI_DOCK_BOTTOM:
                     self.AddPane(minimize_toolbar, AuiPaneInfo(). \
-                        Name(toolpanelname).Caption(paneInfo.caption). \
-                        ToolbarPane().Bottom().TopDockable(False). \
-                        LeftDockable(False).RightDockable(False).DestroyOnClose())
+                                 Name(toolpanelname).Caption(paneInfo.caption). \
+                                 ToolbarPane().Bottom().TopDockable(False). \
+                                 LeftDockable(False).RightDockable(False).DestroyOnClose())
 
                 elif dockDirection == AUI_DOCK_LEFT:
                     self.AddPane(minimize_toolbar, AuiPaneInfo(). \
-                        Name(toolpanelname).Caption(paneInfo.caption). \
-                        ToolbarPane().Left().TopDockable(False). \
-                        BottomDockable(False).RightDockable(False).DestroyOnClose())
+                                 Name(toolpanelname).Caption(paneInfo.caption). \
+                                 ToolbarPane().Left().TopDockable(False). \
+                                 BottomDockable(False).RightDockable(False).DestroyOnClose())
 
                 elif dockDirection in [AUI_DOCK_RIGHT, AUI_DOCK_CENTER]:
                     self.AddPane(minimize_toolbar, AuiPaneInfo(). \
-                        Name(toolpanelname).Caption(paneInfo.caption). \
-                        ToolbarPane().Right().TopDockable(False). \
-                        LeftDockable(False).BottomDockable(False).DestroyOnClose())
+                                 Name(toolpanelname).Caption(paneInfo.caption). \
+                                 ToolbarPane().Right().TopDockable(False). \
+                                 LeftDockable(False).BottomDockable(False).DestroyOnClose())
 
             arr = FindDocks(self._docks, paneInfo.dock_direction, paneInfo.dock_layer, paneInfo.dock_row)
 
@@ -10257,7 +9916,6 @@ class AuiManager(wx.EvtHandler):
                 if self._agwFlags & AUI_MGR_ANIMATE_FRAMES:
                     self.AnimateDocking(win_rect, minimize_toolbar.GetScreenRect())
 
-
     def OnRestoreMinimizedPane(self, event):
         """
         Handles the ``EVT_AUI_PANE_MIN_RESTORE`` event for :class:`AuiManager`.
@@ -10266,7 +9924,6 @@ class AuiManager(wx.EvtHandler):
         """
 
         self.RestoreMinimizedPane(event.pane)
-
 
     def OnPaneDocked(self, event):
         """
@@ -10277,7 +9934,6 @@ class AuiManager(wx.EvtHandler):
 
         event.Skip()
         self.RemoveAutoNBCaption(event.GetPane())
-
 
     def CreateNotebookBase(self, panes, paneInfo):
         """
@@ -10301,7 +9957,6 @@ class AuiManager(wx.EvtHandler):
         # add original pane as tab ...
         paneInfo.NotebookPage(nbid)
 
-
     def RemoveAutoNBCaption(self, pane):
         """
         Removes the caption on newly created automatic notebooks.
@@ -10324,7 +9979,6 @@ class AuiManager(wx.EvtHandler):
         # the caption a moment later
         wx.CallAfter(RemoveCaption)
         return True
-
 
     def RestoreMinimizedPane(self, paneInfo):
         """
@@ -10357,7 +10011,6 @@ class AuiManager(wx.EvtHandler):
             if not pane.IsMinimized():
                 return
 
-
             if pane.HasFlag(pane.wasMaximized):
                 self.SavePreviousDockSizes(pane)
 
@@ -10379,7 +10032,6 @@ class AuiManager(wx.EvtHandler):
                 paneInfo.Hide()
 
             self.Update()
-
 
     def AnimateDocking(self, win_rect, pane_rect):
         """
@@ -10405,10 +10057,10 @@ class AuiManager(wx.EvtHandler):
 
         step = self.GetAnimationStep()
 
-        wstep = int(abs(win_rect.width - pane_rect.width)/step)
-        hstep = int(abs(win_rect.height - pane_rect.height)/step)
-        xstep = int(win_rect.x - pane_rect.x)/step
-        ystep = int(win_rect.y - pane_rect.y)/step
+        wstep = int(abs(win_rect.width - pane_rect.width) // step)
+        hstep = int(abs(win_rect.height - pane_rect.height) // step)
+        xstep = int(win_rect.x - pane_rect.x) // step
+        ystep = int(win_rect.y - pane_rect.y) // step
 
         dc = wx.ScreenDC()
         dc.SetLogicalFunction(wx.INVERT)
@@ -10416,14 +10068,13 @@ class AuiManager(wx.EvtHandler):
         dc.SetPen(wx.LIGHT_GREY_PEN)
 
         for i in range(int(step)):
-            width, height = win_rect.width - i*wstep, win_rect.height - i*hstep
-            x, y = xstart - i*xstep, ystart - i*ystep
+            width, height = win_rect.width - i * wstep, win_rect.height - i * hstep
+            x, y = xstart - i * xstep, ystart - i * ystep
             new_rect = wx.Rect(x, y, width, height)
             dc.DrawRoundedRectangle(new_rect, 3)
             wx.SafeYield()
             wx.MilliSleep(10)
             dc.DrawRoundedRectangle(new_rect, 3)
-
 
     def SmoothDock(self, paneInfo):
         """
@@ -10448,20 +10099,19 @@ class AuiManager(wx.EvtHandler):
         xstart, ystart = win_rect.x, win_rect.y
         xend, yend = hint_rect.x, hint_rect.y
 
-        step = self.GetAnimationStep()/3
+        step = self.GetAnimationStep() // 3
 
-        wstep = int((win_rect.width - hint_rect.width)/step)
-        hstep = int((win_rect.height - hint_rect.height)/step)
-        xstep = int((win_rect.x - hint_rect.x))/step
-        ystep = int((win_rect.y - hint_rect.y))/step
+        wstep = int((win_rect.width - hint_rect.width) // step)
+        hstep = int((win_rect.height - hint_rect.height) // step)
+        xstep = int((win_rect.x - hint_rect.x)) // step
+        ystep = int((win_rect.y - hint_rect.y)) // step
 
         for i in range(int(step)):
-            width, height = win_rect.width - i*wstep, win_rect.height - i*hstep
-            x, y = xstart - i*xstep, ystart - i*ystep
+            width, height = win_rect.width - i * wstep, win_rect.height - i * hstep
+            x, y = xstart - i * xstep, ystart - i * ystep
             new_rect = wx.Rect(x, y, width, height)
             paneInfo.frame.SetRect(new_rect)
             wx.MilliSleep(10)
-
 
     def SetSnapLimits(self, x, y):
         """
@@ -10479,7 +10129,6 @@ class AuiManager(wx.EvtHandler):
 
         self._snap_limits = (x, y)
         self.Snap()
-
 
     def Snap(self):
         """
@@ -10500,7 +10149,6 @@ class AuiManager(wx.EvtHandler):
         if abs(snap_pos.x - wnd_pos.x) < snapX and abs(snap_pos.y - wnd_pos.y) < snapY:
             managed_window.SetPosition(snap_pos)
 
-
     def SnapToScreen(self, snap=True, monitor=0, hAlign=wx.RIGHT, vAlign=wx.TOP):
         """
         Snaps the main frame to specified position on the screen.
@@ -10517,11 +10165,10 @@ class AuiManager(wx.EvtHandler):
 
         displayCount = wx.Display.GetCount()
         if monitor > displayCount:
-            raise Exception("Invalid monitor selected: you only have %d monitors"%displayCount)
+            raise Exception("Invalid monitor selected: you only have %d monitors" % displayCount)
 
         self._is_docked = (True, hAlign, vAlign, monitor)
         self.GetManagedWindow().SetPosition(self.GetSnapPosition())
-
 
     def GetSnapPosition(self):
         """ Returns the main frame snapping position. """
@@ -10536,25 +10183,23 @@ class AuiManager(wx.EvtHandler):
         if hAlign == wx.LEFT:
             pos.x = area.x
         elif hAlign == wx.CENTER:
-            pos.x = area.x + (area.width - size.x)/2
+            pos.x = area.x + (area.width - size.x) // 2
         else:
             pos.x = area.x + area.width - size.x
 
         if vAlign == wx.TOP:
             pos.y = area.y
         elif vAlign == wx.CENTER:
-            pos.y = area.y + (area.height - size.y)/2
+            pos.y = area.y + (area.height - size.y) // 2
         else:
             pos.y = area.y + area.height - size.y
 
         return pos
 
-
     def GetAnimationStep(self):
         """ Returns the animation step speed (a float) to use in :meth:`AnimateDocking`. """
 
         return self._animation_step
-
 
     def SetAnimationStep(self, step):
         """
@@ -10564,7 +10209,6 @@ class AuiManager(wx.EvtHandler):
         """
 
         self._animation_step = float(step)
-
 
     def RequestUserAttention(self, pane_window):
         """
@@ -10593,7 +10237,6 @@ class AuiManager(wx.EvtHandler):
                 self._frame.RefreshRect(part.rect, True)
                 break
 
-
     def StartPreviewTimer(self, toolbar):
         """
         Starts a timer for sliding in and out a minimized pane.
@@ -10613,7 +10256,6 @@ class AuiManager(wx.EvtHandler):
 
         self._preview_timer.Start(1000, wx.TIMER_ONE_SHOT)
 
-
     def StopPreviewTimer(self):
         """ Stops a timer for sliding in and out a minimized pane. """
 
@@ -10622,7 +10264,6 @@ class AuiManager(wx.EvtHandler):
 
         self.SlideOut()
         self._sliding_pane = None
-
 
     def SlideIn(self, event):
         """
@@ -10636,7 +10277,7 @@ class AuiManager(wx.EvtHandler):
         window = self._sliding_pane.window
         self._sliding_frame = wx.MiniFrame(None, -1, title=_("Pane Preview"),
                                            style=wx.FRAME_TOOL_WINDOW | wx.STAY_ON_TOP |
-                                           wx.FRAME_NO_TASKBAR | wx.CAPTION)
+                                                 wx.FRAME_NO_TASKBAR | wx.CAPTION)
         window.Reparent(self._sliding_frame)
         self._sliding_frame.SetSize((0, 0))
         window.Show()
@@ -10646,7 +10287,7 @@ class AuiManager(wx.EvtHandler):
 
         startX, startY, stopX, stopY = GetSlidingPoints(self._sliding_rect, size, self._sliding_direction)
 
-        step = stopX/10
+        step = stopX // 10
         window_size = 0
 
         for i in range(0, stopX, step):
@@ -10659,7 +10300,6 @@ class AuiManager(wx.EvtHandler):
         self._sliding_frame.SetSize(startX, startY, stopX, stopY)
         self._sliding_frame.Refresh()
         self._sliding_frame.Update()
-
 
     def SlideOut(self):
         """
@@ -10676,7 +10316,7 @@ class AuiManager(wx.EvtHandler):
 
         startX, startY, stopX, stopY = GetSlidingPoints(self._sliding_rect, size, self._sliding_direction)
 
-        step = stopX/10
+        step = stopX // 10
         window_size = 0
 
         for i in range(stopX, 0, -step):
@@ -10684,7 +10324,7 @@ class AuiManager(wx.EvtHandler):
             self._sliding_frame.SetSize(startX, startY, window_size, stopY)
             self._sliding_frame.Refresh()
             self._sliding_frame.Update()
-            self._frame.RefreshRect(wx.Rect(startX+window_size, startY, step, stopY))
+            self._frame.RefreshRect(wx.Rect(startX + window_size, startY, step, stopY))
             self._frame.Update()
             wx.MilliSleep(10)
 
@@ -10712,7 +10352,6 @@ class AuiManager_DCP(AuiManager):
         AuiManager.__init__(self, *args, **keys)
         self.hasDummyPane = False
 
-
     def _createDummyPane(self):
         """ Creates a Dummy Center Pane (**DCP**). """
 
@@ -10724,7 +10363,6 @@ class AuiManager_DCP(AuiManager):
         info = AuiPaneInfo().CenterPane().NotebookDockable(True).Name('dummyCenterPane').DestroyOnClose(True)
         self.AddPane(dummy, info)
 
-
     def _destroyDummyPane(self):
         """ Destroys the Dummy Center Pane (**DCP**). """
 
@@ -10733,7 +10371,6 @@ class AuiManager_DCP(AuiManager):
 
         self.hasDummyPane = False
         self.ClosePane(self.GetPane('dummyCenterPane'))
-
 
     def Update(self):
         """
@@ -10759,6 +10396,7 @@ class AuiManager_DCP(AuiManager):
                 def do():
                     self._destroyDummyPane()
                     self.Update()
+
                 wx.CallAfter(do)
         else:
             # if we get here, there's no center pane, create our dummy
@@ -10766,4 +10404,5 @@ class AuiManager_DCP(AuiManager):
                 def do():
                     self._createDummyPane()
                     self.Update()
+
                 wx.CallAfter(do)

--- a/wx/lib/agw/aui/tabart.py
+++ b/wx/lib/agw/aui/tabart.py
@@ -301,13 +301,13 @@ class AuiDefaultTabArt(object):
             tot_width -= self._active_windowlist_bmp.GetWidth()
 
         if tab_count > 0:
-            self._fixed_tab_width = tot_width/tab_count
+            self._fixed_tab_width = tot_width//tab_count
 
         if self._fixed_tab_width < 100:
             self._fixed_tab_width = 100
 
-        if self._fixed_tab_width > tot_width/2:
-            self._fixed_tab_width = tot_width/2
+        if self._fixed_tab_width > tot_width//2:
+            self._fixed_tab_width = tot_width//2
 
         if self._fixed_tab_width > 220:
             self._fixed_tab_width = 220
@@ -474,7 +474,7 @@ class AuiDefaultTabArt(object):
             dc.DrawPoint(r.x+r.width-2, r.y+1)
 
             # set rectangle down a bit for gradient drawing
-            r.SetHeight(r.GetHeight()/2)
+            r.SetHeight(r.GetHeight()//2)
             r.x += 2
             r.width -= 2
             r.y += r.height
@@ -497,7 +497,7 @@ class AuiDefaultTabArt(object):
             r.x += 3
             r.y += 1
             r.width -= 4
-            r.height /= 2
+            r.height //= 2
             r.height -= 1
 
             # -- draw top gradient fill for glossy look
@@ -555,7 +555,7 @@ class AuiDefaultTabArt(object):
             # draw bitmap
             dc.DrawBitmap(pagebitmap,
                           bitmap_offset,
-                          drawn_tab_yoff + (drawn_tab_height/2) - (pagebitmap.GetHeight()/2),
+                          drawn_tab_yoff + (drawn_tab_height//2) - (pagebitmap.GetHeight()//2),
                           True)
 
             text_offset = bitmap_offset + pagebitmap.GetWidth()
@@ -568,7 +568,7 @@ class AuiDefaultTabArt(object):
 
         draw_text = ChopText(dc, caption, tab_width - (text_offset-tab_x) - close_button_width)
 
-        ypos = drawn_tab_yoff + (drawn_tab_height)/2 - (texty/2) - 1
+        ypos = drawn_tab_yoff + (drawn_tab_height)//2 - (texty//2) - 1
 
         offset_focus = text_offset
         if control:
@@ -609,11 +609,11 @@ class AuiDefaultTabArt(object):
             shift = (agwFlags & AUI_NB_BOTTOM and [1] or [0])[0]
 
             if agwFlags & AUI_NB_CLOSE_ON_TAB_LEFT:
-                rect = wx.Rect(tab_x + 4, tab_y + (tab_height - bmp.GetHeight())/2 - shift,
+                rect = wx.Rect(tab_x + 4, tab_y + (tab_height - bmp.GetHeight())//2 - shift,
                                close_button_width, tab_height)
             else:
                 rect = wx.Rect(tab_x + tab_width - close_button_width - 1,
-                               tab_y + (tab_height - bmp.GetHeight())/2 - shift,
+                               tab_y + (tab_height - bmp.GetHeight())//2 - shift,
                                close_button_width, tab_height)
 
             rect = IndentPressedBitmap(rect, close_button_state)
@@ -777,14 +777,14 @@ class AuiDefaultTabArt(object):
         if orientation == wx.LEFT:
 
             rect.SetX(in_rect.x)
-            rect.SetY(((in_rect.y + in_rect.height)/2) - (bmp.GetHeight()/2))
+            rect.SetY(((in_rect.y + in_rect.height)//2) - (bmp.GetHeight()//2))
             rect.SetWidth(bmp.GetWidth())
             rect.SetHeight(bmp.GetHeight())
 
         else:
 
             rect = wx.Rect(in_rect.x + in_rect.width - bmp.GetWidth(),
-                           ((in_rect.y + in_rect.height)/2) - (bmp.GetHeight()/2),
+                           ((in_rect.y + in_rect.height)//2) - (bmp.GetHeight()//2),
                            bmp.GetWidth(), bmp.GetHeight())
 
         rect = IndentPressedBitmap(rect, button_state)
@@ -819,11 +819,11 @@ class AuiDefaultTabArt(object):
 
         if page.active and wx.Window.FindFocus() == wnd:
 
-            focusRectText = wx.Rect(text_offset, (drawn_tab_yoff + (drawn_tab_height)/2 - (texty/2)),
+            focusRectText = wx.Rect(text_offset, (drawn_tab_yoff + (drawn_tab_height)//2 - (texty//2)),
                                     textx, texty)
 
             if page.bitmap.IsOk():
-                focusRectBitmap = wx.Rect(bitmap_offset, drawn_tab_yoff + (drawn_tab_height/2) - (page.bitmap.GetHeight()/2),
+                focusRectBitmap = wx.Rect(bitmap_offset, drawn_tab_yoff + (drawn_tab_height//2) - (page.bitmap.GetHeight()//2),
                                           page.bitmap.GetWidth(), page.bitmap.GetHeight())
 
             if page.bitmap.IsOk() and draw_text == "":
@@ -1110,13 +1110,13 @@ class AuiSimpleTabArt(object):
             tot_width -= self._active_windowlist_bmp.GetWidth()
 
         if tab_count > 0:
-            self._fixed_tab_width = tot_width/tab_count
+            self._fixed_tab_width = tot_width//tab_count
 
         if self._fixed_tab_width < 100:
             self._fixed_tab_width = 100
 
-        if self._fixed_tab_width > tot_width/2:
-            self._fixed_tab_width = tot_width/2
+        if self._fixed_tab_width > tot_width//2:
+            self._fixed_tab_width = tot_width//2
 
         if self._fixed_tab_width > 220:
             self._fixed_tab_width = 220
@@ -1238,23 +1238,23 @@ class AuiSimpleTabArt(object):
             close_button_width = self._active_close_bmp.GetWidth()
             if agwFlags & AUI_NB_CLOSE_ON_TAB_LEFT:
                 if control:
-                    text_offset = tab_x + (tab_height/2) + close_button_width - (textx/2) - 2
+                    text_offset = tab_x + (tab_height//2) + close_button_width - (textx//2) - 2
                 else:
-                    text_offset = tab_x + (tab_height/2) + ((tab_width+close_button_width)/2) - (textx/2) - 2
+                    text_offset = tab_x + (tab_height//2) + ((tab_width+close_button_width)//2) - (textx//2) - 2
             else:
                 if control:
-                    text_offset = tab_x + (tab_height/2) + close_button_width - (textx/2)
+                    text_offset = tab_x + (tab_height//2) + close_button_width - (textx//2)
                 else:
-                    text_offset = tab_x + (tab_height/2) + ((tab_width-close_button_width)/2) - (textx/2)
+                    text_offset = tab_x + (tab_height//2) + ((tab_width-close_button_width)//2) - (textx//2)
 
         else:
 
-            text_offset = tab_x + (tab_height/3) + (tab_width/2) - (textx/2)
+            text_offset = tab_x + (tab_height//3) + (tab_width//2) - (textx//2)
             if control:
                 if agwFlags & AUI_NB_CLOSE_ON_TAB_LEFT:
-                    text_offset = tab_x + (tab_height/3) - (textx/2) + close_button_width + 2
+                    text_offset = tab_x + (tab_height//3) - (textx//2) + close_button_width + 2
                 else:
-                    text_offset = tab_x + (tab_height/3) - (textx/2)
+                    text_offset = tab_x + (tab_height//3) - (textx//2)
 
         # set minimum text offset
         if text_offset < tab_x + tab_height:
@@ -1267,7 +1267,7 @@ class AuiSimpleTabArt(object):
             draw_text = ChopText(dc, caption,
                                  tab_width - (text_offset-tab_x) - close_button_width)
 
-        ypos = (tab_y + tab_height)/2 - (texty/2) + 1
+        ypos = (tab_y + tab_height)//2 - (texty//2) + 1
 
         if control:
             if control.GetPosition() != wx.Point(text_offset+1, ypos):
@@ -1290,7 +1290,7 @@ class AuiSimpleTabArt(object):
         # draw focus rectangle
         if page.active and wx.Window.FindFocus() == wnd and (agwFlags & AUI_NB_NO_TAB_FOCUS) == 0:
 
-            focusRect = wx.Rect(text_offset, ((tab_y + tab_height)/2 - (texty/2) + 1),
+            focusRect = wx.Rect(text_offset, ((tab_y + tab_height)//2 - (texty//2) + 1),
                                 selected_textx, selected_texty)
 
             focusRect.Inflate(2, 2)
@@ -1310,11 +1310,11 @@ class AuiSimpleTabArt(object):
 
             if agwFlags & AUI_NB_CLOSE_ON_TAB_LEFT:
                 rect = wx.Rect(tab_x + tab_height - 2,
-                               tab_y + (tab_height/2) - (bmp.GetHeight()/2) + 1,
+                               tab_y + (tab_height//2) - (bmp.GetHeight()//2) + 1,
                                close_button_width, tab_height - 1)
             else:
                 rect = wx.Rect(tab_x + tab_width - close_button_width - 1,
-                               tab_y + (tab_height/2) - (bmp.GetHeight()/2) + 1,
+                               tab_y + (tab_height//2) - (bmp.GetHeight()//2) + 1,
                                close_button_width, tab_height - 1)
 
             self.DrawButtons(dc, rect, bmp, wx.WHITE, close_button_state)
@@ -1389,7 +1389,7 @@ class AuiSimpleTabArt(object):
             controlW, controlH = control.GetSize()
             tab_width += controlW + 4
 
-        x_extent = tab_width - (tab_height/2) - 1
+        x_extent = tab_width - (tab_height//2) - 1
 
         return (tab_width, tab_height), x_extent
 
@@ -1445,14 +1445,14 @@ class AuiSimpleTabArt(object):
         if orientation == wx.LEFT:
 
             rect.SetX(in_rect.x)
-            rect.SetY(((in_rect.y + in_rect.height)/2) - (bmp.GetHeight()/2))
+            rect.SetY(((in_rect.y + in_rect.height)//2) - (bmp.GetHeight()//2))
             rect.SetWidth(bmp.GetWidth())
             rect.SetHeight(bmp.GetHeight())
 
         else:
 
             rect = wx.Rect(in_rect.x + in_rect.width - bmp.GetWidth(),
-                           ((in_rect.y + in_rect.height)/2) - (bmp.GetHeight()/2),
+                           ((in_rect.y + in_rect.height)//2) - (bmp.GetHeight()//2),
                            bmp.GetWidth(), bmp.GetHeight())
 
         self.DrawButtons(dc, rect, bmp, wx.WHITE, button_state)
@@ -1753,7 +1753,7 @@ class VC71TabArt(AuiDefaultTabArt):
 
             # draw bitmap
             dc.DrawBitmap(pagebitmap, bitmap_offset,
-                          drawn_tab_yoff + (drawn_tab_height/2) - (pagebitmap.GetHeight()/2) + shift,
+                          drawn_tab_yoff + (drawn_tab_height//2) - (pagebitmap.GetHeight()//2) + shift,
                           True)
 
             text_offset = bitmap_offset + pagebitmap.GetWidth()
@@ -1778,7 +1778,7 @@ class VC71TabArt(AuiDefaultTabArt):
 
         draw_text = ChopText(dc, caption, tab_width - (text_offset-tab_x) - close_button_width)
 
-        ypos = drawn_tab_yoff + (drawn_tab_height)/2 - (texty/2) - 1 + shift
+        ypos = drawn_tab_yoff + (drawn_tab_height)//2 - (texty//2) - 1 + shift
 
         offset_focus = text_offset
 
@@ -1821,11 +1821,11 @@ class VC71TabArt(AuiDefaultTabArt):
 
             if agwFlags & AUI_NB_CLOSE_ON_TAB_LEFT:
                 rect = wx.Rect(tab_x + 4,
-                               drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2) + shift,
+                               drawn_tab_yoff + (drawn_tab_height // 2) - (bmp.GetHeight() // 2) + shift,
                                close_button_width, tab_height)
             else:
                 rect = wx.Rect(tab_x + tab_width - close_button_width - 3,
-                               drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2) + shift,
+                               drawn_tab_yoff + (drawn_tab_height // 2) - (bmp.GetHeight() // 2) + shift,
                                close_button_width, tab_height)
 
             # Indent the button if it is pressed down:
@@ -1988,7 +1988,7 @@ class FF2TabArt(AuiDefaultTabArt):
 
             # draw bitmap
             dc.DrawBitmap(pagebitmap, bitmap_offset,
-                          drawn_tab_yoff + (drawn_tab_height/2) - (pagebitmap.GetHeight()/2) + shift,
+                          drawn_tab_yoff + (drawn_tab_height//2) - (pagebitmap.GetHeight()//2) + shift,
                           True)
 
             text_offset = bitmap_offset + pagebitmap.GetWidth()
@@ -2016,7 +2016,7 @@ class FF2TabArt(AuiDefaultTabArt):
         else:
             draw_text = ChopText(dc, caption, tab_width - (text_offset-tab_x) - close_button_width)
 
-        ypos = drawn_tab_yoff + drawn_tab_height/2 - texty/2 - 1 + shift
+        ypos = drawn_tab_yoff + drawn_tab_height//2 - texty//2 - 1 + shift
 
         offset_focus = text_offset
 
@@ -2058,11 +2058,11 @@ class FF2TabArt(AuiDefaultTabArt):
 
             if agwFlags & AUI_NB_CLOSE_ON_TAB_LEFT:
                 rect = wx.Rect(tab_x + 5,
-                               drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2) + shift,
+                               drawn_tab_yoff + (drawn_tab_height // 2) - (bmp.GetHeight() // 2) + shift,
                                close_button_width, tab_height)
             else:
                 rect = wx.Rect(tab_x + tab_width - close_button_width - 3,
-                               drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2) + shift,
+                               drawn_tab_yoff + (drawn_tab_height // 2) - (bmp.GetHeight() // 2) + shift,
                                close_button_width, tab_height)
 
             # Indent the button if it is pressed down:
@@ -2093,14 +2093,14 @@ class FF2TabArt(AuiDefaultTabArt):
 
         if focus:
             if upperTabs:
-                leftPt = wx.Point(rect.x, rect.y + (rect.height / 10)*8)
-                rightPt = wx.Point(rect.x + rect.width - 2, rect.y + (rect.height / 10)*8)
+                leftPt = wx.Point(rect.x, rect.y + (rect.height // 10)*8)
+                rightPt = wx.Point(rect.x + rect.width - 2, rect.y + (rect.height // 10)*8)
             else:
-                leftPt = wx.Point(rect.x, rect.y + (rect.height / 10)*5)
-                rightPt = wx.Point(rect.x + rect.width - 2, rect.y + (rect.height / 10)*5)
+                leftPt = wx.Point(rect.x, rect.y + (rect.height // 10)*5)
+                rightPt = wx.Point(rect.x + rect.width - 2, rect.y + (rect.height // 10)*5)
         else:
-            leftPt = wx.Point(rect.x, rect.y + (rect.height / 2))
-            rightPt = wx.Point(rect.x + rect.width - 2, rect.y + (rect.height / 2))
+            leftPt = wx.Point(rect.x, rect.y + (rect.height // 2))
+            rightPt = wx.Point(rect.x + rect.width - 2, rect.y + (rect.height // 2))
 
         # Define the top region
         top = wx.Rect(rect.GetTopLeft(), rightPt)
@@ -2324,7 +2324,7 @@ class VC8TabArt(AuiDefaultTabArt):
 
             # draw bitmap
             dc.DrawBitmap(pagebitmap, bitmap_offset,
-                          drawn_tab_yoff + (drawn_tab_height/2) - (pagebitmap.GetHeight()/2) + shift,
+                          drawn_tab_yoff + (drawn_tab_height//2) - (pagebitmap.GetHeight()//2) + shift,
                           True)
 
             text_offset = bitmap_offset + pagebitmap.GetWidth()
@@ -2351,7 +2351,7 @@ class VC8TabArt(AuiDefaultTabArt):
         else:
             draw_text = ChopText(dc, caption, tab_width - (text_offset-tab_x) - close_button_width)
 
-        ypos = drawn_tab_yoff + drawn_tab_height/2 - texty/2 - 1 + shift
+        ypos = drawn_tab_yoff + drawn_tab_height//2 - texty//2 - 1 + shift
 
         offset_focus = text_offset
 
@@ -2398,11 +2398,11 @@ class VC8TabArt(AuiDefaultTabArt):
 
             if agwFlags & AUI_NB_CLOSE_ON_TAB_LEFT:
                 rect = wx.Rect(tab_x + 20,
-                               drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2) + shift,
+                               drawn_tab_yoff + (drawn_tab_height // 2) - (bmp.GetHeight() // 2) + shift,
                                close_button_width, tab_height)
             else:
                 rect = wx.Rect(xpos,
-                               drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2) + shift,
+                               drawn_tab_yoff + (drawn_tab_height // 2) - (bmp.GetHeight() // 2) + shift,
                                close_button_width, tab_height)
 
             # Indent the button if it is pressed down:
@@ -2686,7 +2686,7 @@ class ChromeTabArt(AuiDefaultTabArt):
 
             # draw bitmap
             dc.DrawBitmap(pagebitmap, bitmap_offset,
-                          drawn_tab_yoff + (drawn_tab_height/2) - (pagebitmap.GetHeight()/2),
+                          drawn_tab_yoff + (drawn_tab_height//2) - (pagebitmap.GetHeight()//2),
                           True)
 
             text_offset = bitmap_offset + pagebitmap.GetWidth()
@@ -2714,7 +2714,7 @@ class ChromeTabArt(AuiDefaultTabArt):
         else:
             draw_text = ChopText(dc, caption, tab_width - (text_offset-tab_x) - close_button_width - leftw)
 
-        ypos = drawn_tab_yoff + drawn_tab_height/2 - texty/2 - 1
+        ypos = drawn_tab_yoff + drawn_tab_height//2 - texty//2 - 1
 
         if control:
             if control.GetPosition() != wx.Point(text_offset+1, ypos):
@@ -2748,11 +2748,11 @@ class ChromeTabArt(AuiDefaultTabArt):
 
             if agwFlags & AUI_NB_CLOSE_ON_TAB_LEFT:
                 rect = wx.Rect(tab_x + leftw - 2,
-                               drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2) + 1,
+                               drawn_tab_yoff + (drawn_tab_height // 2) - (bmp.GetHeight() // 2) + 1,
                                close_button_width, tab_height)
             else:
                 rect = wx.Rect(tab_x + tab_width - close_button_width - rightw + 2,
-                               drawn_tab_yoff + (drawn_tab_height / 2) - (bmp.GetHeight() / 2) + 1,
+                               drawn_tab_yoff + (drawn_tab_height // 2) - (bmp.GetHeight() // 2) + 1,
                                close_button_width, tab_height)
 
             if agwFlags & AUI_NB_BOTTOM:


### PR DESCRIPTION
wx.lib.agw.aui was never converted to run on Python 3 and as a result the division operator forces a conversion of the used values to a float. Floats cannot be used in functions like `range`. This caused quite number of things to not function properly and produce tracebacks.

The other thing is when wx.lib.agw.aui was written pixels could not be rendered using coordinates that were floats so now passing floats could cause rendering alignment problems because the layout of the various bits were done so in a manner that would have the alignment correct using integers.

Fixes #1881
Fixes #1885

This does not fix the application crash that is caused by setting AuiPaneInfo.FlyOut to `True`. That problem is caused by something internal to wxTimer 

