### PR TITLE
Calculate Scroll based on Childs relative position to ScrolledPanel

### DIFF
--- a/wx/lib/scrolledpanel.py
+++ b/wx/lib/scrolledpanel.py
@@ -186,8 +186,8 @@ class ScrolledPanel(wx.ScrolledWindow):
             is the ScrolledPanel itself.
         """
         cr = child.GetScreenRect()
-        spr = self.GetScreenPosition()
-        return wx.Rect(cr.x - spr.x, cr.y - spr.y, cr.width, cr.height)
+        spp = self.GetScreenPosition()
+        return wx.Rect(cr.x - spp.x, cr.y - spp.y, cr.width, cr.height)
 
 
     def ScrollChildIntoView(self, child):

--- a/wx/lib/scrolledpanel.py
+++ b/wx/lib/scrolledpanel.py
@@ -173,6 +173,23 @@ class ScrolledPanel(wx.ScrolledWindow):
             evt.Skip()
 
 
+    def GetChildRectRelativeToSelf(self, child: wx.Window):
+        """
+        Same as `child.GetRect()` except the position returned is relative
+        to this ScrolledPanel rather than the child's parent.
+
+        :param wx.Window `child`: any :class:`wx.Window` - derived control.
+
+        .. note:: window.GetRect returns the size of a window, and its position
+            relative to its parent. When calculating ScrollChildIntoView, the
+            position relative to its parent is not relevant unless the parent 
+            is the ScrolledPanel itself.
+        """
+        cr = child.GetScreenRect()
+        spr = self.GetScreenPosition()
+        return wx.Rect(cr.x - spr.x, cr.y - spr.y, cr.width, cr.height)
+
+
     def ScrollChildIntoView(self, child):
         """
         Scroll the panel so that the specified child window is in view.
@@ -187,7 +204,7 @@ class ScrolledPanel(wx.ScrolledWindow):
 
         sppu_x, sppu_y = self.GetScrollPixelsPerUnit()
         vs_x, vs_y   = self.GetViewStart()
-        cr = child.GetRect()
+        cr = self.GetChildRectRelativeToSelf(child)
         clntsz = self.GetClientSize()
         new_vs_x, new_vs_y = -1, -1
 


### PR DESCRIPTION
`ScrolledPanel`s do not automatically scroll via tabbing if the focused control is not a direct child of the `ScrolledPanel`

Instead of using `child.GetRect()`, which calculates the position relative to the parent, calculate the position of the `child` relative to the `ScrolledPanel` itself. 