### PR TITLE
WXMSW: use HandleToLong/LongToHandle functions.

### DIFF
--- a/etg/bitmap.py
+++ b/etg/bitmap.py
@@ -106,7 +106,7 @@ def run():
         doc='MSW-only method to fetch the windows handle for the bitmap.',
         body="""\
             #ifdef __WXMSW__
-                return (long)self->GetHandle();
+                return HandleToLong(self->GetHandle());
             #else
                 return 0;
             #endif
@@ -116,7 +116,7 @@ def run():
         doc='MSW-only method to set the windows handle for the bitmap.',
         body="""\
             #ifdef __WXMSW__
-                self->SetHandle((WXHANDLE)handle);
+                self->SetHandle((WXHANDLE)LongToHandle(handle));
             #endif
             """)
 

--- a/etg/cursor.py
+++ b/etg/cursor.py
@@ -51,7 +51,7 @@ def run():
 
     c.addCppMethod('long', 'GetHandle', '()', """\
     #ifdef __WXMSW__
-        return (long)self->GetHandle();
+        return HandleToLong(self->GetHandle());
     #else
         return 0;
     #endif""",
@@ -59,7 +59,7 @@ def run():
 
     c.addCppMethod('void', 'SetHandle', '(long handle)', """\
     #ifdef __WXMSW__
-        self->SetHandle((WXHANDLE)handle);
+        self->SetHandle((WXHANDLE)LongToHandle(handle));
     #endif""",
     briefDoc="Set the handle to use for this Cursor.  Windows only.")
 

--- a/etg/dataview.py
+++ b/etg/dataview.py
@@ -82,7 +82,7 @@ def run():
 
     c.addCppMethod('int', '__nonzero__', '()', "return self->IsOk();")
     c.addCppMethod('int', '__bool__', '()', "return self->IsOk();")
-    c.addCppMethod('long', '__hash__', '()', "return (long)self->GetID();")
+    c.addCppMethod('long', '__hash__', '()', "return (long)(intptr_t)self->GetID();")
 
     c.addCppMethod('bool', '__eq__', '(wxDataViewItem* other)',
                    "return other ? (self->GetID() == other->GetID()) : false;")

--- a/etg/dc.py
+++ b/etg/dc.py
@@ -257,7 +257,7 @@ def run():
 
     c.addCppMethod('long', 'GetHDC', '()', """\
         #ifdef __WXMSW__
-            return (long)self->GetHandle();
+            return HandleToLong(self->GetHandle());
         #else
             wxPyRaiseNotImplemented();
             return 0;

--- a/etg/icon.py
+++ b/etg/icon.py
@@ -56,7 +56,7 @@ def run():
 
     c.addCppMethod('long', 'GetHandle', '()', """\
         #ifdef __WXMSW__
-            return (long)self->GetHandle();
+            return HandleToLong(self->GetHandle());
         #else
             return 0;
         #endif
@@ -64,7 +64,7 @@ def run():
 
     c.addCppMethod('void', 'SetHandle', '(long handle)', """\
         #ifdef __WXMSW__
-            self->SetHandle((WXHANDLE)handle);
+            self->SetHandle((WXHANDLE)LongToHandle(handle));
         #endif
         """)
 
@@ -73,7 +73,7 @@ def run():
         doc='MSW-only method to create a wx.Icon from a native icon handle.',
         body="""\
             #ifdef __WXMSW__
-                return self->CreateFromHICON((WXHICON)hicon);
+                return self->CreateFromHICON((WXHICON)LongToHandle(hicon));
             #else
                 return false;
             #endif

--- a/etg/treelist.py
+++ b/etg/treelist.py
@@ -47,7 +47,7 @@ def run():
     c.addCppMethod('int', '__bool__', '()', "return self->IsOk();")
 
     c.addCppMethod('long', '__hash__', '()', """\
-        return (long)self->GetID();
+        return (long)(intptr_t)self->GetID();
         """)
 
     c.addCppMethod('bool', '__eq__', '(wxTreeListItem* other)',


### PR DESCRIPTION
On Clang++, casting from a pointer to an integer of a smaller size is
considered an error.  In cases where Windows HANDLEs are converted
to/from longs, use the Windows-provided conversion functions
HandleToLong and LongToHandle.

In a couple of cases, a pointer is being cast to long in a `__hash__`
function.  These don't seem Windows-specific so it is not safe to assume
the Windows conversion functions are present.  In those cases, fall back
to the (ugly) double-casting that the Windows functions contain.

Fixes #1971 

