### PR TITLE
Correct typo in eventwatcher.py

### DIFF
--- a/wx/lib/eventwatcher.py
+++ b/wx/lib/eventwatcher.py
@@ -250,7 +250,7 @@ class EventChooser(wx.Panel):
         self.doUpdate = False
         for position in range(self.lb.GetCount()):
             self.lb.Check(position, True)
-            index = self.lb.GetCliendData(position)
+            index = self.lb.GetClientData(position)
             self.watchList[index] = (self.watchList[index][0], check)
         self.lb.Refresh()
         self.doUpdate = True


### PR DESCRIPTION
I noticed a typo when using the bundled eventwatcher in the demos. I think this should be correct

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

