### PR TITLE
Add support for building with SIP v6

### DIFF
--- a/buildtools/wxpysip.py
+++ b/buildtools/wxpysip.py
@@ -62,8 +62,12 @@ def sip_runner(
         abi_major, abi_minor = resolve_abi_version(abi_version).split('.')
 
         # Set the globals.
-        set_globals(SIP_VERSION, SIP_VERSION_STR, int(abi_major), int(abi_minor),
-                UserException, include_dirs)
+        if (SIP_VERSION >> 16) >= 6:
+            set_globals(SIP_VERSION, SIP_VERSION_STR, int(abi_major), int(abi_minor),
+                    sip_module, UserException, include_dirs)
+        else:
+            set_globals(SIP_VERSION, SIP_VERSION_STR, int(abi_major), int(abi_minor),
+                    UserException, include_dirs)
 
         # Parse the input file.
         pt, _, _, _, tags, disabled_features = parse(specification,
@@ -72,9 +76,14 @@ def sip_runner(
 
         # Generate the bindings.
         if sources_dir is not None:
-            generated_files = generateCode(pt, sources_dir, source_suffix,
-                    exceptions, tracing, release_gil, parts, tags,
-                    disabled_features, docstrings, py_debug, sip_module)
+            if (SIP_VERSION >> 16) >= 6:
+                generated_files = generateCode(pt, sources_dir, source_suffix,
+                        exceptions, tracing, release_gil, parts, tags,
+                        disabled_features, docstrings, py_debug)
+            else:
+                generated_files = generateCode(pt, sources_dir, source_suffix,
+                        exceptions, tracing, release_gil, parts, tags,
+                        disabled_features, docstrings, py_debug, sip_module)
 
         if sbf_file is not None:
             generateBuildFile(sbf_file, generated_files)


### PR DESCRIPTION
SIP v6 [was released this month][1], and it is what users now get when installing [`sip` package][2] from PyPI.

In SIP v6, `sipName` argument was removed from `generateCode` function and added to `set_globals`. See [this changeset][3].

`SIP_VERSION` is a number like 0xABCDE, where 0xA is the major version, 0xBC — minor version, 0xDE — patch version (so for SIP 6.0.0 it is 0x60000, for sip 5.5.0 it is 0x50500). So by calling `SIP_VERSION >> 16` we get the major version.

[1]: https://riverbankcomputing.com/news/SIP_v6.0.0_Released
[2]: https://pypi.org/project/sip/
[3]: https://riverbankcomputing.com/hg/sip/rev/a16b972e11a1