### PR TITLE
Fix regression in aui framemanager introduced in last commit

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -9324,6 +9324,8 @@ class AuiManager(wx.EvtHandler):
         if pane.IsFloating():
             diff = pane.floating_pos - (screenPt - self._action_offset)
             pane.floating_pos = screenPt - self._action_offset
+        else:
+            diff = wx.Point()
 
         framePos = pane.floating_pos
 


### PR DESCRIPTION
This PR is identical to PR #1873 (merged in commit d0577746) ). The reason we need his PR again is that the bug fix in PR #1873 was inadvertently undone by commit 2760cbe0.


Notice that this PR is similar to but distinct from PR #1931 which addresses a different regression that was introduced at the same time.


