### PR TITLE
Fix regression in auibar introduced in last commit

### DIFF
--- a/wx/lib/agw/aui/auibar.py
+++ b/wx/lib/agw/aui/auibar.py
@@ -3257,6 +3257,9 @@ class AuiToolBar(wx.Control):
     def DoIdleUpdate(self):
         """ Updates the toolbar during idle times. """
 
+        if not self:
+            return # The action Destroyed the toolbar!
+
         handler = self.GetEventHandler()
         if not handler:
             return


### PR DESCRIPTION
This PR is identical to PR #1857 (merged in commit e059ec1a). The reason we need his PR again is that the bug fix in PR #1857 was inadvertently undone by commit  e32ba711.
