### PR TITLE
Fix position calculations to keep tooltip onscreen

### DIFF
--- a/wx/lib/agw/supertooltip.py
+++ b/wx/lib/agw/supertooltip.py
@@ -682,18 +682,22 @@ class ToolTipWindowBase(object):
 
 
     def CalculateBestPosition(self,widget):
+        x, y = wx.GetMousePosition()
         screen = wx.ClientDisplayRect()[2:]
-        left,top = widget.ClientToScreen((0, 0))
-        right,bottom = widget.ClientToScreen(widget.GetClientRect()[2:])
+        left, top = widget.ClientToScreen((0, 0))
+        right, bottom = widget.ClientToScreen(widget.GetClientRect()[2:])
         size = self.GetSize()
-        if right+size[0]>screen[0]:
-            xpos = left-size[0]
+
+        if x+size[0]>screen[0]:
+            xpos = x-size[0]
         else:
-            xpos = right
+            xpos = x
+
         if bottom+size[1]>screen[1]:
-            ypos = top-size[1]
+            ypos = top-size[1] + 6
         else:
-            ypos = bottom
+            ypos = bottom + 6
+
         self.SetPosition((xpos,ypos))
 
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Before this PR, the tooltip would go offscreen if it was near the edge of the screen. It also now calculates based on the mouse cursor position, which is better IMO.

