### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,7 +19,7 @@ Pip:    ``pip install wxPython==4.1.2``
 New and improved in this release:
 
 * Tweaked the build scripts a bit to ensure that on non-Windows platforms that
-  the complier and flags used by default match those used by wxWidgets, (with
+  the compiler and flags used by default match those used by wxWidgets, (with
   the flags needed by Python added on.) The compiler commands can be overridden
   by setting CC and CXX in the environment if needed. (#1247)
 

--- a/build.py
+++ b/build.py
@@ -1735,7 +1735,7 @@ def cmd_build_docker(options, args):
 
     # TODO: Instead of the simple options.gtk2 test above, do something like the
     # following to select both. But currently if gtk2 is selected then
-    # options.gtk3 is explicity set to False... That needs to be made a little
+    # options.gtk3 is explicitly set to False... That needs to be made a little
     # smarter.
     # if options.gtk2 and options.gtk3:
     #     cmd.extend(['--port', 'all'])

--- a/buildbot/master.cfg
+++ b/buildbot/master.cfg
@@ -68,7 +68,7 @@ c['protocols'] = {'pb': {'port': WORKER_PORT}}
 # about source code changes.
 
 # NOTE: Instead of using the usual GitPoller here, the BB web server has been
-# configured to recieve webhooks from GitHub. See below for the 'www'
+# configured to receive webhooks from GitHub. See below for the 'www'
 # configuration settings.
 
 # c['change_source'] = []

--- a/buildtools/backports/pathlib2/scandir.py
+++ b/buildtools/backports/pathlib2/scandir.py
@@ -168,7 +168,7 @@ if sys.platform == 'win32':
         ERROR_NO_MORE_FILES = 18
         IO_REPARSE_TAG_SYMLINK = 0xA000000C
 
-        # Numer of seconds between 1601-01-01 and 1970-01-01
+        # Number of seconds between 1601-01-01 and 1970-01-01
         SECONDS_BETWEEN_EPOCHS = 11644473600
 
         kernel32 = ctypes.windll.kernel32

--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -937,7 +937,7 @@ def textfile_open(filename, mode='rt'):
 
 def getSipFiles(names):
     """
-    Returns a list of the coresponding .sip files for each of the names in names.
+    Returns a list of the corresponding .sip files for each of the names in names.
     """
     files = list()
     for template in ['sip/gen/%s.sip', 'src/%s.sip']:

--- a/buildtools/distutils_hacks.py
+++ b/buildtools/distutils_hacks.py
@@ -267,7 +267,7 @@ def _setup_compile(self, outdir, macros, incdirs, sources, depends, extra):
           _orig_setup_compile(self, outdir, macros, incdirs, sources, depends, extra)
 
     # Remove items from the build collection that don't need to be built
-    # because their obj file is newer than the source fle and any other
+    # because their obj file is newer than the source file and any other
     # dependencies.
     for obj in objects:
         src, ext = build[obj]

--- a/buildtools/sipdistutils.py
+++ b/buildtools/sipdistutils.py
@@ -1,4 +1,4 @@
-# Subclasses disutils.command.build_ext,
+# Subclasses distutils.command.build_ext,
 # replacing it with a SIP version that compiles .sip -> .cpp
 # before calling the original build_ext command.
 # Written by Giovanni Bajo <rasky at develer dot com>

--- a/demo/DragImage.py
+++ b/demo/DragImage.py
@@ -232,7 +232,7 @@ class DragCanvas(wx.ScrolledWindow):
             self.dragImage.Show()
 
 
-        # if we have shape and image then move it, posibly highlighting another shape.
+        # if we have shape and image then move it, possibly highlighting another shape.
         elif self.dragShape and self.dragImage:
             onShape = self.FindShape(evt.GetPosition())
             unhiliteOld = False

--- a/demo/Joystick.py
+++ b/demo/Joystick.py
@@ -1043,7 +1043,7 @@ values over 30. For that reason, this demo is limited to 16 buttons.
 
 POV hats come in two flavors: four-way, and continuous. four-way POVs are restricted to
 the cardinal points of the compass; continuous, or CTS POV hats can deliver input in
-.01 degree increments, theoreticaly. The data is returned as a whole number; the last
+.01 degree increments, theoretically. The data is returned as a whole number; the last
 two digits are considered to be to the right of the decimal point, so in order to
 use this information, you need to divide by 100 right off the bat.
 

--- a/demo/Timer.py
+++ b/demo/Timer.py
@@ -172,7 +172,7 @@ class TestPanel(sp.ScrolledPanel):
 
         # Normally a FutureCall is one-shot, but we can make it
         # recurring just by calling Restart.  We can even use a
-        # different timeout or pass differnt args this time.
+        # different timeout or pass different args this time.
         self.t2.Restart(1500, "restarted")
 
         # The return value of this function is saved and can be

--- a/demo/data/stc.h.html
+++ b/demo/data/stc.h.html
@@ -258,7 +258,7 @@
 
 <font color="#0000ff">// If CARET_EVEN is not set, instead of having symmetrical UZs,</font>
 <font color="#0000ff">// the left and bottom UZs are extended up to right and top UZs respectively.</font>
-<font color="#0000ff">// This way, we favour the displaying of useful information: the begining of lines,</font>
+<font color="#0000ff">// This way, we favour the displaying of useful information: the beginning of lines,</font>
 <font color="#0000ff">// where most code reside, and the lines after the caret, eg. the body of a function.</font>
 <font color="#a020f0">#define wxSTC_CARET_EVEN </font><font color="#ff00ff">0x08</font>
 
@@ -2034,7 +2034,7 @@
     <font color="#2e8b57"><b>void</b></font> SetCaretPeriod(<font color="#2e8b57"><b>int</b></font> periodMilliseconds);
 
     <font color="#0000ff">// Set the set of characters making up words for when moving or selecting by word.</font>
-    <font color="#0000ff">// First sets deaults like SetCharsDefault.</font>
+    <font color="#0000ff">// First sets defaults like SetCharsDefault.</font>
     <font color="#2e8b57"><b>void</b></font> SetWordChars(<font color="#2e8b57"><b>const</b></font> wxString&amp; characters);
 
     <font color="#0000ff">// Start a sequence of actions that is undone and redone as a unit.</font>
@@ -2532,19 +2532,19 @@
     <font color="#0000ff">// Set the display mode of visual flags for wrapped lines.</font>
     <font color="#2e8b57"><b>void</b></font> SetWrapVisualFlags(<font color="#2e8b57"><b>int</b></font> wrapVisualFlags);
 
-    <font color="#0000ff">// Retrive the display mode of visual flags for wrapped lines.</font>
+    <font color="#0000ff">// Retrieve the display mode of visual flags for wrapped lines.</font>
     <font color="#2e8b57"><b>int</b></font> GetWrapVisualFlags();
 
     <font color="#0000ff">// Set the location of visual flags for wrapped lines.</font>
     <font color="#2e8b57"><b>void</b></font> SetWrapVisualFlagsLocation(<font color="#2e8b57"><b>int</b></font> wrapVisualFlagsLocation);
 
-    <font color="#0000ff">// Retrive the location of visual flags for wrapped lines.</font>
+    <font color="#0000ff">// Retrieve the location of visual flags for wrapped lines.</font>
     <font color="#2e8b57"><b>int</b></font> GetWrapVisualFlagsLocation();
 
     <font color="#0000ff">// Set the start indent for wrapped lines.</font>
     <font color="#2e8b57"><b>void</b></font> SetWrapStartIndent(<font color="#2e8b57"><b>int</b></font> indent);
 
-    <font color="#0000ff">// Retrive the start indent for wrapped lines.</font>
+    <font color="#0000ff">// Retrieve the start indent for wrapped lines.</font>
     <font color="#2e8b57"><b>int</b></font> GetWrapStartIndent();
 
     <font color="#0000ff">// Sets the degree of caching of layout information.</font>
@@ -2922,7 +2922,7 @@
     <font color="#0000ff">// Delete forwards from the current position to the end of the line.</font>
     <font color="#2e8b57"><b>void</b></font> DelLineRight();
 
-    <font color="#0000ff">// Get and Set the xOffset (ie, horizonal scroll position).</font>
+    <font color="#0000ff">// Get and Set the xOffset (ie, horizontal scroll position).</font>
     <font color="#2e8b57"><b>void</b></font> SetXOffset(<font color="#2e8b57"><b>int</b></font> newOffset);
     <font color="#2e8b57"><b>int</b></font> GetXOffset();
 

--- a/demo/data/tables.htm
+++ b/demo/data/tables.htm
@@ -11,7 +11,7 @@ This                              is TABLES
 tests page...</H3>
 
 
-(yes, really, see bellow:)
+(yes, really, see below:)
 <BR>Click <a href="test.htm">here</a> to go to original testing page...
 
 <BR>&nbsp;

--- a/docs/MigrationGuide.rst
+++ b/docs/MigrationGuide.rst
@@ -555,7 +555,7 @@ problem into Phoenix the C++ wrappers have been tossed out and some of the
 more commonly used classes from wx.gizmos has been ported to pure Python code,
 which now lives in the ``wx.lib.gizmos`` package. There is also a temporary
 ``wx.gizmos`` module provided in order to provide the class names at the old
-location too in order to ease transitioning to the new packge. Please migrate
+location too in order to ease transitioning to the new package. Please migrate
 your code to use ``wx.lib.gizmos`` as ``wx.gizmos`` will likely go away in a
 future release.
 

--- a/docs/sphinx/_downloads/SplitterWindow.1.py
+++ b/docs/sphinx/_downloads/SplitterWindow.1.py
@@ -2,7 +2,7 @@
 #!/usr/bin/env python
 
 # This sample shows how to create a "spli-split" window, i.e. a
-# window split verticall which contains two windows split horizontally
+# window split vertical which contains two windows split horizontally
 
 import wx
 

--- a/docs/sphinx/_static/javascript/jquery.cookie.js
+++ b/docs/sphinx/_static/javascript/jquery.cookie.js
@@ -28,7 +28,7 @@
  *                             If a negative value is specified (e.g. a date in the past), the cookie will be deleted.
  *                             If set to null or omitted, the cookie will be a session cookie and will not be retained
  *                             when the the browser exits.
- * @option String path The value of the path atribute of the cookie (default: path of page that created the cookie).
+ * @option String path The value of the path attribute of the cookie (default: path of page that created the cookie).
  * @option String domain The value of the domain attribute of the cookie (default: domain of page that created the cookie).
  * @option Boolean secure If true, the secure attribute of the cookie will be set and the cookie transmission will
  *                        require a secure protocol (like HTTPS).

--- a/docs/sphinx/rest_substitutions/overviews/DocstringsGuidelines.rst
+++ b/docs/sphinx/rest_substitutions/overviews/DocstringsGuidelines.rst
@@ -242,7 +242,7 @@ documentation, please follow these conventions:
 
 
 2. At the very top of the snippet file (on the first line), put your
-   name, or your alias, or anything you use as internet name preceeded
+   name, or your alias, or anything you use as internet name preceded
    by a double-hash, i.e.:
 
    ``##Andrea Gavana``

--- a/docs/sphinx/rest_substitutions/overviews/datetime_overview.rst
+++ b/docs/sphinx/rest_substitutions/overviews/datetime_overview.rst
@@ -51,7 +51,7 @@ achieved with this class is 1 millisecond.
 
 The size of :ref:`wx.DateTime` object is 8 bytes because it is
 represented as a 64 bit integer. The resulting range of supported
-dates is thus approximatively 580 million years, but due to the
+dates is thus approximately 580 million years, but due to the
 current limitations in the Gregorian calendar support, only dates from
 Nov 24, 4714BC are supported (this is subject to change if there is
 sufficient interest in doing it).
@@ -110,7 +110,7 @@ understand what 'in a month' means - of course, it is just::
 
 
 
-Date arithmetics
+Date arithmetic
 ----------------
 
 Many different operations may be performed with the dates, however not

--- a/docs/sphinx/rest_substitutions/overviews/printing_framework_overview.rst
+++ b/docs/sphinx/rest_substitutions/overviews/printing_framework_overview.rst
@@ -69,7 +69,7 @@ the preview and printed images. This class provides a set of routines
 named `FitThisSizeToXXX()`, `MapScreenSizeToXXX()`, and
 `GetLogicalXXXRect`, which can be used to set the user scale and
 origin of the Printout's DC so that your class can easily map your
-image to the printout withouth getting into the details of screen and
+image to the printout without getting into the details of screen and
 printer PPI and scaling.
 
 
@@ -180,7 +180,7 @@ PageSetupDialog
 Class :ref:`wx.PageSetupDialog` puts up the standard page setup dialog,
 which allows you to specify the orientation, paper size, and related
 settings. You provide it with a :ref:`wx.PageSetupDialogData` object at
-intialization, which is used to populate the dialog; when the dialog
+initialization, which is used to populate the dialog; when the dialog
 is dismissed, this object contains the settings chosen by the user,
 including orientation and/or page margins.
 

--- a/docs/sphinx/rest_substitutions/overviews/richtextctrl_overview.rst
+++ b/docs/sphinx/rest_substitutions/overviews/richtextctrl_overview.rst
@@ -1023,7 +1023,7 @@ An event will be sent to the control when the focus changes.
 
 When the user clicks on the control,
 :class:`~wx.richtext.RichTextCtrl` determines which container to set
-as the current object focus by calling the found container's overrided
+as the current object focus by calling the found container's overridden
 :meth:`~wx.richtext.RichTextObject.AcceptsFocus` function. For
 example, although a table is a container, it must not itself be the
 object focus because there is no text editing at the table

--- a/docs/sphinx/rest_substitutions/snippets/python/contrib/SplitterWindow.1.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/contrib/SplitterWindow.1.py
@@ -2,7 +2,7 @@
 #!/usr/bin/env python
 
 # This sample shows how to create a "spli-split" window, i.e. a
-# window split verticall which contains two windows split horizontally
+# window split vertical which contains two windows split horizontally
 
 import wx
 

--- a/docs/sphinx/rest_substitutions/snippets/python/converted/wx.ComboCtrl.1.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/converted/wx.ComboCtrl.1.py
@@ -6,7 +6,7 @@
 
         #----------------------------------------------------------------------
         # This class is used to provide an interface between a ComboCtrl and the
-        # ListCtrl that is used as the popoup for the combo widget.
+        # ListCtrl that is used as the popup for the combo widget.
 
         class ListCtrlComboPopup(wx.ComboPopup):
 

--- a/docs/sphinx/rest_substitutions/snippets/python/converted/wx.ConfigPathChanger.1.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/converted/wx.ConfigPathChanger.1.py
@@ -1,5 +1,5 @@
 
-        # this function loads somes settings from the given wx.Config object
+        # this function loads some settings from the given wx.Config object
         # the path selected inside it is left unchanged
         def LoadMySettings(config):
 

--- a/docs/sphinx/rest_substitutions/snippets/python/converted/wx.LogNull.1.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/converted/wx.LogNull.1.py
@@ -1,5 +1,5 @@
 
-          # There will normally be a log message if a non-existant file is
+          # There will normally be a log message if a non-existent file is
           # loaded into a wx.Bitmap.  It can be suppressed with wx.LogNull
           noLog = wx.LogNull()
           bmp = wx.Bitmap('bogus.png')

--- a/docs/sphinx/rest_substitutions/snippets/python/converted/wx.propgrid.PGProperty.8.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/converted/wx.propgrid.PGProperty.8.py
@@ -22,7 +22,7 @@
 
         def StringToValue(self, st, flags):
             """
-            Convert a string to the correct type for the propery.
+            Convert a string to the correct type for the property.
 
             If failed, return False or (False, None). If success, return tuple
             (True, newValue).

--- a/etg/colour.py
+++ b/etg/colour.py
@@ -82,7 +82,7 @@ def run():
     c.addProperty('blue Blue')
     c.addProperty('alpha Alpha')
 
-    c.find('GetPixel').ignore()  # We need to add a typcast
+    c.find('GetPixel').ignore()  # We need to add a typecast
     c.addCppMethod('wxIntPtr*', 'GetPixel', '()', """\
         #if defined(__WXGTK3__) || defined(__WXOSX__)
             return new wxIntPtr(0);

--- a/etg/headerctrl.py
+++ b/etg/headerctrl.py
@@ -61,7 +61,7 @@ def run():
     c = module.find('wxHeaderCtrlSimple')
     tools.fixWindowClass(c)
 
-    # Uningnore the protected virtuals that are indended to be overridden in
+    # Uningnore the protected virtuals that are intended to be overridden in
     # derived classes.
     c.find('GetBestFittingWidth').ignore(False)
     c.find('GetBestFittingWidth').isVirtual = True

--- a/etg/rawbmp.py
+++ b/etg/rawbmp.py
@@ -55,7 +55,7 @@ def run():
     #addPixelDataClass(module, 'wxImagePixelData', 'wxImage', bpp=32,
     #    doc="""\
     #    ImagePixelData: A class providing direct access to a wx.Image's
-    #    internal data usign the same api as the other PixelData classes.
+    #    internal data using the same api as the other PixelData classes.
     #    """)
 
 

--- a/etg/webview.py
+++ b/etg/webview.py
@@ -73,7 +73,7 @@ def run():
         """)
 
     module.addPyCode(order=15, code="""\
-        # On Windows we need to ensure that the wx pacakge folder is on on the
+        # On Windows we need to ensure that the wx package folder is on on the
         # PATH, so the MS Edge Loader DLLs can be found when they are dynamically
         # loaded.
         import os

--- a/samples/doodle/superdoodle.py
+++ b/samples/doodle/superdoodle.py
@@ -238,7 +238,7 @@ class ControlPanel(wx.Panel):
             self.thknsBtns[x] = b
         self.thknsBtns[1].SetToggle(True)
 
-        # Make a colour indicator window, it is registerd as a listener
+        # Make a colour indicator window, it is registered as a listener
         # with the doodle window so it will be notified when the settings
         # change
         ci = ColourIndicator(self)

--- a/sip/cpp/README.txt
+++ b/sip/cpp/README.txt
@@ -1,4 +1,4 @@
-This folder is where the ouput of SIP is placed. These will be the C++ source
+This folder is where the output of SIP is placed. These will be the C++ source
 and header files, as well as a file for each module that specifies what files
 were generated for that module (which is used by the build scripts.)
 

--- a/sip/siplib/apiversions.c
+++ b/sip/siplib/apiversions.c
@@ -1,5 +1,5 @@
 /*
- * The implementation of the supprt for setting API versions.
+ * The implementation of the support for setting API versions.
  *
  * Copyright (c) 2019 Riverbank Computing Limited <info@riverbankcomputing.com>
  *

--- a/sip/siplib/int_convertors.c
+++ b/sip/siplib/int_convertors.c
@@ -1,5 +1,5 @@
 /*
- * The implementation of the Python object to C/C++ integer convertors.
+ * The implementation of the Python object to C/C++ integer converters.
  *
  * Copyright (c) 2019 Riverbank Computing Limited <info@riverbankcomputing.com>
  *
@@ -248,7 +248,7 @@ unsigned PY_LONG_LONG sip_api_long_as_unsigned_long_long(PyObject *o)
 
     /*
      * Note that this doesn't handle Python v2 int objects, but the old
-     * convertors didn't either.
+     * converters didn't either.
      */
 
     PyErr_Clear();

--- a/sip/siplib/objmap.c
+++ b/sip/siplib/objmap.c
@@ -180,7 +180,7 @@ static void add_aliases(sipObjectMap *om, void *addr, sipSimpleWrapper *val,
     {
         sipClassTypeDef *sup_ctd = sipGetGeneratedClassType(sup, ctd);
 
-        /* Recurse up the hierachy for the first super-class. */
+        /* Recurse up the hierarchy for the first super-class. */
         add_aliases(om, addr, val, base_ctd, sup_ctd);
 
         /*
@@ -193,7 +193,7 @@ static void add_aliases(sipObjectMap *om, void *addr, sipSimpleWrapper *val,
 
             sup_ctd = sipGetGeneratedClassType(sup, ctd);
 
-            /* Recurse up the hierachy for the remaining super-classes. */
+            /* Recurse up the hierarchy for the remaining super-classes. */
             add_aliases(om, addr, val, base_ctd, sup_ctd);
 
             sup_addr = (*base_ctd->ctd_cast)(addr, (sipTypeDef *)sup_ctd);
@@ -398,7 +398,7 @@ static void remove_aliases(sipObjectMap *om, void *addr, sipSimpleWrapper *val,
     {
         sipClassTypeDef *sup_ctd = sipGetGeneratedClassType(sup, ctd);
 
-        /* Recurse up the hierachy for the first super-class. */
+        /* Recurse up the hierarchy for the first super-class. */
         remove_aliases(om, addr, val, base_ctd, sup_ctd);
 
         /*
@@ -411,7 +411,7 @@ static void remove_aliases(sipObjectMap *om, void *addr, sipSimpleWrapper *val,
 
             sup_ctd = sipGetGeneratedClassType(sup, ctd);
 
-            /* Recurse up the hierachy for the remaining super-classes. */
+            /* Recurse up the hierarchy for the remaining super-classes. */
             remove_aliases(om, addr, val, base_ctd, sup_ctd);
 
             sup_addr = (*base_ctd->ctd_cast)(addr, (sipTypeDef *)sup_ctd);

--- a/sip/siplib/sip.h
+++ b/sip/siplib/sip.h
@@ -457,10 +457,10 @@ typedef struct _sipInitExtenderDef {
 
 
 /*
- * The information describing a sub-class convertor.
+ * The information describing a sub-class converter.
  */
 typedef struct _sipSubClassConvertorDef {
-    /* The convertor. */
+    /* The converter. */
     sipSubClassConvertFunc scc_convertor;
 
     /* The encoded base type. */
@@ -1105,7 +1105,7 @@ typedef struct _sipExportedModuleDef {
     /* The table of virtual error handlers. */
     sipVirtErrorHandlerDef *em_virterrorhandlers;
 
-    /* The sub-class convertors. */
+    /* The sub-class converters. */
     sipSubClassConvertorDef *em_convertors;
 
     /* The static instances. */
@@ -1677,7 +1677,7 @@ typedef struct _sipQtAPI {
  * sipConvertToType() and sipForceConvertToType().
  */
 #define SIP_NOT_NONE        0x01    /* Disallow None. */
-#define SIP_NO_CONVERTORS   0x02    /* Disable any type convertors. */
+#define SIP_NO_CONVERTORS   0x02    /* Disable any type converters. */
 
 
 /*
@@ -1743,7 +1743,7 @@ typedef struct _sipQtAPI {
 #define SIP_TYPE_ENUM       0x0003  /* If the type is a named enum. */
 #define SIP_TYPE_SCOPED_ENUM    0x0004  /* If the type is a scoped enum. */
 #define SIP_TYPE_ABSTRACT   0x0008  /* If the type is abstract. */
-#define SIP_TYPE_SCC        0x0010  /* If the type is subject to sub-class convertors. */
+#define SIP_TYPE_SCC        0x0010  /* If the type is subject to sub-class converters. */
 #define SIP_TYPE_ALLOW_NONE 0x0020  /* If the type can handle None. */
 #define SIP_TYPE_STUB       0x0040  /* If the type is a stub. */
 #define SIP_TYPE_NONLAZY    0x0080  /* If the type has a non-lazy method. */

--- a/sip/siplib/sipint.h
+++ b/sip/siplib/sipint.h
@@ -97,7 +97,7 @@ PyObject *sip_api_convert_from_const_void_ptr_and_size(const void *val,
 
 
 /*
- * Support for int convertors.
+ * Support for int converters.
  */
 PyObject *sipEnableOverflowChecking(PyObject *self, PyObject *args);
 int sip_api_enable_overflow_checking(int enable);

--- a/sip/siplib/siplib.c
+++ b/sip/siplib/siplib.c
@@ -41,7 +41,7 @@
 /*
  * The Python metatype for a C++ wrapper type.  We inherit everything from the
  * standard Python metatype except the init and getattro methods and the size
- * of the type object created is increased to accomodate the extra information
+ * of the type object created is increased to accommodate the extra information
  * we associate with a wrapped type.
  */
 
@@ -629,7 +629,7 @@ static const sipAPIDef sip_api = {
 #define FMT_AP_DEREF            0x01    /* The pointer will be dereferenced. */
 #define FMT_AP_TRANSFER         0x02    /* Implement /Transfer/. */
 #define FMT_AP_TRANSFER_BACK    0x04    /* Implement /TransferBack/. */
-#define FMT_AP_NO_CONVERTORS    0x08    /* Suppress any convertors. */
+#define FMT_AP_NO_CONVERTORS    0x08    /* Suppress any converters. */
 #define FMT_AP_TRANSFER_THIS    0x10    /* Support for /TransferThis/. */
 
 
@@ -726,7 +726,7 @@ static PyObject *sipEnumType_getattro(PyObject *self, PyObject *name);
 
 /*
  * The type data structure.  We inherit everything from the standard Python
- * metatype and the size of the type object created is increased to accomodate
+ * metatype and the size of the type object created is increased to accommodate
  * the extra information we associate with a named enum type.
  */
 static PyTypeObject sipEnumType_Type = {
@@ -1944,7 +1944,7 @@ static int sip_api_init_module(sipExportedModuleDef *client,
         }
     }
 
-    /* Set the base class object for any sub-class convertors. */
+    /* Set the base class object for any sub-class converters. */
     if (client->em_convertors != NULL)
     {
         sipSubClassConvertorDef *scc = client->em_convertors;
@@ -5384,7 +5384,7 @@ static int parsePass2(sipSimpleWrapper *self, int selfarg, PyObject *sipArgs,
     int a, ok;
     Py_ssize_t nr_pos_args;
 
-    /* Handle the converions of "self" first. */
+    /* Handle the conversions of "self" first. */
     switch (*fmt++)
     {
     case 'B':
@@ -5968,7 +5968,7 @@ static void sip_api_instance_destroyed_ex(sipSimpleWrapper **sipSelfp)
 
         /*
          * This no longer points to anything useful.  Actually it might do as
-         * the partialy destroyed C++ instance may still be trying to invoke
+         * the partially destroyed C++ instance may still be trying to invoke
          * reimplemented virtuals.
          */
         clear_access_func(sipSelf);
@@ -8859,7 +8859,7 @@ static int sip_api_can_convert_to_type(PyObject *pyObj, const sipTypeDef *td,
 /*
  * Convert a Python object to a C/C++ pointer, assuming a previous call to
  * sip_api_can_convert_to_type() has been successful.  Allow ownership to be
- * transferred and any type convertors to be disabled.
+ * transferred and any type converters to be disabled.
  */
 static void *sip_api_convert_to_type(PyObject *pyObj, const sipTypeDef *td,
         PyObject *transferObj, int flags, int *statep, int *iserrp)
@@ -8953,7 +8953,7 @@ void *sip_api_force_convert_to_type(PyObject *pyObj, const sipTypeDef *td,
 
 
 /*
- * Release a possibly temporary C/C++ instance created by a type convertor.
+ * Release a possibly temporary C/C++ instance created by a type converter.
  */
 static void sip_api_release_type(void *cpp, const sipTypeDef *td, int state)
 {
@@ -9026,11 +9026,11 @@ PyObject *sip_api_convert_from_type(void *cpp, const sipTypeDef *td,
         void *orig_cpp = cpp;
         const sipTypeDef *orig_td = td;
 
-        /* Apply the sub-class convertor. */
+        /* Apply the sub-class converter. */
         td = convertSubClass(td, &cpp);
 
         /*
-         * If the sub-class convertor has done something then check the cache
+         * If the sub-class converter has done something then check the cache
          * again using the modified values.
          */
         if (cpp != orig_cpp || td != orig_td)
@@ -9094,7 +9094,7 @@ static PyObject *sip_api_convert_from_new_type(void *cpp, const sipTypeDef *td,
         return res;
     }
 
-    /* Apply any sub-class convertor. */
+    /* Apply any sub-class converter. */
     if (sipTypeHasSCC(td))
         td = convertSubClass(td, &cpp);
 
@@ -9312,9 +9312,9 @@ static void sip_api_call_hook(const char *hookname)
 
 
 /*
- * Call any sub-class convertors for a given type returning a pointer to the
+ * Call any sub-class converters for a given type returning a pointer to the
  * sub-type object, and possibly modifying the C++ address (in the case of
- * multiple inheritence).
+ * multiple inheritance).
  */
 static const sipTypeDef *convertSubClass(const sipTypeDef *td, void **cppPtr)
 {
@@ -9331,7 +9331,7 @@ static const sipTypeDef *convertSubClass(const sipTypeDef *td, void **cppPtr)
 
 
 /*
- * Do a single pass through the available convertors.
+ * Do a single pass through the available converters.
  */
 static int convertPass(const sipTypeDef **tdp, void **cppPtr)
 {
@@ -9340,7 +9340,7 @@ static int convertPass(const sipTypeDef **tdp, void **cppPtr)
 
     /*
      * Note that this code depends on the fact that a module appears in the
-     * list of modules before any module it imports, ie. sub-class convertors
+     * list of modules before any module it imports, ie. sub-class converters
      * will be invoked for more specific types first.
      */
     for (em = moduleList; em != NULL; em = em->em_next)
@@ -9356,11 +9356,11 @@ static int convertPass(const sipTypeDef **tdp, void **cppPtr)
 
             /*
              * The base type is the "root" class that may have a number of
-             * convertors each handling a "branch" of the derived tree of
+             * converters each handling a "branch" of the derived tree of
              * classes.  The "root" normally implements the base function that
-             * provides the RTTI used by the convertors and is re-implemented
+             * provides the RTTI used by the converters and is re-implemented
              * by derived classes.  We therefore see if the target type is a
-             * sub-class of the root, ie. see if the convertor might be able to
+             * sub-class of the root, ie. see if the converter might be able to
              * convert the target type to something more specific.
              */
             if (PyType_IsSubtype(py_type, base_type))
@@ -9377,8 +9377,8 @@ static int convertPass(const sipTypeDef **tdp, void **cppPtr)
                     /*
                      * We are only interested in types that are not
                      * super-classes of the target.  This happens either
-                     * because it is in an earlier convertor than the one that
-                     * handles the type or it is in a later convertor that
+                     * because it is in an earlier converter than the one that
+                     * handles the type or it is in a later converter that
                      * handles a different branch of the hierarchy.  Either
                      * way, the ordering of the modules ensures that there will
                      * be no more than one and that it will be the right one.
@@ -9389,8 +9389,8 @@ static int convertPass(const sipTypeDef **tdp, void **cppPtr)
                         *cppPtr = ptr;
 
                         /*
-                         * Finally we allow the convertor to return a type that
-                         * is apparently unrelated to the current convertor.
+                         * Finally we allow the converter to return a type that
+                         * is apparently unrelated to the current converter.
                          * This causes the whole process to be restarted with
                          * the new values.  The use case is PyQt's QLayoutItem.
                          */
@@ -9408,7 +9408,7 @@ static int convertPass(const sipTypeDef **tdp, void **cppPtr)
      * it must be.  This can happen legitimately if the wrapped library is
      * returning an internal class that is down-cast to a more generic class.
      * Also we want this function to be safe when a class doesn't have any
-     * convertors.
+     * converters.
      */
     return FALSE;
 }
@@ -12768,7 +12768,7 @@ static int sip_api_check_plugin_for_type(const sipTypeDef *td,
      * The current thinking on plugins is that SIP v5 will look for a plugin
      * with a name derived from the name as the current module in the same
      * directory as the .sip defining the module (ie. no %Plugin directive).  A
-     * module hierachy may have multiple plugins but they must co-operate.  If
+     * module hierarchy may have multiple plugins but they must co-operate.  If
      * a plugin generates user data then it should include a void* (and a
      * run-time API) so that other plugins can extend it further.  This
      * approach means that a plugin's user data structure can be opaque.

--- a/src/wxpy_api.sip
+++ b/src/wxpy_api.sip
@@ -565,7 +565,7 @@ void i_wxPyReinitializeModules() {
         // function in a dyn-loaded DLL. When modules are cleaned up then that
         // DLL will be unloaded, leaving a dangling function pointer.  We'll
         // likely end up with multiple instances of some things, but that is
-        // better than the alternaive currently.
+        // better than the alternative currently.
         //wxModule::CleanUpModules();
 
         wxModule::RegisterModules();

--- a/unittests/test_bitmap.py
+++ b/unittests/test_bitmap.py
@@ -63,7 +63,7 @@ class BitmapTests(wtc.WidgetTestCase):
         else:
             self.assertTrue( b2.__nonzero__() == b2.IsOk() )
 
-        # check that the __nonzero__ method can be used with if satements
+        # check that the __nonzero__ method can be used with if statements
         nzcheck = False
         if b2:
             nzcheck = True

--- a/unittests/test_cursor.py
+++ b/unittests/test_cursor.py
@@ -75,7 +75,7 @@ class CursorTests(wtc.WidgetTestCase):
         else:
             self.assertTrue( c2.__nonzero__() == c2.IsOk() )
 
-        # check that the __nonzero__ method can be used with if satements
+        # check that the __nonzero__ method can be used with if statements
         nzcheck = False
         if c2:
             nzcheck = True

--- a/unittests/test_dataview.py
+++ b/unittests/test_dataview.py
@@ -262,7 +262,7 @@ class dataview_Tests(wtc.WidgetTestCase):
         count2 = model.GetRefCount()
 
         # The reference count should still be 1 because the model was
-        # DecRef'ed when it's ownership transfered to C++ in the
+        # DecRef'ed when it's ownership transferred to C++ in the
         # AssociateModel call
         self.assertEqual(count2, 1)
         self.assertTrue(count2 == count1)

--- a/unittests/test_deadobj.py
+++ b/unittests/test_deadobj.py
@@ -35,7 +35,7 @@ class deadobj_Tests(wtc.WidgetTestCase):
 
     def test_deadobjException(self):
         # There should be a RuntimeError exception if we try to use an object
-        # after it's C++ parts have been detroyed.
+        # after it's C++ parts have been destroyed.
         p = wx.Panel(self.frame)
         p.Destroy()
         with self.assertRaises(RuntimeError):

--- a/unittests/test_lib_pubsub_api3.py
+++ b/unittests/test_lib_pubsub_api3.py
@@ -266,7 +266,7 @@ class lib_pubsub_Except(wtc.PubsubTestCase):
             pass       # parent's arg1 missing
 
         # with getOrCreateTopic(topic, proto), the 'required args' set
-        # is garanteed to be a subset of 'all args'
+        # is guaranteed to be a subset of 'all args'
         self.pub.getDefaultTopicMgr().getOrCreateTopic('tasd',          ok_0)
         self.pub.getDefaultTopicMgr().getOrCreateTopic('tasd.t_1',      ok_1)
         self.assertRaises(self.pub.MessageDataSpecError, self.pub.getDefaultTopicMgr().getOrCreateTopic,
@@ -298,7 +298,7 @@ class lib_pubsub_Except(wtc.PubsubTestCase):
         self.pub.getDefaultTopicMgr().newTopic('tasd.t_2.t_23', 'desc', ('arg1',), arg1='docs for arg1') # ok_21
         check('t_2.t_24', ('arg2',), arg2='docs for arg2')                     # err_22
 
-        # check when no inheritence involved
+        # check when no inheritance involved
         # reqd args wrong
         check('t_1.t_16', ('arg1',), arg2='docs for arg2')
         check('t_1.t_17', ('arg2',), arg1='docs for arg1')

--- a/wx/include/wxPython/sip.h
+++ b/wx/include/wxPython/sip.h
@@ -457,10 +457,10 @@ typedef struct _sipInitExtenderDef {
 
 
 /*
- * The information describing a sub-class convertor.
+ * The information describing a sub-class converter.
  */
 typedef struct _sipSubClassConvertorDef {
-    /* The convertor. */
+    /* The converter. */
     sipSubClassConvertFunc scc_convertor;
 
     /* The encoded base type. */
@@ -1105,7 +1105,7 @@ typedef struct _sipExportedModuleDef {
     /* The table of virtual error handlers. */
     sipVirtErrorHandlerDef *em_virterrorhandlers;
 
-    /* The sub-class convertors. */
+    /* The sub-class converters. */
     sipSubClassConvertorDef *em_convertors;
 
     /* The static instances. */
@@ -1677,7 +1677,7 @@ typedef struct _sipQtAPI {
  * sipConvertToType() and sipForceConvertToType().
  */
 #define SIP_NOT_NONE        0x01    /* Disallow None. */
-#define SIP_NO_CONVERTORS   0x02    /* Disable any type convertors. */
+#define SIP_NO_CONVERTORS   0x02    /* Disable any type converters. */
 
 
 /*
@@ -1743,7 +1743,7 @@ typedef struct _sipQtAPI {
 #define SIP_TYPE_ENUM       0x0003  /* If the type is a named enum. */
 #define SIP_TYPE_SCOPED_ENUM    0x0004  /* If the type is a scoped enum. */
 #define SIP_TYPE_ABSTRACT   0x0008  /* If the type is abstract. */
-#define SIP_TYPE_SCC        0x0010  /* If the type is subject to sub-class convertors. */
+#define SIP_TYPE_SCC        0x0010  /* If the type is subject to sub-class converters. */
 #define SIP_TYPE_ALLOW_NONE 0x0020  /* If the type can handle None. */
 #define SIP_TYPE_STUB       0x0040  /* If the type is a stub. */
 #define SIP_TYPE_NONLAZY    0x0080  /* If the type has a non-lazy method. */

--- a/wx/include/wxPython/wxpy_api.h
+++ b/wx/include/wxPython/wxpy_api.h
@@ -74,7 +74,7 @@ inline void wxPyEndAllowThreads(PyThreadState* saved) {
 
 
 
-// A macro that will help to execute simple statments wrapped in
+// A macro that will help to execute simple statements wrapped in
 // StartBlock/EndBlockThreads calls
 #define wxPyBLOCK_THREADS(stmt) \
     { wxPyThreadBlocker _blocker; stmt; }

--- a/wx/lib/agw/__init__.py
+++ b/wx/lib/agw/__init__.py
@@ -14,7 +14,7 @@ an asterisk were already present in :mod:`lib` before:
 - AdvancedSplash: reproduces the behaviour of :class:`~adv.SplashScreen`, with more
   advanced features like custom shapes and text animations;
 - AquaButton: this is another custom-drawn button class which
-  *approximatively* mimics the behaviour of Aqua buttons on the Mac;
+  *approximately* mimics the behaviour of Aqua buttons on the Mac;
 - AUI: a pure-Python implementation of :mod:`~wx.lib.agw.aui`, with many bug fixes and
   new features like HUD docking and :class:`~wx.lib.agw.aui.auibook.AuiNotebook` tab arts;
 - BalloonTip: allows you to display tooltips in a balloon style window

--- a/wx/lib/agw/advancedsplash.py
+++ b/wx/lib/agw/advancedsplash.py
@@ -335,7 +335,7 @@ class AdvancedSplash(wx.Frame):
         # Here We Redraw The Bitmap Over The Frame
         dc.DrawBitmap(self.bmp, 0, 0, True)
 
-        # We Draw The Text Anyway, Wheter It Is Empty ("") Or Not
+        # We Draw The Text Anyway, Whether It Is Empty ("") Or Not
         textcolour = self.GetTextColour()
         textfont = self.GetTextFont()
         textpos = self.GetTextPosition()

--- a/wx/lib/agw/aquabutton.py
+++ b/wx/lib/agw/aquabutton.py
@@ -24,14 +24,14 @@
 # --------------------------------------------------------------------------------- #
 
 """
-:class:`~wx.lib.agw.aquabutton.AquaButton` is another custom-drawn button class which *approximatively* mimics
+:class:`~wx.lib.agw.aquabutton.AquaButton` is another custom-drawn button class which *approximately* mimics
 the behaviour of Aqua buttons on the Mac.
 
 
 Description
 ===========
 
-:class:`AquaButton` is another custom-drawn button class which *approximatively* mimics
+:class:`AquaButton` is another custom-drawn button class which *approximately* mimics
 the behaviour of Aqua buttons on the Mac. At the moment this class supports:
 
 * Bubble and shadow effects;

--- a/wx/lib/agw/artmanager.py
+++ b/wx/lib/agw/artmanager.py
@@ -752,7 +752,7 @@ class ArtManager(wx.EvtHandler):
         :param string `name`: the bitmap name.
 
         :return: The stock bitmap, if `name` was found in the stock bitmap dictionary.
-         Othewise, :class:`NullBitmap` is returned.
+         Otherwise, :class:`NullBitmap` is returned.
         """
 
         return self._bitmaps.get(name, wx.NullBitmap)
@@ -1160,9 +1160,9 @@ class ArtManager(wx.EvtHandler):
         :return: An instance of :class:`wx.Colour`.
         """
 
-        r = random.randint(0, 255) # Random value betweem 0-255
-        g = random.randint(0, 255) # Random value betweem 0-255
-        b = random.randint(0, 255) # Random value betweem 0-255
+        r = random.randint(0, 255) # Random value between 0-255
+        g = random.randint(0, 255) # Random value between 0-255
+        b = random.randint(0, 255) # Random value between 0-255
 
         return wx.Colour(r, g, b)
 
@@ -1194,7 +1194,7 @@ class ArtManager(wx.EvtHandler):
         :param string `text`: the text to be (eventually) truncated;
         :param integer `maxWidth`: the maximum width allowed for the text.
 
-        :return: A new string containining the (possibly) truncated text.
+        :return: A new string containing the (possibly) truncated text.
         """
 
         textLen = len(text)
@@ -1447,7 +1447,7 @@ class ArtManager(wx.EvtHandler):
 
     def GetBitmapStartLocation(self, dc, rect, bitmap, text="", style=0):
         """
-        Returns the top left `x` and `y` cordinates of the bitmap drawing.
+        Returns the top left `x` and `y` coordinates of the bitmap drawing.
 
         :param `dc`: an instance of :class:`wx.DC`;
         :param wx.Rect `rect`: the bitmap's client rectangle;
@@ -1466,7 +1466,7 @@ class ArtManager(wx.EvtHandler):
          ``BU_EXT_RIGHT_TO_LEFT_STYLE``    32   A button suitable for right-to-left languages
          ============================== ======= ================================
 
-        :return: A tuple containining the top left `x` and `y` cordinates of the bitmap drawing.
+        :return: A tuple containing the top left `x` and `y` coordinates of the bitmap drawing.
         """
 
         alignmentBuffer = self.GetAlignBuffer()
@@ -1495,7 +1495,7 @@ class ArtManager(wx.EvtHandler):
                 # get the truncated text. The text may stay as is, it is not a must that is will be trancated
                 fixedText = self.TruncateText(dc, text, maxWidth)
 
-                # get the fixed text dimentions
+                # get the fixed text dimensions
                 fixedTextWidth, fixedTextHeight = dc.GetTextExtent(fixedText)
 
                 # calculate the start location
@@ -1513,7 +1513,7 @@ class ArtManager(wx.EvtHandler):
                 # get the truncated text. The text may stay as is, it is not a must that is will be trancated
                 fixedText = self.TruncateText(dc, text, maxWidth)
 
-                # get the fixed text dimentions
+                # get the fixed text dimensions
                 fixedTextWidth, fixedTextHeight = dc.GetTextExtent(fixedText)
 
                 if maxWidth > fixedTextWidth:
@@ -1535,7 +1535,7 @@ class ArtManager(wx.EvtHandler):
 
     def GetTextStartLocation(self, dc, rect, bitmap, text, style=0):
         """
-        Returns the top left `x` and `y` cordinates of the text drawing.
+        Returns the top left `x` and `y` coordinates of the text drawing.
         In case the text is too long, the text is being fixed (the text is cut and
         a '...' mark is added in the end).
 
@@ -1545,7 +1545,7 @@ class ArtManager(wx.EvtHandler):
         :param string `text`: the button label;
         :param integer `style`: the button style.
 
-        :return: A tuple containining the top left `x` and `y` cordinates of the text drawing, plus
+        :return: A tuple containing the top left `x` and `y` coordinates of the text drawing, plus
          the truncated version of the input `text`.
 
         :see: :meth:`~ArtManager.GetBitmapStartLocation` for a list of valid button styles.
@@ -1563,7 +1563,7 @@ class ArtManager(wx.EvtHandler):
 
         fixedText = self.TruncateText(dc, text, maxWidth)
 
-        # get the fixed text dimentions
+        # get the fixed text dimensions
         fixedTextWidth, fixedTextHeight = dc.GetTextExtent(fixedText)
         startLocationY = (rect.height - fixedTextHeight) / 2 + rect.y
 
@@ -1648,7 +1648,7 @@ class ArtManager(wx.EvtHandler):
         location, labelOnly = self.GetAccelIndex(text)
         startLocationX, startLocationY, fixedText = self.GetTextStartLocation(dc, rect, bitmap, labelOnly, style)
 
-        # after all the caculations are finished, it is time to draw the text
+        # after all the calculations are finished, it is time to draw the text
         # underline the first letter that is marked with a '&'
         if location == -1 or font.GetUnderlined() or location >= len(fixedText):
             # draw the text
@@ -1781,9 +1781,9 @@ class ArtManager(wx.EvtHandler):
         Returns the mnemonic index of the label and the label stripped of the ampersand mnemonic
         (e.g. 'lab&el' ==> will result in 3 and labelOnly = label).
 
-        :param string `label`: a string containining an ampersand.
+        :param string `label`: a string containing an ampersand.
 
-        :return: A tuple containining the mnemonic index of the label and the label
+        :return: A tuple containing the mnemonic index of the label and the label
          stripped of the ampersand mnemonic.
         """
 
@@ -1843,7 +1843,7 @@ class ArtManager(wx.EvtHandler):
         """
         Returns the currently used menu theme.
 
-        :return: A string containining the currently used theme for the menu.
+        :return: A string containing the currently used theme for the menu.
         """
 
         return self._menuTheme

--- a/wx/lib/agw/aui/__init__.py
+++ b/wx/lib/agw/aui/__init__.py
@@ -127,7 +127,7 @@ missing features (the list is not exhaustive):
 - wxAuiManager & wxToolBar - ToolBar Of Size Zero: http://trac.wxwidgets.org/ticket/9724
 - wxAuiNotebook doesn't behave properly like a container as far as...: http://trac.wxwidgets.org/ticket/9911
 - Serious layout bugs in wxAUI: http://trac.wxwidgets.org/ticket/10620
-- wAuiDefaultTabArt::Clone() should just use copy contructor: http://trac.wxwidgets.org/ticket/11388
+- wAuiDefaultTabArt::Clone() should just use copy constructor: http://trac.wxwidgets.org/ticket/11388
 - Drop down button for check tool on wxAuiToolbar: http://trac.wxwidgets.org/ticket/11139
 
 Plus the following features:

--- a/wx/lib/agw/aui/aui_utilities.py
+++ b/wx/lib/agw/aui/aui_utilities.py
@@ -463,7 +463,7 @@ class TabDragImage(wx.DragImage):
 
         memory.SelectObject(wx.NullBitmap)
 
-        # Gtk and Windows unfortunatly don't do so well with transparent
+        # Gtk and Windows unfortunately don't do so well with transparent
         # drawing so this hack corrects the image to have a transparent
         # background.
         if wx.Platform != '__WXMAC__':

--- a/wx/lib/agw/aui/auibar.py
+++ b/wx/lib/agw/aui/auibar.py
@@ -739,7 +739,7 @@ class AuiToolBarItem(object):
 class AuiDefaultToolBarArt(object):
     """
     Toolbar art provider code - a tab provider provides all drawing functionality to the :class:`AuiToolBar`.
-    This allows the :class:`AuiToolBar` to have a plugable look-and-feel.
+    This allows the :class:`AuiToolBar` to have a pluggable look-and-feel.
 
     By default, a :class:`AuiToolBar` uses an instance of this class called :class:`AuiDefaultToolBarArt`
     which provides bitmap art and a colour scheme that is adapted to the major platforms'
@@ -1028,7 +1028,7 @@ class AuiDefaultToolBarArt(object):
 
             elif item_state & AUI_BUTTON_STATE_CHECKED:
 
-                # it's important to put this code in an else statment after the
+                # it's important to put this code in an else statement after the
                 # hover, otherwise hovers won't draw properly for checked items
                 dc.SetPen(wx.Pen(self._highlight_colour))
                 dc.SetBrush(wx.Brush(StepColour(self._highlight_colour, 170)))
@@ -1107,7 +1107,7 @@ class AuiDefaultToolBarArt(object):
             dc.DrawRectangle(dropdown_rect)
 
         elif item_state & AUI_BUTTON_STATE_CHECKED:
-            # it's important to put this code in an else statment after the
+            # it's important to put this code in an else statement after the
             # hover, otherwise hovers won't draw properly for checked items
             dc.SetPen(wx.Pen(self._highlight_colour))
             dc.SetBrush(wx.Brush(StepColour(self._highlight_colour, 170)))
@@ -1705,7 +1705,7 @@ class AuiToolBar(wx.Control):
     def SetArtProvider(self, art):
         """
         Instructs :class:`AuiToolBar` to use art provider specified by parameter `art`
-        for all drawing calls. This allows plugable look-and-feel features.
+        for all drawing calls. This allows pluggable look-and-feel features.
 
         :param `art`: an art provider.
 

--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -939,7 +939,7 @@ class AuiTabContainer(object):
     def SetArtProvider(self, art):
         """
         Instructs :class:`AuiTabContainer` to use art provider specified by parameter `art`
-        for all drawing calls. This allows plugable look-and-feel features.
+        for all drawing calls. This allows pluggable look-and-feel features.
 
         :param `art`: an art provider.
 
@@ -3390,7 +3390,7 @@ class AuiNotebook(wx.Panel):
     def UpdateTabCtrlHeight(self, force=False):
         """
         :meth:`UpdateTabCtrlHeight` does the actual tab resizing. It's meant
-        to be used interally.
+        to be used internally.
 
         :param bool `force`: ``True`` to force the tab art to repaint.
         """
@@ -4716,7 +4716,7 @@ class AuiNotebook(wx.Panel):
             self.RemovePage(idx)
             # re-add in the same position so it will tab
             self.InsertPage(idx, win, title, False, bmp)
-        # restore orignial selected tab
+        # restore original selected tab
         self.SetSelection(nowSelected)
 
         self.Thaw()

--- a/wx/lib/agw/aui/dockart.py
+++ b/wx/lib/agw/aui/dockart.py
@@ -13,7 +13,7 @@
 #----------------------------------------------------------------------------
 """
 Dock art provider code - a dock provider provides all drawing functionality to
-the AUI dock manager. This allows the dock manager to have a plugable look-and-feel.
+the AUI dock manager. This allows the dock manager to have a pluggable look-and-feel.
 
 By default, a :class:`~wx.lib.agw.aui.framemanager` uses an instance of this class called :mod:`~wx.lib.agw.aui.dockart`
 which provides bitmap art and a colour scheme that is adapted to the major platforms'
@@ -52,7 +52,7 @@ if wx.Platform == "__WXMSW__":
 class AuiDefaultDockArt(object):
     """
     Dock art provider code - a dock provider provides all drawing functionality to the AUI dock manager.
-    This allows the dock manager to have a plugable look-and-feel.
+    This allows the dock manager to have a pluggable look-and-feel.
 
     By default, a :class:`~wx.lib.agw.aui.framemanager.AuiManager` uses an instance of this class called
     :class:`AuiDefaultDockArt` which provides bitmap art and a colour scheme that is adapted to the major

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -4473,7 +4473,7 @@ class AuiManager(wx.EvtHandler):
     def SetArtProvider(self, art_provider):
         """
         Instructs :class:`AuiManager` to use art provider specified by the parameter
-        `art_provider` for all drawing calls. This allows plugable look-and-feel
+        `art_provider` for all drawing calls. This allows pluggable look-and-feel
         features.
 
         :param `art_provider`: a AUI dock art provider.
@@ -4495,7 +4495,7 @@ class AuiManager(wx.EvtHandler):
     def AddPane(self, window, arg1=None, arg2=None, target=None):
         """
         Tells the frame manager to start managing a child window. There
-        are four versions of this function. The first verison allows the full spectrum
+        are four versions of this function. The first version allows the full spectrum
         of pane parameter possibilities (:meth:`AddPane1`). The second version is used for
         simpler user interfaces which do not require as much configuration (:meth:`AddPane2`).
         The :meth:`AddPane3` version allows a drop position to be specified, which will determine
@@ -4606,7 +4606,7 @@ class AuiManager(wx.EvtHandler):
                 # so use GetBestSize()
                 pinfo.best_size = pinfo.window.GetBestSize()
 
-                # this is needed for Win2000 to correctly fill toolbar backround
+                # this is needed for Win2000 to correctly fill toolbar background
                 # it should probably be repeated once system colour change happens
                 if wx.Platform == "__WXMSW__" and pinfo.window.UseBgCol():
                     pinfo.window.SetBackgroundColour(self.GetArtProvider().GetColour(AUI_DOCKART_BACKGROUND_COLOUR))
@@ -6113,7 +6113,7 @@ class AuiManager(wx.EvtHandler):
     def SetDockSizeConstraint(self, width_pct, height_pct):
         """
         When a user creates a new dock by dragging a window into a docked position,
-        often times the large size of the window will create a dock that is unwieldly
+        often times the large size of the window will create a dock that is unwieldy
         large.
 
         :class:`AuiManager` by default limits the size of any new dock to 1/3 of the window
@@ -9976,7 +9976,7 @@ class AuiManager(wx.EvtHandler):
                 self.GetPane(notebook).CaptionVisible(False).PaneBorder(False)
                 self.Update()
 
-        # it seems the notebook isnt created by this stage, so remove
+        # it seems the notebook isn't created by this stage, so remove
         # the caption a moment later
         wx.CallAfter(RemoveCaption)
         return True
@@ -10393,7 +10393,7 @@ class AuiManager_DCP(AuiManager):
                              not pane.IsFloating() and pane.IsShown() for pane in self.GetAllPanes())
         if haveCenterPane:
             if self.hasDummyPane:
-                # there's our dummy pane and also another center pane, therefor let's remove our dummy
+                # there's our dummy pane and also another center pane, therefore let's remove our dummy
                 def do():
                     self._destroyDummyPane()
                     self.Update()

--- a/wx/lib/agw/aui/tabart.py
+++ b/wx/lib/agw/aui/tabart.py
@@ -14,7 +14,7 @@
 """
 Tab art provider code - a tab provider provides all drawing functionality to
 the :class:`~wx.lib.agw.aui.auibook.AuiNotebook`. This allows the
-:class:`~wx.lib.agw.aui.auibook.AuiNotebook` to have a plugable look-and-feel.
+:class:`~wx.lib.agw.aui.auibook.AuiNotebook` to have a pluggable look-and-feel.
 
 By default, a :class:`~wx.lib.agw.aui.auibook.AuiNotebook` uses an instance of this class
 called :class:`AuiDefaultTabArt` which provides bitmap art and a colour scheme that is
@@ -113,7 +113,7 @@ class AuiCommandCapture(wx.EvtHandler):
 class AuiDefaultTabArt(object):
     """
     Tab art provider code - a tab provider provides all drawing functionality to the :class:`~wx.lib.agw.aui.auibook.AuiNotebook`.
-    This allows the :class:`~wx.lib.agw.aui.auibook.AuiNotebook` to have a plugable look-and-feel.
+    This allows the :class:`~wx.lib.agw.aui.auibook.AuiNotebook` to have a pluggable look-and-feel.
 
     By default, a :class:`~wx.lib.agw.aui.auibook.AuiNotebook` uses an instance of this class called
     :class:`AuiDefaultTabArt` which provides bitmap art and a colour scheme that is adapted to the major platforms'
@@ -2115,7 +2115,7 @@ class FF2TabArt(AuiDefaultTabArt):
         bottomStartColour = topEndColour
         bottomEndColour = topEndColour
 
-        # Incase we use bottom tabs, switch the colours
+        # In case we use bottom tabs, switch the colours
         if upperTabs:
             if focus:
                 dc.GradientFillLinear(top, topStartColour, topEndColour, wx.SOUTH)
@@ -2289,7 +2289,7 @@ class VC8TabArt(AuiDefaultTabArt):
         dc.DrawPolygon(tabPoints)
 
         if page.active:
-            # Delete the bottom line (or the upper one, incase we use wxBOTTOM)
+            # Delete the bottom line (or the upper one, in case we use wxBOTTOM)
             dc.SetPen(wx.WHITE_PEN)
             dc.DrawLine(tabPoints[0].x, tabPoints[0].y, tabPoints[6].x, tabPoints[6].y)
 

--- a/wx/lib/agw/aui/tabmdi.py
+++ b/wx/lib/agw/aui/tabmdi.py
@@ -320,7 +320,7 @@ class AuiMDIChildFrame(wx.Panel):
         # before Create() (as is customary on some ports with wxFrame-type
         # windows), or wx.MINIMIZE can be passed in the style flags.  Note that
         # AuiMDIChildFrame is not really derived from wxFrame, as MDIChildFrame
-        # is, but those are the expected symantics.  No style flag is passed
+        # is, but those are the expected semantics.  No style flag is passed
         # onto the panel underneath.
 
         self._activate_on_create = True

--- a/wx/lib/agw/buttonpanel.py
+++ b/wx/lib/agw/buttonpanel.py
@@ -50,7 +50,7 @@ code using the usual::
 method.
 
 The control is generic, and support theming (well, I tested it under
-Windows with the three defauls themes: grey, blue, silver and the
+Windows with the three default themes: grey, blue, silver and the
 classic look).
 
 
@@ -758,7 +758,7 @@ class BPArt(object):
         """
 
         if style & BP_USE_GRADIENT:
-            # Draw gradient colour in the backgroud of the panel
+            # Draw gradient colour in the background of the panel
             self.FillGradientColour(dc, rect)
 
         # Draw a rectangle around the panel
@@ -939,7 +939,7 @@ class Control(wx.EvtHandler):
          done, i.e. if the window had already been in the specified state.
 
         :note: Note that when a parent window is disabled, all of its children are disabled as
-         well and they are reenabled again when the parent is.
+         well and they are re-enabled again when the parent is.
         """
 
         self.disabled = not enable
@@ -2287,7 +2287,7 @@ class ButtonPanel(wx.Panel):
 
     def LayoutItems(self):
         """
-        Layout the items using a different algorithms depending on the existance
+        Layout the items using a different algorithms depending on the existence
         of the main caption.
         """
 
@@ -2728,7 +2728,7 @@ class ButtonPanel(wx.Panel):
         def Freeze(self):
             """
             Freezes the window or, in other words, prevents any updates from taking place
-            on screen, the window is not redrawn at all. :meth:`~ButtonPanel.Thaw` must be called to reenable
+            on screen, the window is not redrawn at all. :meth:`~ButtonPanel.Thaw` must be called to re-enable
             window redrawing. Calls to these two functions may be nested.
 
             :note: This method is useful for visual appearance optimization.

--- a/wx/lib/agw/customtreectrl.py
+++ b/wx/lib/agw/customtreectrl.py
@@ -856,7 +856,7 @@ class DragImage(wx.DragImage):
 
         memory.SelectObject(wx.NullBitmap)
 
-        # Gtk and Windows unfortunatly don't do so well with transparent
+        # Gtk and Windows unfortunately don't do so well with transparent
         # drawing so this hack corrects the image to have a transparent
         # background.
         if wx.Platform != '__WXMAC__':
@@ -1660,7 +1660,7 @@ class GenericTreeItem(object):
 
         """
 
-        # since there can be very many of these, we save size by chosing
+        # since there can be very many of these, we save size by choosing
         # the smallest representation for the elements and by ordering
         # the members to avoid padding.
         self._text = text       # label to be rendered for item
@@ -3483,7 +3483,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
 
     def CheckChilds(self, item, checked=True):
         """
-        Programatically check/uncheck item children.
+        Programmatically check/uncheck item children.
 
         :param `item`: an instance of :class:`GenericTreeItem`;
         :param bool `checked`: ``True`` to check an item, ``False`` to uncheck it.
@@ -5962,7 +5962,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
 
             select = True # the default
 
-            # Check if we need to toggle hilight (ctrl mode)
+            # Check if we need to toggle highlight (ctrl mode)
             if not unselect_others:
                 select = not item.IsSelected()
 
@@ -7228,7 +7228,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
                     yOrigin = abs(yOrigin)
                     width, height = self.GetClientSize()
 
-                    # Move end points to the begining/end of the view?
+                    # Move end points to the beginning/end of the view?
                     if y_mid < yOrigin:
                         y_mid = yOrigin
                     if oldY > yOrigin + height:
@@ -8682,7 +8682,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
         Freeze :class:`CustomTreeCtrl`.
 
         Freezes the window or, in other words, prevents any updates from taking place
-        on screen, the window is not redrawn at all. :meth:`~Thaw` must be called to reenable
+        on screen, the window is not redrawn at all. :meth:`~Thaw` must be called to re-enable
         window redrawing. Calls to these two functions may be nested.
 
         :note: This method is useful for visual appearance optimization (for example,
@@ -8821,7 +8821,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
         rect = self.GetBoundingRect(root, True)
 
         # It looks like the space between the "+" and the node
-        # rect occupies 4 pixels approximatively
+        # rect occupies 4 pixels approximately
         maxwidth = rect.x + rect.width + 4
         lastheight = rect.y + rect.height
 
@@ -8861,7 +8861,7 @@ class CustomTreeCtrl(wx.ScrolledWindow):
             rect = self.GetBoundingRect(child, True)
 
             # It looks like the space between the "+" and the node
-            # rect occupies 4 pixels approximatively
+            # rect occupies 4 pixels approximately
             maxwidth = max(maxwidth, rect.x + rect.width + 4)
             lastheight = rect.y + rect.height
 

--- a/wx/lib/agw/flatmenu.py
+++ b/wx/lib/agw/flatmenu.py
@@ -305,7 +305,7 @@ def GetAccelIndex(label):
     Returns the mnemonic index of the label and the label stripped of the ampersand mnemonic
     (e.g. 'lab&el' ==> will result in 3 and labelOnly = label).
 
-    :param string `label`: a string possibly containining an ampersand.
+    :param string `label`: a string possibly containing an ampersand.
     """
 
     indexAccel = 0
@@ -760,7 +760,7 @@ class FMRenderer(object):
          the menu border;
         :param integer `textX`: the menu item label x position;
         :param integer `rightMarginX`: the right margin between the text and the menu border;
-        :param bool `selected`: ``True`` if this menu item is currentl hovered by the mouse,
+        :param bool `selected`: ``True`` if this menu item is currently hovered by the mouse,
          ``False`` otherwise.
         :param `backgroundImage`: if not ``None``, an instance of :class:`wx.Bitmap` which will
          become the background image for this :class:`FlatMenu`.
@@ -812,7 +812,7 @@ class FMRenderer(object):
 
         if bmp.IsOk():
 
-            # Calculate the postion to place the image
+            # Calculate the position to place the image
             imgHeight = bmp.GetHeight()
             imgWidth  = bmp.GetWidth()
 
@@ -3293,7 +3293,7 @@ class FlatMenuBar(wx.Panel):
         :param `menuInfo`: an instance of :class:`wx.MenuEntryInfo`.
         """
 
-        # first make sure all other menus are not popedup
+        # first make sure all other menus are not poppedup
         if menuInfo.GetMenu().IsShown():
             return
 
@@ -3649,7 +3649,7 @@ class FlatMenuBar(wx.Panel):
         if not self._dlg:
             self._dlg = FMCustomizeDlg(self)
         else:
-            # intialize the dialog
+            # initialize the dialog
             self._dlg.Initialise()
 
         if self._dlg.ShowModal() == wx.ID_OK:
@@ -3907,7 +3907,7 @@ class ShadowPopupWindow(wx.PopupWindow):
         """
         Default class constructor.
 
-        :param `parent`: the :class:`ShadowPopupWindow` parent (tipically your main frame).
+        :param `parent`: the :class:`ShadowPopupWindow` parent (typically your main frame).
         """
 
         if not parent:
@@ -4422,7 +4422,7 @@ class FlatMenuBase(ShadowPopupWindow):
          owner menu, ``False`` otherwise.
         """
 
-        # Check if child menu is poped, if so, dismiss it
+        # Check if child menu is popped, if so, dismiss it
         if self._openedSubMenu:
             self._openedSubMenu.Dismiss(False, resetOwner)
 
@@ -5620,7 +5620,7 @@ class FlatMenu(FlatMenuBase):
 
         dc.SetFont(font)
 
-        accelFiller = "XXXX"     # 4 spaces betweem text and accel column
+        accelFiller = "XXXX"     # 4 spaces between text and accel column
 
         # Calc text length/height
         dummy, itemHeight = dc.GetTextExtent("Tp")
@@ -5836,7 +5836,7 @@ class FlatMenu(FlatMenuBase):
         from this.
         """
 
-        # Draw all childs menus of self menu as well
+        # Draw all child menus of self menu as well
         child = self._openedSubMenu
         while child:
             dc = wx.ClientDC(child)
@@ -5958,7 +5958,7 @@ class FlatMenu(FlatMenuBase):
 
                             itemIdx = i
                             # We keep the index of only
-                            # the first occurence
+                            # the first occurrence
 
                         occur += 1
 
@@ -6735,7 +6735,7 @@ class FlatMenu(FlatMenuBase):
 
         if item.IsRadioItem():
 
-            # Udpate radio groups in case this item is a radio item
+            # Update radio groups in case this item is a radio item
             sibling = self.GetSiblingGroupItem(item)
             if sibling:
 

--- a/wx/lib/agw/flatnotebook.py
+++ b/wx/lib/agw/flatnotebook.py
@@ -947,7 +947,7 @@ def DrawButton(dc, rect, focus, upperTabs):
     bottomStartColour = topEndColour
     bottomEndColour = topEndColour
 
-    # Incase we use bottom tabs, switch the colours
+    # In case we use bottom tabs, switch the colours
     if upperTabs:
         if focus:
             PaintStraightGradientBox(dc, top, topStartColour, topEndColour)
@@ -2231,7 +2231,7 @@ class FNBRenderer(object):
                 pc.Hide()
                 return
 
-        # Get the text hight
+        # Get the text height
         tabHeight = self.CalcTabHeight(pageContainer)
         agwStyle = pc.GetParent().GetAGWWindowStyleFlag()
 
@@ -2290,7 +2290,7 @@ class FNBRenderer(object):
             pen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DFACE))
             dc.SetPen(pen)
 
-            # Draw thik grey line between the windows area and
+            # Draw thick grey line between the windows area and
             # the tab area
             for num in range(3):
                 dc.DrawLine(0, greyLineYVal + num, size.x, greyLineYVal + num)
@@ -2360,7 +2360,7 @@ class FNBRenderer(object):
                 x1 = posx
                 x2 = posx + tabWidth + 2
 
-            # Restore the text forground
+            # Restore the text foreground
             dc.SetTextForeground(pc._activeTextColour)
 
             # Update the tab position & size
@@ -2833,8 +2833,8 @@ class FNBRendererVC71(FNBRenderer):
             dc.DrawLine(posx + tabWidth, blackLineY1, posx + tabWidth, blackLineY2)
 
             # To give the tab more 3D look we do the following
-            # Incase the tab is on top,
-            # Draw a thik white line on topof the rectangle
+            # In case the tab is on top,
+            # Draw a thick white line on topof the rectangle
             # Otherwise, draw a thin (1 pixel) black line at the bottom
 
             pen = wx.Pen((pc.HasAGWFlag(FNB_BOTTOM) and [wx.BLACK] or [wx.WHITE])[0])
@@ -3057,7 +3057,7 @@ class FNBRendererVC8(FNBRenderer):
                 pc.Hide()
                 return
 
-        # Get the text hight
+        # Get the text height
         tabHeight = self.CalcTabHeight(pageContainer)
 
         # Set the font for measuring the tab height
@@ -3142,7 +3142,7 @@ class FNBRendererVC8(FNBRenderer):
             posx = vTabsInfo[cur].x
 
             # By default we clean the tab region
-            # incase we use the VC8 style which requires
+            # in case we use the VC8 style which requires
             # the region, it will be filled by the function
             # drawVc8Tab
             pc._pagesInfoVec[i].GetRegion().Clear()
@@ -3153,7 +3153,7 @@ class FNBRendererVC8(FNBRenderer):
             pc._pagesInfoVec[i].GetXRect().SetSize(wx.Size(-1, -1))
 
             # Draw the tab
-            # Incase we are drawing the active tab
+            # In case we are drawing the active tab
             # we need to redraw so it will appear on top
             # of all other tabs
 
@@ -3168,14 +3168,14 @@ class FNBRendererVC8(FNBRenderer):
 
                 self.DrawTab(pc, dc, posx, i, tabWidth, tabHeight, pc._nTabXButtonStatus)
 
-            # Restore the text forground
+            # Restore the text foreground
             dc.SetTextForeground(pc._activeTextColour)
 
             # Update the tab position & size
             pc._pagesInfoVec[i].SetPosition(wx.Point(posx, VERTICAL_BORDER_PADDING))
             pc._pagesInfoVec[i].SetSize(wx.Size(tabWidth, tabHeight))
 
-        # Incase we are in VC8 style, redraw the active tab (incase it is visible)
+        # In case we are in VC8 style, redraw the active tab (in case it is visible)
         if pc.GetSelection() >= pc._nFrom and pc.GetSelection() < pc._nFrom + len(vTabsInfo):
 
             self.DrawTab(pc, dc, activeTabPosx, pc.GetSelection(), activeTabWidth, activeTabHeight, pc._nTabXButtonStatus)
@@ -3269,8 +3269,8 @@ class FNBRendererVC8(FNBRenderer):
             dc.SetPen(curPen)
             dc.DrawLine(posx, lineY, posx+rect.width, lineY)
 
-        # Incase we are drawing the selected tab, we draw the border of it as well
-        # but without the bottom (upper line incase of wxBOTTOM)
+        # In case we are drawing the selected tab, we draw the border of it as well
+        # but without the bottom (upper line in case of wxBOTTOM)
         if tabIdx == pc.GetSelection():
 
             borderPen = wx.Pen(wx.SystemSettings.GetColour(wx.SYS_COLOUR_BTNSHADOW))
@@ -3278,7 +3278,7 @@ class FNBRendererVC8(FNBRenderer):
             dc.SetBrush(wx.TRANSPARENT_BRUSH)
             dc.DrawPolygon(tabPoints)
 
-            # Delete the bottom line (or the upper one, incase we use wxBOTTOM)
+            # Delete the bottom line (or the upper one, in case we use wxBOTTOM)
             dc.SetPen(wx.WHITE_PEN)
             dc.DrawLine(tabPoints[0].x, tabPoints[0].y, tabPoints[6].x, tabPoints[6].y)
 
@@ -3394,7 +3394,7 @@ class FNBRendererVC8(FNBRenderer):
         # If we are drawing the selected tab, we need also to draw a line
         # from 0.tabPoints[0].x and tabPoints[6].x . end, we achieve this
         # by drawing the rectangle with transparent brush
-        # the line under the selected tab will be deleted by the drwaing loop
+        # the line under the selected tab will be deleted by the drawing loop
         if bSelectedTab:
             self.DrawTabsLine(pc, dc)
 
@@ -3616,7 +3616,7 @@ class FNBRendererRibbonTabs(FNBRenderer):
         self._first = True
         self._factor = 1
 
-    # definte this because we don't want to use the bold font
+    # define this because we don't want to use the bold font
     def CalcTabWidth(self, pageContainer, tabIdx, tabHeight):
         """
         Calculates the width of the input tab.
@@ -3848,7 +3848,7 @@ class FNBRendererRibbonTabs(FNBRenderer):
             # Draw the tab (border, text, image & 'x' on tab)
             self.DrawTab(pc, dc, posx, i, tabWidth, tabHeight, pc._nTabXButtonStatus)
 
-            # Restore the text forground
+            # Restore the text foreground
             dc.SetTextForeground(pc._activeTextColour)
 
             # Update the tab position & size
@@ -3969,7 +3969,7 @@ class FlatNotebook(wx.Panel):
         if "__WXGTK__" in wx.PlatformInfo:
             # For GTK it seems that we must do this steps in order
             # for the tabs will get the proper height on initialization
-            # on MSW, preforming these steps yields wierd results
+            # on MSW, preforming these steps yields weird results
             boldFont = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
             boldFont.SetWeight(wx.FONTWEIGHT_BOLD)
             dc.SetFont(boldFont)
@@ -6207,12 +6207,12 @@ class PageContainer(wx.Panel):
 
     def CanFitToScreen(self, page):
         """
-        Returns wheter a tab can fit in the left space in the screen or not.
+        Returns whether a tab can fit in the left space in the screen or not.
 
         :param `page`: an integer specifying the page index.
         """
 
-        # Incase the from is greater than page,
+        # In case the from is greater than page,
         # we need to reset the self._nFrom, so in order
         # to force the caller to do so, we return false
         if self._nFrom > page:

--- a/wx/lib/agw/floatspin.py
+++ b/wx/lib/agw/floatspin.py
@@ -1327,7 +1327,7 @@ class FixedPoint(object):
         >>>
 
 
-    The string produced by `str(x)` (implictly invoked by `print`) always
+    The string produced by `str(x)` (implicitly invoked by `print`) always
     contains at least one digit before the decimal point, followed by a
     decimal point, followed by exactly `x.get_precision()` digits.  If `x` is
     negative, `str(x)[0] == "-"`.
@@ -1476,7 +1476,7 @@ class FixedPoint(object):
         try:
             p = int(precision)
         except:
-            raise TypeError("precision not convertable to int: " +
+            raise TypeError("precision not convertible to int: " +
                             repr(precision))
         if p < 0:
             raise ValueError("precision must be >= 0: " + repr(precision))

--- a/wx/lib/agw/fmcustomizedlg.py
+++ b/wx/lib/agw/fmcustomizedlg.py
@@ -225,7 +225,7 @@ class FMCustomizeDlg(wx.Dialog):
 
 
     def Initialise(self):
-        """ Initialzes the :class:`~wx.lib.agw.labelbook.LabelBook` pages. """
+        """ Initializes the :class:`~wx.lib.agw.labelbook.LabelBook` pages. """
 
         self._book.DeleteAllPages()
         self._book.AddPage(self.CreateMenusPage(), _("Menus"), True)
@@ -307,10 +307,10 @@ class FMCustomizeDlg(wx.Dialog):
 
 
     def CreateShortcutsPage(self):
-        """ Creates the :class:`~wx.lib.agw.labelbook.LabelBook` shorcuts page. """
+        """ Creates the :class:`~wx.lib.agw.labelbook.LabelBook` shortcuts page. """
 
-        shorcuts = wx.Panel(self._book, wx.ID_ANY, wx.DefaultPosition, wx.Size(300, 300))
-        return shorcuts
+        shortcuts = wx.Panel(self._book, wx.ID_ANY, wx.DefaultPosition, wx.Size(300, 300))
+        return shortcuts
 
 
     def CreateOptionsPage(self):

--- a/wx/lib/agw/foldpanelbar.py
+++ b/wx/lib/agw/foldpanelbar.py
@@ -27,7 +27,7 @@
 # Don't Know What It Means. Probably Is My Poor English...
 #
 # 4. OnSizePanel Function In FoldPanelBar Class:
-# TODO: A Smart Way To Check Wether The Old - New Width Of The
+# TODO: A Smart Way To Check Whether The Old - New Width Of The
 # Panel Changed, If So No Need To Resize The Fold Panel Items
 #
 #
@@ -736,7 +736,7 @@ class CaptionBar(wx.Window):
 
 
     def IsCollapsed(self):
-        """ Returns wether the status of the bar is expanded or collapsed. """
+        """ Returns whether the status of the bar is expanded or collapsed. """
 
         return self._collapsed
 
@@ -796,7 +796,7 @@ class CaptionBar(wx.Window):
 
     def IsVertical(self):
         """
-        Returns wether the :class:`CaptionBar` has a default orientation or not.
+        Returns whether the :class:`CaptionBar` has a default orientation or not.
         Default is vertical.
         """
 
@@ -1425,7 +1425,7 @@ class FoldPanelBar(wx.Panel):
             if vertical and rect.GetHeight() > 0 or not vertical and rect.GetWidth() > 0:
                 self.RefreshRect(rect)
 
-        # TODO: A smart way to check wether the old - new width of the
+        # TODO: A smart way to check whether the old - new width of the
         # panel changed, if so no need to resize the fold panel items
 
         self.RedisplayFoldPanelItems()
@@ -1509,7 +1509,7 @@ class FoldPanelBar(wx.Panel):
         value = wx.Rect(0,0,0,0)
         vertical = self.IsVertical()
 
-        # determine wether the number of panels left
+        # determine whether the number of panels left
         # times the size of their captions is enough
         # to be placed in the left over space
 

--- a/wx/lib/agw/genericmessagedialog.py
+++ b/wx/lib/agw/genericmessagedialog.py
@@ -1422,7 +1422,7 @@ class GenericMessageDialog(wx.Dialog):
 
         :return: a new message wrapped at maximum `wrap` pixels wide.
 
-        :todo: Estabilish if wrapping all messages by default is a better idea than
+        :todo: Establish if wrapping all messages by default is a better idea than
          provide a keyword parameter to :class:`GenericMessageDialog`. A default maximum
          line width might be the wxMac one, at 360 pixels.
         """

--- a/wx/lib/agw/hyperlink.py
+++ b/wx/lib/agw/hyperlink.py
@@ -283,7 +283,7 @@ class HyperLinkCtrl(StaticText):
 
         :param `URL`: the url link we wish to navigate;
         :param `ReportErrors`: Use ``True`` to display error dialog if an error
-         occurrs navigating to the URL;
+         occurs navigating to the URL;
         :param `NotSameWinIfPossible`: Use ``True`` to attempt to open the URL
          in new browser window.
         """
@@ -435,7 +435,7 @@ class HyperLinkCtrl(StaticText):
         :class:`MessageBox`.
 
         :param `ErrorMessage`: a string representing the error to display;
-        :param `ReportErrors`: ``True`` to display error dialog if an error occurrs
+        :param `ReportErrors`: ``True`` to display error dialog if an error occurs
          navigating to the URL.
         """
 
@@ -592,7 +592,7 @@ class HyperLinkCtrl(StaticText):
         Set whether to report browser errors or not.
 
         :param `ReportErrors`: Use ``True`` to display error dialog if an error
-         occurrs navigating to the URL;
+         occurs navigating to the URL;
         """
 
         self._ReportErrors = ReportErrors

--- a/wx/lib/agw/hypertreelist.py
+++ b/wx/lib/agw/hypertreelist.py
@@ -55,7 +55,7 @@ two sub-windows:
 * :class:`TreeListMainWindow` is the main tree list based off :class:`~wx.lib.agw.customtreectrl.CustomTreeCtrl`.
 
 These widgets can be obtained by the :meth:`~HyperTreeList.GetHeaderWindow`
-and :meth:`~HyperTreeList.GetMainWindow` methods respectively althought this
+and :meth:`~HyperTreeList.GetMainWindow` methods respectively although this
 shouldn't be needed in normal usage because most of the methods of the
 sub-windows are monkey-patched and can be called directly from the
 :class:`~wx.lib.agw.hypertreelist.HyperTreeList` itself.
@@ -1119,7 +1119,7 @@ class TreeListHeaderWindow(wx.Window):
             # end of the current column
             xpos = 0
 
-            # find the column where this event occured
+            # find the column where this event occurred
             countCol = self.GetColumnCount()
 
             for column in range(countCol):
@@ -4017,7 +4017,7 @@ class TreeListMainWindow(CustomTreeCtrl):
             header.Update()
 
         # Update the header window after this scroll event has fully finished
-        # processing, and the scoll action is complete.
+        # processing, and the scroll action is complete.
         if event.GetOrientation() == wx.HORIZONTAL:
             wx.CallAfter(_updateHeaderWindow, self._owner.GetHeaderWindow())
         event.Skip()
@@ -4391,7 +4391,7 @@ class HyperTreeList(wx.Control):
     * :class:`TreeListMainWindow` is the main tree list based off :class:`~wx.lib.agw.customtreectrl.CustomTreeCtrl`.
 
     These widgets can be obtained by the :meth:`~HyperTreeList.GetHeaderWindow`
-    and :meth:`~HyperTreeList.GetMainWindow` methods respectively althought this
+    and :meth:`~HyperTreeList.GetMainWindow` methods respectively although this
     shouldn't be needed in normal usage.
 
     Please note that in addition to the defined methods of :class:`HyperTreeList`
@@ -4408,7 +4408,7 @@ class HyperTreeList(wx.Control):
     :meth:`~wx.lib.agw.customtreectrl.CustomTreeCtrl.AutoCheckChild`                 Transverses the tree and checks/unchecks the items.
     :meth:`~wx.lib.agw.customtreectrl.CustomTreeCtrl.AutoCheckParent`                Traverses up the tree and checks/unchecks parent items.
     :meth:`~wx.lib.agw.customtreectrl.CustomTreeCtrl.AutoToggleChild`                Transverses the tree and toggles the items.
-    :meth:`~wx.lib.agw.customtreectrl.CustomTreeCtrl.CheckChilds`                    Programatically check/uncheck item children.
+    :meth:`~wx.lib.agw.customtreectrl.CustomTreeCtrl.CheckChilds`                    Programmatically check/uncheck item children.
     :meth:`~wx.lib.agw.customtreectrl.CustomTreeCtrl.CheckItem`                      Actually checks/uncheks an item, sending the two related events.
     :meth:`~wx.lib.agw.customtreectrl.CustomTreeCtrl.CheckItem2`                     Used internally to avoid ``EVT_TREE_ITEM_CHECKED`` events.
     :meth:`~wx.lib.agw.customtreectrl.CustomTreeCtrl.CheckSameLevel`                 Uncheck radio items which are on the same level of the checked one.
@@ -4622,7 +4622,7 @@ class HyperTreeList(wx.Control):
         Freezes the HyperTreeList main (tree) and and header windows.
         This prevents any re-calculation or updates from taking place
         allowing mass updates to the tree very quickly. :meth:`~Thaw`
-        must be called to reenable updates. Calls to these two
+        must be called to re-enable updates. Calls to these two
         functions may be nested.
         """
         self._main_win.Freeze()

--- a/wx/lib/agw/labelbook.py
+++ b/wx/lib/agw/labelbook.py
@@ -875,7 +875,7 @@ class ImageContainerBase(wx.Panel):
                 self.DrawPin(dc, self._pinBtnRect, not self._bCollapsed)
                 return
 
-        # Incase panel is collapsed, there is nothing
+        # In case panel is collapsed, there is nothing
         # to check
         if self._bCollapsed:
             return
@@ -902,7 +902,7 @@ class ImageContainerBase(wx.Panel):
         self._nHoveredImgIdx = -1
 
         # Make sure the pin button status is NONE
-        # incase we were in pin button style
+        # in case we were in pin button style
         style = self.GetParent().GetAGWWindowStyleFlag()
 
         if style & INB_USE_PIN_BUTTON:
@@ -1247,7 +1247,7 @@ class ImageContainer(ImageContainerBase):
         # We reserver 20 pixels for the 'pin' button
 
         # The drawing of the images start position. This is
-        # depenedent of the style, especially when Pin button
+        # dependent of the style, especially when Pin button
         # style is requested
 
         if bUsePin:
@@ -1270,9 +1270,9 @@ class ImageContainer(ImageContainerBase):
 
             count = count + 1
 
-            # incase the 'fit button' style is applied, we set the rectangle width to the
+            # in case the 'fit button' style is applied, we set the rectangle width to the
             # text width plus padding
-            # Incase the style IS applied, but the style is either LEFT or RIGHT
+            # In case the style IS applied, but the style is either LEFT or RIGHT
             # we ignore it
             dc.SetFont(normalFont)
 
@@ -1300,7 +1300,7 @@ class ImageContainer(ImageContainerBase):
                     rectWidth += 1
 
             # Check that we have enough space to draw the button
-            # If Pin button is used, consider its space as well (applicable for top/botton style)
+            # If Pin button is used, consider its space as well (applicable for top/bottom style)
             # since in the left/right, its size is already considered in 'pos'
             pinBtnSize = (bUsePin and [20] or [0])[0]
 
@@ -1360,7 +1360,7 @@ class ImageContainer(ImageContainerBase):
             else:
                 rect = wx.Rect(pos, 0, rectWidth, rectWidth)
 
-            # Incase user set both flags:
+            # In case user set both flags:
             # INB_SHOW_ONLY_TEXT and INB_SHOW_ONLY_IMAGES
             # We override them to display both
 

--- a/wx/lib/agw/multidirdialog.py
+++ b/wx/lib/agw/multidirdialog.py
@@ -39,7 +39,7 @@ ability of selecting multiple folders at once. It may be useful when you wish to
 present to the user a directory browser which allows multiple folder selections.
 :class:`MultiDirDialog` sports the following features:
 
-* Ability to select a single or mutliple folders, depending on the style passed;
+* Ability to select a single or multiple folders, depending on the style passed;
 * More colourful and eye-catching buttons;
 * Good old Python code :-D .
 
@@ -468,7 +468,7 @@ class MultiDirDialog(wx.Dialog):
         """
         Recurse a directory tree to include the parent-folder.
 
-        :param `treeCtrl`: the tree control associated with teh internal :class:`GenericDirCtrl`;
+        :param `treeCtrl`: the tree control associated with the internal :class:`GenericDirCtrl`;
         :param `item`: the selected tree control item;
         :param `itemText`: the selected tree control item text.
         """

--- a/wx/lib/agw/pycollapsiblepane.py
+++ b/wx/lib/agw/pycollapsiblepane.py
@@ -484,7 +484,7 @@ class PyCollapsiblePane(wx.Panel):
         self.SetSize(sz)
 
         if self.HasAGWFlag(wx.CP_NO_TLW_RESIZE):
-            # the user asked to explicitely handle the resizing itself...
+            # the user asked to explicitly handle the resizing itself...
             return
 
         # NB: the following block of code has been accurately designed to

--- a/wx/lib/agw/pyprogress.py
+++ b/wx/lib/agw/pyprogress.py
@@ -612,7 +612,7 @@ class PyProgress(wx.Dialog):
                 return False
 
             else:
-                # reenable other windows before hiding this one because otherwise
+                # re-enable other windows before hiding this one because otherwise
                 # Windows wouldn't give the focus back to the window which had
                 # been previously focused because it would still be disabled
                 self.ReenableOtherWindows()
@@ -723,7 +723,7 @@ class PyProgress(wx.Dialog):
          ``False`` otherwise.
         """
 
-        # reenable other windows before hiding this one because otherwise
+        # re-enable other windows before hiding this one because otherwise
         # Windows wouldn't give the focus back to the window which had
         # been previously focused because it would still be disabled
         if not show:

--- a/wx/lib/agw/ribbon/art_aui.py
+++ b/wx/lib/agw/ribbon/art_aui.py
@@ -954,7 +954,7 @@ class RibbonAUIArtProvider(RibbonMSWArtProvider):
         """
         Draw the background and chrome for a :class:`~wx.lib.agw.ribbon.gallery.RibbonGallery` control.
 
-        This should draw the border, brackground, scroll buttons, extension button, and
+        This should draw the border, background, scroll buttons, extension button, and
         any other UI elements which are not attached to a specific gallery item.
 
         :param `dc`: The device context to draw onto;

--- a/wx/lib/agw/ribbon/art_msw.py
+++ b/wx/lib/agw/ribbon/art_msw.py
@@ -129,7 +129,7 @@ class RibbonMSWArtProvider(object):
         in a colour scheme similar to, if not identical to, the default colours of the
         art provider. Note that if :meth:`~RibbonMSWArtProvider.SetColour` is called, then :meth:`~RibbonMSWArtProvider.GetColourScheme` does
         not try and return a colour scheme similar to colours being used - it's return
-        values are dependant upon the last values given to :meth:`~RibbonMSWArtProvider.SetColourScheme`, as
+        values are dependent upon the last values given to :meth:`~RibbonMSWArtProvider.SetColourScheme`, as
         described above.
 
         :param `primary`: Pointer to a location to store the primary colour, or ``None``;
@@ -1135,7 +1135,7 @@ class RibbonMSWArtProvider(object):
         background = page.AdjustRectToIncludeScrollButtons(background)
         background.height -= 2
 
-        # Page background isn't dependant upon the width of the page
+        # Page background isn't dependent upon the width of the page
         # (at least not the part of it intended to be painted by this
         # function). Set to wider than the page itself for when externally
         # expanded panels need a background - the expanded panel can be wider
@@ -1144,7 +1144,7 @@ class RibbonMSWArtProvider(object):
         background.x = 0
         background.width = 10000
 
-        # upper_rect, lower_rect, paint_rect are all in page co-ordinates
+        # upper_rect, lower_rect, paint_rect are all in page coordinates
         upper_rect = wx.Rect(*background)
         upper_rect.height /= 5
 
@@ -1536,7 +1536,7 @@ class RibbonMSWArtProvider(object):
         """
         Draw the background and chrome for a :class:`~wx.lib.agw.ribbon.gallery.RibbonGallery` control.
 
-        This should draw the border, brackground, scroll buttons, extension button, and
+        This should draw the border, background, scroll buttons, extension button, and
         any other UI elements which are not attached to a specific gallery item.
 
         :param `dc`: The device context to draw onto;
@@ -2517,7 +2517,7 @@ class RibbonMSWArtProvider(object):
         is resized.
 
         To optimise the drawing of page backgrounds, as small an area as possible should
-        be returned. Of couse, if the way in which a background is drawn means that the
+        be returned. Of course, if the way in which a background is drawn means that the
         entire background needs to be repainted on resize, then the entire new size
         should be returned.
 

--- a/wx/lib/agw/ribbon/buttonbar.py
+++ b/wx/lib/agw/ribbon/buttonbar.py
@@ -1093,7 +1093,7 @@ class RibbonButtonBar(RibbonControl):
             # If height isn't preserved (i.e. it is reduced), then the minimum
             # size for the button bar will decrease, preventing the original
             # layout from being used (in some cases).
-            # It may be a good idea to always preverse the height, but for now
+            # It may be a good idea to always preserve the height, but for now
             # it is only done when the first button is involved in a collapse.
             preserve_height = True
 

--- a/wx/lib/agw/ribbon/page.py
+++ b/wx/lib/agw/ribbon/page.py
@@ -261,7 +261,7 @@ class RibbonPage(RibbonControl):
         Scroll the page by some amount up / down / left / right.
 
         When the page's children are too big to fit in the onscreen area given to the
-        page, scroll buttons will appear, and the page can be programatically scrolled.
+        page, scroll buttons will appear, and the page can be programmatically scrolled.
         Positive values of will scroll right or down, while negative values will scroll
         up or left (depending on the direction in which panels are stacked). A line is
         equivalent to a constant number of pixels.
@@ -284,7 +284,7 @@ class RibbonPage(RibbonControl):
         Scroll the page by a set number of pixels up / down / left / right.
 
         When the page's children are too big to fit in the onscreen area given to the
-        page, scroll buttons will appear, and the page can be programatically scrolled.
+        page, scroll buttons will appear, and the page can be programmatically scrolled.
         Positive values of will scroll right or down, while negative values will scroll
         up or left (depending on the direction in which panels are stacked).
 
@@ -418,7 +418,7 @@ class RibbonPage(RibbonControl):
         # When a resize triggers the scroll buttons to become visible, the page is resized.
         # This resize from within a resize event can cause (MSW) wxWidgets some confusion,
         # and report the 1st size to the 2nd size event. Hence the most recent size is
-        # remembered internally and used in Layout() where appropiate.
+        # remembered internally and used in Layout() where appropriate.
 
         if self.GetMajorAxis() == wx.HORIZONTAL:
             self._size_in_major_axis_for_children = width

--- a/wx/lib/agw/ribbon/panel.py
+++ b/wx/lib/agw/ribbon/panel.py
@@ -901,13 +901,13 @@ class RibbonPanel(RibbonControl):
         Show the panel externally expanded.
 
         When a panel is minimised, it can be shown full-size in a pop-out window, which
-        is refered to as being (externally) expanded.
+        is referred to as being (externally) expanded.
 
         :returns: ``True`` if the panel was expanded, ``False`` if it was not (possibly
          due to it not being minimised, or already being expanded).
 
         :note: When a panel is expanded, there exist two panels - the original panel
-         (which is refered to as the dummy panel) and the expanded panel. The original
+         (which is referred to as the dummy panel) and the expanded panel. The original
          is termed a dummy as it sits in the ribbon bar doing nothing, while the expanded
          panel holds the panel children.
 
@@ -1020,7 +1020,7 @@ class RibbonPanel(RibbonControl):
             self.HideExpanded()
             # Do not skip event, as the panel has been de-expanded, causing the
             # child with focus to be reparented (and hidden). If the event
-            # continues propogation then bad things happen.
+            # continues propagation then bad things happen.
 
         else:
             event.Skip()

--- a/wx/lib/agw/ribbon/toolbar.py
+++ b/wx/lib/agw/ribbon/toolbar.py
@@ -393,7 +393,7 @@ class RibbonToolBar(RibbonControl):
         Adds a separator to the tool bar.
 
         Separators are used to separate tools into groups. As such, a separator is not
-        explicity drawn, but is visually seen as the gap between tool groups.
+        explicitly drawn, but is visually seen as the gap between tool groups.
         """
 
         if not self._groups[-1].tools:
@@ -408,7 +408,7 @@ class RibbonToolBar(RibbonControl):
         Inserts a separator into the tool bar at the position specified by `pos`.
 
         Separators are used to separate tools into groups. As such, a separator is not
-        explicity drawn, but is visually seen as the gap between tool groups.
+        explicitly drawn, but is visually seen as the gap between tool groups.
 
         :param `pos`: the position of the new tool in the toolbar (zero-based).
 
@@ -944,7 +944,7 @@ class RibbonToolBar(RibbonControl):
         Set the number of rows to distribute tool groups over.
 
         Tool groups can be distributed over a variable number of rows. The way in which
-        groups are assigned to rows is not specificed, and the order of groups may
+        groups are assigned to rows is not specified, and the order of groups may
         change, but they will be distributed in such a way as to minimise the overall
         size of the tool bar.
 

--- a/wx/lib/agw/rulerctrl.py
+++ b/wx/lib/agw/rulerctrl.py
@@ -344,7 +344,7 @@ class RulerCtrlEvent(wx.CommandEvent):
 
 class Label(object):
     """
-    Auxilary class. Just holds information about a label in :class:`RulerCtrl`.
+    Auxiliary class. Just holds information about a label in :class:`RulerCtrl`.
     """
 
     def __init__(self, pos=-1, lx=-1, ly=-1, text=""):

--- a/wx/lib/agw/scrolledthumbnail.py
+++ b/wx/lib/agw/scrolledthumbnail.py
@@ -46,7 +46,7 @@ title frame, or a PDF by providing an image of the cover page.  The images for
 these files may be generated on the fly by a suitably extended :class:`ImageHandler`,
 or may be provided with the instance of :class:`Thumb`.  The list of `Thumb`
 instances passed to `ScrolledThumbnail` may contain different derived classes,
-as long as each contains the required funtions.
+as long as each contains the required functions.
 
 NB:  Use of :class:`ScrolledThumbnail` has not been tested with extended classes.
 

--- a/wx/lib/agw/shapedbutton.py
+++ b/wx/lib/agw/shapedbutton.py
@@ -463,7 +463,7 @@ class SButton(wx.Window):
 
 
     def IsEnabled(self):
-        """ Returns wheter the button is enabled or not. """
+        """ Returns whether the button is enabled or not. """
 
         return self._enabled
 

--- a/wx/lib/agw/shortcuteditor.py
+++ b/wx/lib/agw/shortcuteditor.py
@@ -1370,7 +1370,7 @@ class Shortcut(object):
          the `filter` string to look for a match.
 
         :return: An instance of :class:`Shortcut` if the `filter` string is contained in
-         the `item` lable, ``None`` otherwise.
+         the `item` label, ``None`` otherwise.
 
         :note: The string-matching is case-insensitive.
         """
@@ -1951,7 +1951,7 @@ class ListShortcut(HTL.HyperTreeList, treemixin.ExpansionState):
         keyCode = event.GetKeyCode()
         modifiers = event.GetModifiers()
 
-        # If we press backspace with no modifers down, *and* the current text is
+        # If we press backspace with no modifiers down, *and* the current text is
         # "New accelerator..." then we reset the accelerator to "Disabled"
         if keyCode == wx.WXK_BACK and modifiers == 0 and currentText in [NEW_ACCEL_STRING, DISABLED_STRING]:
 

--- a/wx/lib/agw/speedmeter.py
+++ b/wx/lib/agw/speedmeter.py
@@ -161,7 +161,7 @@ This class supports the following window styles:
 Window Styles               Hex Value   Description
 =========================== =========== ==================================================
 ``SM_ROTATE_TEXT``                  0x1 Draws the ticks rotated: the ticks are rotated accordingly to the tick marks positions.
-``SM_DRAW_SECTORS``                 0x2 Different intervals are painted in differend colours (every sector of the circle has its own colour).
+``SM_DRAW_SECTORS``                 0x2 Different intervals are painted in different colours (every sector of the circle has its own colour).
 ``SM_DRAW_PARTIAL_SECTORS``         0x4 Every interval has its own colour, but only a circle corona is painted near the ticks.
 ``SM_DRAW_HAND``                    0x8 The hand (arrow indicator) is drawn.
 ``SM_DRAW_SHADOW``                 0x10 A shadow for the hand is drawn.
@@ -217,7 +217,7 @@ SM_BUFFERED_DC = 1
 #----------------------------------------------------------------------
 # SM_ROTATE_TEXT: Draws The Ticks Rotated: The Ticks Are Rotated
 #                 Accordingly To The Tick Marks Positions
-# SM_DRAW_SECTORS: Different Intervals Are Painted In Differend Colours
+# SM_DRAW_SECTORS: Different Intervals Are Painted In Different Colours
 #                  (Every Sector Of The Circle Has Its Own Colour)
 # SM_DRAW_PARTIAL_SECTORS: Every Interval Has Its Own Colour, But Only
 #                          A Circle Corona Is Painted Near The Ticks
@@ -239,7 +239,7 @@ SM_BUFFERED_DC = 1
 SM_ROTATE_TEXT = 1
 """ Draws the ticks rotated: the ticks are rotated accordingly to the tick marks positions. """
 SM_DRAW_SECTORS = 2
-""" Different intervals are painted in differend colours (every sector of the circle has its own colour). """
+""" Different intervals are painted in different colours (every sector of the circle has its own colour). """
 SM_DRAW_PARTIAL_SECTORS = 4
 """ Every interval has its own colour, but only a circle corona is painted near the ticks. """
 SM_DRAW_HAND = 8
@@ -455,7 +455,7 @@ class SpeedMeter(BufferedWindow):
          Window Styles               Hex Value   Description
          =========================== =========== ==================================================
          ``SM_ROTATE_TEXT``                  0x1 Draws the ticks rotated: the ticks are rotated accordingly to the tick marks positions.
-         ``SM_DRAW_SECTORS``                 0x2 Different intervals are painted in differend colours (every sector of the circle has its own colour).
+         ``SM_DRAW_SECTORS``                 0x2 Different intervals are painted in different colours (every sector of the circle has its own colour).
          ``SM_DRAW_PARTIAL_SECTORS``         0x4 Every interval has its own colour, but only a circle corona is painted near the ticks.
          ``SM_DRAW_HAND``                    0x8 The hand (arrow indicator) is drawn.
          ``SM_DRAW_SHADOW``                 0x10 A shadow for the hand is drawn.
@@ -592,7 +592,7 @@ class SpeedMeter(BufferedWindow):
         self.Radius = radius
         self.Radius = radius
 
-        # Get The Angle Of Existance Of The Sector
+        # Get The Angle Of Existence Of The Sector
         anglerange = self.GetAngleRange()
         startangle = anglerange[1]
         endangle = anglerange[0]
@@ -1689,7 +1689,7 @@ class SpeedMeter(BufferedWindow):
 
     def DrawExternalArc(self, draw=True):
         """
-        Specify wheter or not you wish to draw the external (thicker) arc.
+        Specify whether or not you wish to draw the external (thicker) arc.
 
         :param `draw`: ``True`` to draw the external arc, ``False`` otherwise.
         """

--- a/wx/lib/agw/supertooltip.py
+++ b/wx/lib/agw/supertooltip.py
@@ -43,8 +43,8 @@ windows, although it is a custom-drawn widget.
 This class supports:
 
 * Blended triple-gradient for the tooltip background;
-* Header text and header image, with possibility to set the header font indipendently;
-* Footer text and footer image, with possibility to set the footer font indipendently;
+* Header text and header image, with possibility to set the header font independently;
+* Footer text and footer image, with possibility to set the footer font independently;
 * Multiline text message in the tooltip body, plus an optional image as "body image";
 * Bold lines and hyperlink lines in the tooltip body;
 * A wide set of predefined drawing styles for the tooltip background;
@@ -1260,7 +1260,7 @@ class SuperToolTip(object):
 
 
     def InitFont(self):
-        """ Initalizes the fonts for :class:`SuperToolTip`. """
+        """ Initializes the fonts for :class:`SuperToolTip`. """
 
         self._messageFont = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
         self._headerFont = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)

--- a/wx/lib/agw/thumbnailctrl.py
+++ b/wx/lib/agw/thumbnailctrl.py
@@ -484,7 +484,7 @@ class ThumbnailCtrl(wx.Panel):
         Deletes the selected thumbnails and their associated files.
         .. warning:: This method deletes the original files too.
 
-        :parem `thumbs`:  List of indexs to thumbnails.
+        :param `thumbs`:  List of indexes to thumbnails.
 
         """
 

--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -163,7 +163,7 @@ Window Styles                    Hex Value   Description
 ``ULC_AUTO_CHECK_PARENT``          0x1000000 Only meaningful foe checkbox-type items: when an item is checked/unchecked its column header item is checked/unchecked as well.
 ``ULC_SHOW_TOOLTIPS``              0x2000000 Show tooltips for ellipsized items/subitems (text too long to be shown in the available space) containing the full item/subitem text.
 ``ULC_HOT_TRACKING``               0x4000000 Enable hot tracking of items on mouse motion.
-``ULC_BORDER_SELECT``              0x8000000 Changes border colour whan an item is selected, instead of highlighting the item.
+``ULC_BORDER_SELECT``              0x8000000 Changes border colour when an item is selected, instead of highlighting the item.
 ``ULC_TRACK_SELECT``              0x10000000 Enables hot-track selection in a list control. Hot track selection means that an item is automatically selected when the cursor remains over the item for a certain period of time. The delay is retrieved on Windows using the `win32api` call `win32gui.SystemParametersInfo(win32con.SPI_GETMOUSEHOVERTIME)`, and is defaulted to 400ms on other platforms. This style applies to all views of `UltimateListCtrl`.
 ``ULC_HEADER_IN_ALL_VIEWS``       0x20000000 Show column headers in all view modes.
 ``ULC_NO_FULL_ROW_SELECT``        0x40000000 When an item is selected, the only the item in the first column is highlighted.
@@ -286,7 +286,7 @@ ULC_AUTO_TOGGLE_CHILD   = 0x800000     # only meaningful for checkboxes
 ULC_AUTO_CHECK_PARENT   = 0x1000000    # only meaningful for checkboxes
 ULC_SHOW_TOOLTIPS       = 0x2000000    # shows tooltips on items with ellipsis (...)
 ULC_HOT_TRACKING        = 0x4000000    # enable hot tracking on mouse motion
-ULC_BORDER_SELECT       = 0x8000000    # changes border colour whan an item is selected, instead of highlighting the item
+ULC_BORDER_SELECT       = 0x8000000    # changes border colour when an item is selected, instead of highlighting the item
 ULC_TRACK_SELECT        = 0x10000000   # Enables hot-track selection in a list control. Hot track selection means that an item
                                        # is automatically selected when the cursor remains over the item for a certain period
                                        # of time. The delay is retrieved on Windows using the win32api call
@@ -4288,7 +4288,7 @@ class UltimateListLineData(object):
         # fg colour
         # don't use foreground colour for drawing highlighted items - this might
         # make them completely invisible (and there is no way to do bit
-        # arithmetics on wxColour, unfortunately)
+        # arithmetic on wxColour, unfortunately)
 
         if not self._owner.HasAGWFlag(ULC_BORDER_SELECT) and not self._owner.HasAGWFlag(ULC_NO_FULL_ROW_SELECT):
             if highlighted:
@@ -5991,7 +5991,7 @@ class UltimateListMainWindow(wx.ScrolledWindow):
          ``ULC_AUTO_CHECK_PARENT``          0x1000000 Only meaningful foe checkbox-type items: when an item is checked/unchecked its column header item is checked/unchecked as well.
          ``ULC_SHOW_TOOLTIPS``              0x2000000 Show tooltips for ellipsized items/subitems (text too long to be shown in the available space) containing the full item/subitem text.
          ``ULC_HOT_TRACKING``               0x4000000 Enable hot tracking of items on mouse motion.
-         ``ULC_BORDER_SELECT``              0x8000000 Changes border colour whan an item is selected, instead of highlighting the item.
+         ``ULC_BORDER_SELECT``              0x8000000 Changes border colour when an item is selected, instead of highlighting the item.
          ``ULC_TRACK_SELECT``              0x10000000 Enables hot-track selection in a list control. Hot track selection means that an item is automatically selected when the cursor remains over the item for a certain period of time. The delay is retrieved on Windows using the `win32api` call `win32gui.SystemParametersInfo(win32con.SPI_GETMOUSEHOVERTIME)`, and is defaulted to 400ms on other platforms. This style applies to all views of `UltimateListCtrl`.
          ``ULC_HEADER_IN_ALL_VIEWS``       0x20000000 Show column headers in all view modes.
          ``ULC_NO_FULL_ROW_SELECT``        0x40000000 When an item is selected, the only the item in the first column is highlighted.
@@ -6309,7 +6309,7 @@ class UltimateListMainWindow(wx.ScrolledWindow):
 
     # bring the current item into view
     def MoveToFocus(self):
-        """ Brings tyhe current item into view. """
+        """ Brings the current item into view. """
 
         self.MoveToItem(self._current)
 
@@ -8851,8 +8851,8 @@ class UltimateListMainWindow(wx.ScrolledWindow):
 
         if self.HasCurrent() and state == 0 and stateMask & ULC_STATE_FOCUSED:
 
-            # unfocus all: only one item can be focussed, so clearing focus for
-            # all items is simply clearing focus of the focussed item.
+            # unfocus all: only one item can be focused, so clearing focus for
+            # all items is simply clearing focus of the focused item.
             self.SetItemState(self._current, state, stateMask)
 
         #(setting focus to all items makes no sense, so it is not handled here.)
@@ -10839,7 +10839,7 @@ class UltimateListCtrl(wx.Control):
          ``ULC_AUTO_CHECK_PARENT``          0x1000000 Only meaningful foe checkbox-type items: when an item is checked/unchecked its column header item is checked/unchecked as well.
          ``ULC_SHOW_TOOLTIPS``              0x2000000 Show tooltips for ellipsized items/subitems (text too long to be shown in the available space) containing the full item/subitem text.
          ``ULC_HOT_TRACKING``               0x4000000 Enable hot tracking of items on mouse motion.
-         ``ULC_BORDER_SELECT``              0x8000000 Changes border colour whan an item is selected, instead of highlighting the item.
+         ``ULC_BORDER_SELECT``              0x8000000 Changes border colour when an item is selected, instead of highlighting the item.
          ``ULC_TRACK_SELECT``              0x10000000 Enables hot-track selection in a list control. Hot track selection means that an item is automatically selected when the cursor remains over the item for a certain period of time. The delay is retrieved on Windows using the `win32api` call `win32gui.SystemParametersInfo(win32con.SPI_GETMOUSEHOVERTIME)`, and is defaulted to 400ms on other platforms. This style applies to all views of `UltimateListCtrl`.
          ``ULC_HEADER_IN_ALL_VIEWS``       0x20000000 Show column headers in all view modes.
          ``ULC_NO_FULL_ROW_SELECT``        0x40000000 When an item is selected, the only the item in the first column is highlighted.
@@ -11036,7 +11036,7 @@ class UltimateListCtrl(wx.Control):
          ``ULC_AUTO_CHECK_PARENT``          0x1000000 Only meaningful foe checkbox-type items: when an item is checked/unchecked its column header item is checked/unchecked as well.
          ``ULC_SHOW_TOOLTIPS``              0x2000000 Show tooltips for ellipsized items/subitems (text too long to be shown in the available space) containing the full item/subitem text.
          ``ULC_HOT_TRACKING``               0x4000000 Enable hot tracking of items on mouse motion.
-         ``ULC_BORDER_SELECT``              0x8000000 Changes border colour whan an item is selected, instead of highlighting the item.
+         ``ULC_BORDER_SELECT``              0x8000000 Changes border colour when an item is selected, instead of highlighting the item.
          ``ULC_TRACK_SELECT``              0x10000000 Enables hot-track selection in a list control. Hot track selection means that an item is automatically selected when the cursor remains over the item for a certain period of time. The delay is retrieved on Windows using the `win32api` call `win32gui.SystemParametersInfo(win32con.SPI_GETMOUSEHOVERTIME)`, and is defaulted to 400ms on other platforms. This style applies to all views of `UltimateListCtrl`.
          ``ULC_HEADER_IN_ALL_VIEWS``       0x20000000 Show column headers in all view modes.
          ``ULC_NO_FULL_ROW_SELECT``        0x40000000 When an item is selected, the only the item in the first column is highlighted.
@@ -11123,7 +11123,7 @@ class UltimateListCtrl(wx.Control):
          ``ULC_AUTO_CHECK_PARENT``          0x1000000 Only meaningful foe checkbox-type items: when an item is checked/unchecked its column header item is checked/unchecked as well.
          ``ULC_SHOW_TOOLTIPS``              0x2000000 Show tooltips for ellipsized items/subitems (text too long to be shown in the available space) containing the full item/subitem text.
          ``ULC_HOT_TRACKING``               0x4000000 Enable hot tracking of items on mouse motion.
-         ``ULC_BORDER_SELECT``              0x8000000 Changes border colour whan an item is selected, instead of highlighting the item.
+         ``ULC_BORDER_SELECT``              0x8000000 Changes border colour when an item is selected, instead of highlighting the item.
          ``ULC_TRACK_SELECT``              0x10000000 Enables hot-track selection in a list control. Hot track selection means that an item is automatically selected when the cursor remains over the item for a certain period of time. The delay is retrieved on Windows using the `win32api` call `win32gui.SystemParametersInfo(win32con.SPI_GETMOUSEHOVERTIME)`, and is defaulted to 400ms on other platforms. This style applies to all views of `UltimateListCtrl`.
          ``ULC_HEADER_IN_ALL_VIEWS``       0x20000000 Show column headers in all view modes.
          ``ULC_NO_FULL_ROW_SELECT``        0x40000000 When an item is selected, the only the item in the first column is highlighted.

--- a/wx/lib/agw/xlsgrid.py
+++ b/wx/lib/agw/xlsgrid.py
@@ -97,7 +97,7 @@ the following formatting features already implemented:
   gradient shading inside a cell as `xlrd` doesn't report this information.
 
 * Cell borders: support for all the border types and colours exposed by Excel
-  (left, top, bottom, right and diagonal borders, thin, double, thick, ect...
+  (left, top, bottom, right and diagonal borders, thin, double, thick, etc...
   line styles).
 
 * Cell text: support for all kind of fonts (except strikethrough, but this is
@@ -2069,7 +2069,7 @@ class XLSGrid(gridlib.Grid):
 
 class TransientPopup(STT.SuperToolTip):
     """
-    This is a sublass of :class:`SuperToolTip` and it is used to display a
+    This is a subclass of :class:`SuperToolTip` and it is used to display a
     "comment-window" on the cells containing a comment (a note).
 
     :note: If Mark Hammonds' `pywin32` package is not available, this class is

--- a/wx/lib/analogclock/analogclock.py
+++ b/wx/lib/analogclock/analogclock.py
@@ -496,7 +496,7 @@ class AnalogClock(wx.Window):
 
 
     def SetBackgroundColour(self, colour):
-        """Overriden base wx.Window method."""
+        """Overridden base wx.Window method."""
 
         wx.Window.SetBackgroundColour(self, colour)
         self.Reset()
@@ -504,7 +504,7 @@ class AnalogClock(wx.Window):
 
     def SetForegroundColour(self, colour):
         """
-        Overriden base wx.Window method. This method sets a colour for
+        Overridden base wx.Window method. This method sets a colour for
         all hands and ticks at once.
         """
 
@@ -517,7 +517,7 @@ class AnalogClock(wx.Window):
 
 
     def SetWindowStyle(self, *args, **kwargs):
-        """Overriden base wx.Window method."""
+        """Overridden base wx.Window method."""
 
         size = self.GetSize()
         self.Freeze()
@@ -528,7 +528,7 @@ class AnalogClock(wx.Window):
 
 
     def SetWindowStyleFlag(self, *args, **kwargs):
-        """Overriden base wx.Window method."""
+        """Overridden base wx.Window method."""
 
         self.SetWindowStyle(*args, **kwargs)
 

--- a/wx/lib/busy.py
+++ b/wx/lib/busy.py
@@ -26,7 +26,7 @@ class BusyInfo(object):
     size) and the background and foreground colors of the message box can be
     set.
 
-    Creating an instace of the class will create and show a window with the
+    Creating an instance of the class will create and show a window with the
     given message, and when the instance is deleted then that window will be
     closed. This class also implements the context manager magic methods, so
     it can be used with Python's `with` statement, like this::

--- a/wx/lib/buttons.py
+++ b/wx/lib/buttons.py
@@ -535,7 +535,7 @@ class GenButton(wx.Control):
                     colBg = self.GetParent().GetBackgroundColour()
                     brush = wx.Brush(colBg)
         else:
-            # this line assumes that a pressed button should be hilighted with
+            # this line assumes that a pressed button should be highlighted with
             # a solid colour even if the background is supposed to be transparent
             brush = wx.Brush(self.faceDnClr)
         return brush

--- a/wx/lib/calendar.py
+++ b/wx/lib/calendar.py
@@ -44,7 +44,7 @@
 # 06/02/2004 - Joerg "Adi" Sieker adi@sieker.info
 #
 # o Changed color handling, use dictionary instead of members.
-#   This causes all color changes to be ignored if they manipluate the members directly.
+#   This causes all color changes to be ignored if they manipulate the members directly.
 #   SetWeekColor and other method color methods were adapted to use the new dictionary.
 # o Added COLOR_* constants
 # o Added SetColor method for Calendar class
@@ -440,7 +440,7 @@ class CalDraw:
                 date = date + 7
 
     def GetRect(self):
-        """Get the display rectange list of the day grid."""
+        """Get the display rectangle list of the day grid."""
         cnt = 0
         h = 0
         w = 0
@@ -575,12 +575,12 @@ class CalDraw:
 
             pen = wx.Pen(MakeColor(self.colors[COLOR_3D_LIGHT]), 1, wx.PENSTYLE_SOLID)
             DC.SetPen(pen)
-            # draw the horizontal hilight
+            # draw the horizontal highlight
             startPoint = wx.Point(x + 1, y + 1)
             endPoint = wx.Point(x + width - 1, y + 1)
             DC.DrawLine(startPoint, endPoint)
 
-            # draw the vertical hilight
+            # draw the vertical highlight
             startPoint = wx.Point(x + 1, y + 1)
             endPoint = wx.Point(x + 1, y + height - 2)
             DC.DrawLine(startPoint, endPoint)
@@ -759,7 +759,7 @@ class CalDraw:
         self.gridy = []
 
         self.x_st = self.cx_st + self.x_mrg
-        # start postion of draw
+        # start position of draw
         self.y_st = self.cy_st + self.y_mrg + self.title_offset
 
         x1 = self.x_st
@@ -1218,7 +1218,7 @@ class Calendar(wx.Control):
         Find the clicked area rectangle.
 
         :param `mx`: the x position
-        :param `my`: the y positon
+        :param `my`: the y position
 
         """
         for key in self.rg:
@@ -1244,10 +1244,10 @@ class Calendar(wx.Control):
 
     def SetTextAlign(self, vert, horz):
         """
-        Set the text allignment.
+        Set the text alignment.
 
-        :param `vert`: the vertical allignment
-        :param `horz`: the horizontal allignment
+        :param `vert`: the vertical alignment
+        :param `horz`: the horizontal alignment
 
         """
         self.num_align_horz = horz

--- a/wx/lib/checkbox.py
+++ b/wx/lib/checkbox.py
@@ -3,7 +3,7 @@
 # Purpose:     Various kinds of generic checkbox stuff, (not native controls
 #              but self-drawn.)
 #
-# Author:      wxPython Team and wxPyWiki Contributers
+# Author:      wxPython Team and wxPyWiki Contributors
 #
 # Created:     22-June-2020
 # Copyright:   (c) 2020 by Total Control Software
@@ -127,9 +127,9 @@ class GenCheckBox(wx.Control):
         self.Bind(wx.EVT_PAINT, self.OnPaint)
         # Since the paint event draws the whole widget, we will use
         # SetBackgroundStyle(wx.BG_STYLE_PAINT) and then
-        # implementing an erase-background handler is not neccessary.
+        # implementing an erase-background handler is not necessary.
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
-        # Add a size handler to refresh so the paint wont smear when resizing.
+        # Add a size handler to refresh so the paint won't smear when resizing.
         self.Bind(wx.EVT_SIZE, self.OnSize)
 
         # Then we want to monitor user clicks, so that we can switch our

--- a/wx/lib/colourchooser/canvas.py
+++ b/wx/lib/colourchooser/canvas.py
@@ -91,7 +91,7 @@ class Canvas(wx.Window):
             self.SetMaxClientSize(forceClientSize)
             self.SetMinClientSize(forceClientSize)
 
-        # Perform an intial sizing
+        # Perform an initial sizing
         self.ReDraw()
 
         # Register event handlers
@@ -132,7 +132,7 @@ class Canvas(wx.Window):
         dc.Blit(0, 0, width, height, self.buffer, 0, 0)
 
     def GetBoundingRect(self):
-        """Returns a tuple that contains the co-ordinates of the
+        """Returns a tuple that contains the coordinates of the
         top-left and bottom-right corners of the canvas."""
         x, y = self.GetPosition()
         w, h = self.GetSize()

--- a/wx/lib/combotreebox.py
+++ b/wx/lib/combotreebox.py
@@ -661,7 +661,7 @@ class BaseComboTreeBox(object):
         :rtype: integer
 
         """
-        # Note: We don't need to substract 1 for the hidden root item,
+        # Note: We don't need to subtract 1 for the hidden root item,
         # because the TreeCtrl does that for us
         return self._tree.GetCount()
 

--- a/wx/lib/delayedresult.py
+++ b/wx/lib/delayedresult.py
@@ -86,7 +86,7 @@ class Handler:
 class Sender:
     """
     Base class for various kinds of senders. A sender sends a result
-    produced by a worker funtion to a result handler (listener). Note
+    produced by a worker function to a result handler (listener). Note
     that each sender can be given a "job id". This can be anything
     (number, string, id, and object, etc) and is not used, it is
     simply added as attribute whenever a DelayedResult is created.

--- a/wx/lib/docview.py
+++ b/wx/lib/docview.py
@@ -320,7 +320,7 @@ class Document(wx.EvtHandler):
         Calls :meth:`View.Close` and deletes each view. Deleting the final view will
         implicitly delete the document itself, because the wxView destructor
         calls RemoveView. This in turn calls :meth:`Document.OnChangedViewList`,
-        whose default implemention is to save and delete the document if no
+        whose default implementation is to save and delete the document if no
         views exist.
         """
         manager = self.GetDocumentManager()
@@ -2112,7 +2112,7 @@ class DocManager(wx.EvtHandler):
         only an approximate method of finding a template for creating a
         document.
 
-        Note this wxPython verson looks for and returns a default template
+        Note this wxPython version looks for and returns a default template
         if no specific template is found.
         """
         default = None

--- a/wx/lib/eventwatcher.py
+++ b/wx/lib/eventwatcher.py
@@ -355,7 +355,7 @@ class EventWatcher(wx.Frame):
     def buildWatchList(self, exclusions):
         # This is a list of (PyEventBinder, flag) tuples where the flag indicates
         # whether to bind that event or not. By default all execpt those in
-        # the _noWatchList wil be set to be watched.
+        # the _noWatchList will be set to be watched.
         self._watchedEvents = list()
         for item in _eventBinders:
             self._watchedEvents.append( (item, item not in exclusions) )

--- a/wx/lib/evtmgr.py
+++ b/wx/lib/evtmgr.py
@@ -306,7 +306,7 @@ class EventManager:
 
 
 #---------------------------------------------------------------------------
-# From here down is implementaion and support classes, although you may
+# From here down is implementation and support classes, although you may
 # find some of them useful in other contexts.
 #---------------------------------------------------------------------------
 

--- a/wx/lib/expando.py
+++ b/wx/lib/expando.py
@@ -22,7 +22,7 @@ Description
 ===========
 
 The :class:`ExpandoTextCtrl` is a multi-line :class:`TextCtrl` that will
-adjust its height on the fly as needed to accomodate the number of
+adjust its height on the fly as needed to accommodate the number of
 lines needed to display the current content of the control.  It is
 assumed that the width of the control will be a fixed value and
 that only the height will be adjusted automatically.  If the
@@ -121,7 +121,7 @@ EVT_ETC_LAYOUT_NEEDED = wx.PyEventBinder(wxEVT_ETC_LAYOUT_NEEDED, 1)
 class ExpandoTextCtrl(wx.TextCtrl):
     """
     The ExpandoTextCtrl is a multi-line wx.TextCtrl that will
-    adjust its height on the fly as needed to accomodate the number of
+    adjust its height on the fly as needed to accommodate the number of
     lines needed to display the current content of the control.  It is
     assumed that the width of the control will be a fixed value and
     that only the height will be adjusted automatically.  If the

--- a/wx/lib/fancytext.py
+++ b/wx/lib/fancytext.py
@@ -393,7 +393,7 @@ def GetFullExtent(str, dc=None, enclose=True):
 
 
 def RenderToBitmap(str, background=None, enclose=1):
-    "Return str rendered on a minumum size bitmap"
+    "Return str rendered on a minimum size bitmap"
     dc = wx.MemoryDC()
     # Chicken and egg problem, we need a bitmap in the DC in order to
     # measure how big the bitmap should be...

--- a/wx/lib/floatcanvas/FCObjects.py
+++ b/wx/lib/floatcanvas/FCObjects.py
@@ -461,7 +461,7 @@ class ColorOnlyMixin:
         self.SetPen(Color,"Solid",1)
         self.SetBrush(Color,"Solid")
 
-    SetFillColor = SetColor # Just to provide a consistant interface
+    SetFillColor = SetColor # Just to provide a consistent interface
 
 
 class LineOnlyMixin:
@@ -847,7 +847,7 @@ class Arrow(XYObjectMixin, LineOnlyMixin, DrawObject):
 
     def SetLengthDirection(self, Length, Direction):
         """
-        Set the lenght and direction
+        Set the length and direction
 
         :param integer `Length`: length of arrow in pixels
         :param integer `Direction`: angle of arrow in degrees, zero is straight
@@ -996,7 +996,7 @@ class PointSet(PointsObjectMixin, ColorOnlyMixin, DrawObject):
     Each point will be drawn the same color and Diameter. The Diameter
     is in screen pixels, not world coordinates.
 
-    The hit-test code does not distingish between the points, you will
+    The hit-test code does not distinguish between the points, you will
     only know that one of the points got hit, not which one. You can use
     PointSet.FindClosestPoint(WorldPoint) to find out which one
 
@@ -1559,11 +1559,11 @@ class Text(TextObjectMixin, DrawObject):
 
 class ScaledText(TextObjectMixin, DrawObject):
     """
-    ##fixme: this can be depricated and jsut use ScaledTextBox with different defaults.
+    ##fixme: this can be deprecated and just use ScaledTextBox with different defaults.
 
     This class creates a text object that is scaled when zoomed.  It is
     placed at the coordinates, x,y. the "Position" argument is a two
-    charactor string, indicating where in relation to the coordinates
+    character string, indicating where in relation to the coordinates
     the string should be oriented.
 
     The first letter is: t, c, or b, for top, center and bottom The
@@ -1600,7 +1600,7 @@ class ScaledText(TextObjectMixin, DrawObject):
     Bugs/Limitations:
 
     As fonts are scaled, the do end up a little different, so you don't
-    get exactly the same picture as you scale up and doen, but it's
+    get exactly the same picture as you scale up and done, but it's
     pretty darn close.
 
     On wxGTK1 on my Linux system, at least, using a font of over about
@@ -1710,7 +1710,7 @@ class ScaledText(TextObjectMixin, DrawObject):
             else:
                 dc.SetBackgroundMode(wx.TRANSPARENT)
             (w,h) = dc.GetTextExtent(self.String)
-            # compute the shift, and adjust the coordinates, if neccesary
+            # compute the shift, and adjust the coordinates, if necessary
             # This had to be put in here, because it changes with Zoom, as
             # fonts don't scale exactly.
             xy = self.ShiftFun(X, Y, w, h)
@@ -2589,7 +2589,7 @@ class PieChart(XYObjectMixin, LineOnlyMixin, DrawObject):
         Default class constructor.
 
         :param `XY`: The (x,y) coords of the center of the chart
-        :param `Diameter`: The diamter of the chart in worls coords, unless you
+        :param `Diameter`: The diamter of the chart in world coords, unless you
                  set "Scaled" to False, in which case it's in pixel coords.
         :param `Values`: sequence of values you want to make the chart of.
         :param `FillColors`: sequence of colors you want the slices. If

--- a/wx/lib/floatcanvas/FloatCanvas.py
+++ b/wx/lib/floatcanvas/FloatCanvas.py
@@ -280,7 +280,7 @@ class FloatCanvas(wx.Panel):
         self.SetCursor(self.GUIMode.Cursor)
 
     def MakeHitDict(self):
-        """Initialize the Hit dictonary."""
+        """Initialize the Hit dictionary."""
         ##fixme: Should this just be None if nothing has been bound?
         self.HitDict = {EVT_FC_LEFT_DOWN: {},
                         EVT_FC_LEFT_UP: {},
@@ -531,9 +531,9 @@ class FloatCanvas(wx.Panel):
                                         depth=self.HitTestBitmapDepth)
 
     def MakeNewForegroundHTBitmap(self):
-        ## Note: the foreground and backround HT bitmaps are in separate functions
+        ## Note: the foreground and background HT bitmaps are in separate functions
         ##       so that they can be created separate --i.e. when a foreground is
-        ##       added after the backgound is drawn
+        ##       added after the background is drawn
         """
         Off screen Bitmap used for Hit tests on foreground objects
 
@@ -553,7 +553,7 @@ class FloatCanvas(wx.Panel):
         self.Draw()
 
     def InitializePanel(self):
-        """Intialize the panel."""
+        """Initialize the panel."""
         PanelSize  = N.array(self.GetClientSize(),  N.int32)
         self.PanelSize  = N.maximum(PanelSize, (2,2)) ## OS-X sometimes gives a Size event when the panel is size (0,0)
         self.HalfPanelSize = self.PanelSize / 2 # lrk: added for speed in WorldToPixel

--- a/wx/lib/floatcanvas/__init__.py
+++ b/wx/lib/floatcanvas/__init__.py
@@ -53,7 +53,7 @@ Bugs and Limitations: Lots: patches, fixes welcome
 For Map drawing: It ignores the fact that the world is, in fact, a
 sphere, so it will do strange things if you are looking at stuff near
 the poles or the date line. so far I don't have a need to do that, so I
-havn't bothered to add any checks for that yet.
+haven't bothered to add any checks for that yet.
 
 Zooming: I have set no zoom limits. What this means is that if you zoom
 in really far, you can get integer overflows, and get weird results. It

--- a/wx/lib/gestures.py
+++ b/wx/lib/gestures.py
@@ -28,7 +28,7 @@ and set the pop up as the parent).
 Start() starts recording mouse movement.
 End() stops the recording, compiles all the gestures into a list,
 and looks through the registered gestures to find a match.
-The first matchs associated    action is then run.
+The first match associated action is then run.
 
 The marginoferror is how much to forgive when calculating movement:
 If the margin is 25, then movement less than 25 pixels will not be detected.
@@ -148,7 +148,7 @@ class MouseGestures:
         and creates the mouse gesture, returns the result as a string.'''
         self.recording = False
 
-        #Figure out the gestures (Look for occurances of 5 in a row or more):
+        #Figure out the gestures (Look for occurrences of 5 in a row or more):
 
         tempstring = '0'
         possiblechange = '0'

--- a/wx/lib/graphics.py
+++ b/wx/lib/graphics.py
@@ -1326,7 +1326,7 @@ class GraphicsContext(GraphicsObject):
 
     def CreatePath(self):
         """
-        Create a new path obejct.
+        Create a new path object.
         """
         return GraphicsPath()
 
@@ -1754,7 +1754,7 @@ class GraphicsContext(GraphicsObject):
 
     def DrawEllipse(self, x, y, w, h):
         """
-        Stroke and fill an elipse that fits in the given rectangle,
+        Stroke and fill an ellipse that fits in the given rectangle,
         using the current pen and current brush.
         """
         path = GraphicsPath()

--- a/wx/lib/infoframe.py
+++ b/wx/lib/infoframe.py
@@ -8,7 +8,7 @@
 infoframe.py
 Released under wxWindows license etc.
 
-This is a fairly rudimentary, but slightly fancier tha
+This is a fairly rudimentary, but slightly fancier than
 wxPyOnDemandOutputWindow (on which it's based; thanks Robin), version
 of the same sort of thing: a file-like class called
 wxInformationalMessagesFrame. This window also has a status bar with a
@@ -256,7 +256,7 @@ class PyInformationalMessagesFrame(object):
 
     def write(self, string):
         if not wx.Thread_IsMain():
-            # Aquire the GUI mutex before making GUI calls.  Mutex is released
+            # Acquire the GUI mutex before making GUI calls.  Mutex is released
             # when locker is deleted at the end of this function.
             #
             # TODO: This should be updated to use wx.CallAfter similarly to how

--- a/wx/lib/inspection.py
+++ b/wx/lib/inspection.py
@@ -88,7 +88,7 @@ class InspectionTool:
     def Show(self, selectObj=None, refreshTree=False):
         """
         Creates the inspection frame if it hasn't been already, and
-        raises it if neccessary.
+        raises it if necessary.
 
         :param `selectObj`: Pass a widget or sizer to have that object be
                      preselected in widget tree.
@@ -1052,7 +1052,7 @@ class _InspectionHighlighter(object):
 
     def FlickerTLW(self, tlw):
         """
-        Use a timer to alternate a TLW between shown and hidded state a
+        Use a timer to alternate a TLW between shown and hidden state a
         few times.  Use to highlight a TLW since drawing and clearing an
         outline is trickier.
         """

--- a/wx/lib/layoutf.py
+++ b/wx/lib/layoutf.py
@@ -14,7 +14,7 @@ import  wx
 class Layoutf(wx.LayoutConstraints):
     """
     The class Layoutf(wxLayoutConstraints) presents a simplification
-    of the wxLayoutConstraints syntax. The name Layoutf is choosen
+    of the wxLayoutConstraints syntax. The name Layoutf is chosen
     because of the similarity with C's printf function.
 
     Quick Example::
@@ -105,7 +105,7 @@ class Layoutf(wx.LayoutConstraints):
 
     Note that these are the same letters as used for <own attribute>,
     so you'll only need to remember one set. Finally, the object
-    whose attribute is refered to, is specified by #<compare object
+    whose attribute is referred to, is specified by #<compare object
     nr>, where <compare object nr> is the 1-based (stupid, I know,
     but I've gotten used to it) index of the object in the
     objects_tuple argument.

--- a/wx/lib/masked/ipaddrctrl.py
+++ b/wx/lib/masked/ipaddrctrl.py
@@ -155,7 +155,7 @@ class IpAddrCtrl( BaseMaskedTextCtrl, IpAddrCtrlAccessorsMixin ):
         if not event.ShiftDown():
             if pos > edit_start and pos < edit_end:
                 # clip data in field to the right of pos, if adjusting fields
-                # when not at delimeter; (assumption == they hit '.')
+                # when not at delimiter; (assumption == they hit '.')
                 newvalue = oldvalue[:pos] + ' ' * (edit_end - pos) + oldvalue[edit_end:]
                 self._SetValue(newvalue)
                 self._SetInsertionPoint(pos)

--- a/wx/lib/masked/maskededit.py
+++ b/wx/lib/masked/maskededit.py
@@ -235,7 +235,7 @@ formatcodes
             0  integer fields get leading zeros
             D  Date[/time] field
             T  Time field
-            F  Auto-Fit: the control calulates its size from
+            F  Auto-Fit: the control calculates its size from
                the length of the template mask
             V  validate entered chars against validRegex before allowing them
                to be entered vs. being allowed by basic mask and then having
@@ -993,7 +993,7 @@ masktags = {
            'excludeChars': am_pm_exclude,
            'formatcodes': 'DF!',
            'validRegex': '^' + months + '-' + days + '-' + '\d{4} ' + hours + ':' + minutes + ':' + seconds + ' (A|P)M',
-           'description': "US Date + Time\n(w/hypens)"
+           'description': "US Date + Time\n(w/hyphens)"
            },
        "USDATE24HRTIMEMMDDYYYY/HHMMSS": {
            'mask': "##/##/#### ##:##:##",
@@ -1005,7 +1005,7 @@ masktags = {
            'mask': "##-##-#### ##:##:##",
            'formatcodes': 'DF',
            'validRegex': '^' + months + '-' + days + '-' + '\d{4} ' + milhours + ':' + minutes + ':' + seconds,
-           'description': "US Date + 24Hr Time\n(w/hypens)"
+           'description': "US Date + 24Hr Time\n(w/hyphens)"
            },
        "USDATETIMEMMDDYYYY/HHMM": {
            'mask': "##/##/#### ##:## AM",
@@ -1025,7 +1025,7 @@ masktags = {
            'excludeChars': am_pm_exclude,
            'formatcodes': 'DF!',
            'validRegex': '^' + months + '-' + days + '-' + '\d{4} ' + hours + ':' + minutes + ' (A|P)M',
-           'description': "US Date + Time\n(w/hypens and w/o secs)"
+           'description': "US Date + Time\n(w/hyphens and w/o secs)"
            },
        "USDATE24HRTIMEMMDDYYYY-HHMM": {
            'mask': "##-##-#### ##:##",
@@ -1316,7 +1316,7 @@ class Field:
               'choiceRequired': False,          ## If choices supplied this specifies if valid value must be in the list
               'compareNoCase': False,           ## Optional flag to indicate whether or not to use case-insensitive list search
               'autoSelect': False,              ## Set to True to try auto-completion on each keystroke:
-              'validFunc': None,                ## Optional function for defining additional, possibly dynamic validation constraints on contrl
+              'validFunc': None,                ## Optional function for defining additional, possibly dynamic validation constraints on control
               'validRequired': False,           ## Set to True to disallow input that results in an invalid value
               'emptyInvalid':  False,           ## Set to True to make EMPTY = INVALID
               'description': "",                ## primarily for autoformats, but could be useful elsewhere
@@ -4180,7 +4180,7 @@ class MaskedEditMixin:
                 self._SetValue(newvalue)
                 self._SetInsertionPoint(min(edit_end, len(newvalue.rstrip())))
                 self._OnAutoSelect(field, match_index)
-                self._CheckValid()  # recolor as appopriate
+                self._CheckValid()  # recolor as appropriate
 
 
         if keycode in (wx.WXK_UP, wx.WXK_DOWN, wx.WXK_LEFT, wx.WXK_RIGHT,
@@ -4774,7 +4774,7 @@ class MaskedEditMixin:
     def _applyFormatting(self):
         """ Apply formatting depending on the control's state.
             Need to find a way to call this whenever the value changes, in case the control's
-            value has been changed or set programatically.
+            value has been changed or set programmatically.
         """
 ##        dbg(suspend=1)
 ##        dbg('MaskedEditMixin::_applyFormatting', indent=1)
@@ -5591,7 +5591,7 @@ class MaskedEditMixin:
 
         The trouble is that, a priori, there's no explicit notification of
         why the focus event we received.  However, the whole reason we need to
-        do this is because the default behavior on TAB traveral in a wx.TextCtrl is
+        do this is because the default behavior on TAB traversal in a wx.TextCtrl is
         now to select the entire contents of the window, something we don't want.
         So we can *now* test the selection range, and if it's "the whole text"
         we can assume the cause, change the insertion point to the start of
@@ -7041,7 +7041,7 @@ __i=0
 ##
 ##  Version 1.0
 ##   1. Decimal point behavior restored for decimal and integer type controls:
-##      decimal point now trucates the portion > 0.
+##      decimal point now truncates the portion > 0.
 ##   2. Return key now works like the tab character and moves to the next field,
 ##      provided no default button is set for the form panel on which the control
 ##      resides.
@@ -7227,7 +7227,7 @@ __i=0
 ##   5. Decimal values now collapse to decimal with '.00' on losefocus if the user never
 ##      presses the decimal point.
 ##   6. Cursor now goes to the beginning of the field if the user clicks in an
-##      "empty" field intead of leaving the insertion point in the middle of the
+##      "empty" field instead of leaving the insertion point in the middle of the
 ##      field.
 ##   7. New "N" mask type includes upper and lower chars plus digits. a-zA-Z0-9.
 ##   8. New formatcodes init parameter replaces other init params and adds functions.

--- a/wx/lib/masked/numctrl.py
+++ b/wx/lib/masked/numctrl.py
@@ -929,7 +929,7 @@ class NumCtrl(BaseMaskedTextCtrl, NumCtrlAccessorsMixin):
     def _GetNumValue(self, value):
         """
         This function attempts to "clean up" a text value, providing a regularized
-        convertable string, via atol() or atof(), for any well-formed numeric text value.
+        convertible string, via atol() or atof(), for any well-formed numeric text value.
         """
         return value.replace(self._groupChar, '').replace(self._decimalChar, '.').replace('(', '-').replace(')','').strip()
 
@@ -1012,7 +1012,7 @@ class NumCtrl(BaseMaskedTextCtrl, NumCtrlAccessorsMixin):
     def _SetValue(self, value):
         """
         This routine supersedes the base masked control _SetValue().  It is
-        needed to ensure that the value of the control is always representable/convertable
+        needed to ensure that the value of the control is always representable/convertible
         to a numeric return value (via GetValue().)  This routine also handles
         automatic adjustment and grouping of the value without explicit intervention
         by the user.
@@ -1369,7 +1369,7 @@ class NumCtrl(BaseMaskedTextCtrl, NumCtrlAccessorsMixin):
         If min > the max value allowed by the width of the control,
         the function will return False, and the min will not be set.
 
-        :param `min`: Minium value for the control
+        :param `min`: Minimum value for the control
         :type `min`: integer or None
 
         """
@@ -1410,7 +1410,7 @@ class NumCtrl(BaseMaskedTextCtrl, NumCtrlAccessorsMixin):
         If max > the max value allowed by the width of the control,
         the function will return False, and the max will not be set.
 
-        :param `max`: Minium value for the control
+        :param `max`: Minimum value for the control
         :type `max`: integer or None
 
         """
@@ -1443,9 +1443,9 @@ class NumCtrl(BaseMaskedTextCtrl, NumCtrlAccessorsMixin):
 
         .. note:: leaving out an argument will remove the corresponding bound.
 
-        :param `min`: Minium value for the control
+        :param `min`: Minimum value for the control
         :type `min`: integer or None
-        :param `max`: Minium value for the control
+        :param `max`: Minimum value for the control
         :type `max`: integer or None
 
         """

--- a/wx/lib/masked/textctrl.py
+++ b/wx/lib/masked/textctrl.py
@@ -212,7 +212,7 @@ class BaseMaskedTextCtrl( wx.TextCtrl, MaskedEditMixin ):
 
     def ChangeValue(self, value):
         """
-        Provided to accomodate similar functionality added to base
+        Provided to accommodate similar functionality added to base
         control in wxPython 2.7.1.1.
 
         :param string `value`: new value for control, this will not fire an event
@@ -298,7 +298,7 @@ class BaseMaskedTextCtrl( wx.TextCtrl, MaskedEditMixin ):
         """
         Set the font, then recalculate control size, if appropriate.
 
-        see :meth:`TextCtrl.SetFont` for valid arguements
+        see :meth:`TextCtrl.SetFont` for valid arguments
         """
         wx.TextCtrl.SetFont(self, *args, **kwargs)
         if self._autofit:

--- a/wx/lib/masked/timectrl.py
+++ b/wx/lib/masked/timectrl.py
@@ -414,7 +414,7 @@ class TimeCtrl(BaseMaskedTextCtrl):
         max = self.__max
         limited = self.__limited
         self.__posCurrent = 0
-        # handle deprecated keword argument name:
+        # handle deprecated keyword argument name:
         if 'display_seconds' in kwargs:
             kwargs['displaySeconds'] = kwargs['display_seconds']
             del kwargs['display_seconds']
@@ -851,7 +851,7 @@ class TimeCtrl(BaseMaskedTextCtrl):
         adjusted to the new minimum value; if not limited, the value in the
         control will be colored as invalid.
 
-        :param `min`: Minium value for the control
+        :param `min`: Minimum value for the control
         :type `min`: integer or None
 
         """
@@ -915,7 +915,7 @@ class TimeCtrl(BaseMaskedTextCtrl):
         adjusted to this maximum value; if not limited, the value in the
         control will be colored as invalid.
 
-        :param `max`: Minium value for the control
+        :param `max`: Minimum value for the control
         :type `max`: integer or None
 
         """
@@ -975,9 +975,9 @@ class TimeCtrl(BaseMaskedTextCtrl):
 
         .. note:: Leaving out an argument will remove the corresponding bound.
 
-        :param `min`: Minium value for the control
+        :param `min`: Minimum value for the control
         :type `min`: integer or None
-        :param `max`: Minium value for the control
+        :param `max`: Minimum value for the control
         :type `max`: integer or None
 
         """

--- a/wx/lib/mixins/inspection.py
+++ b/wx/lib/mixins/inspection.py
@@ -160,7 +160,7 @@ class InspectionMixin(object):
 
     def ShowInspectionTool(self):
         """
-        Show the Inspection tool, creating it if neccesary, setting it
+        Show the Inspection tool, creating it if necessary, setting it
         to display the widget under the cursor.
         """
         # get the current widget under the mouse

--- a/wx/lib/mixins/listctrl.py
+++ b/wx/lib/mixins/listctrl.py
@@ -47,7 +47,7 @@ class ColumnSorterMixin:
     A mixin class that handles sorting of a wx.ListCtrl in REPORT mode when
     the column header is clicked on.
 
-    There are a few requirments needed in order for this to work genericly:
+    There are a few requirements needed in order for this to work genericly:
 
       1. The combined class must have a GetListCtrl method that
          returns the wx.ListCtrl to be sorted, and the list control
@@ -106,7 +106,7 @@ class ColumnSorterMixin:
         Returns a tuple of image list indexesthe indexes in the image list for an image to be put on the column
         header when sorting in descending order.
         """
-        return (-1, -1)  # (decending, ascending) image IDs
+        return (-1, -1)  # (descending, ascending) image IDs
 
 
     def GetColumnSorter(self):
@@ -584,7 +584,7 @@ class TextEditMixin:
                 # don't start scrolling unless we really need to
                 offset = x0+x1-self.GetSize()[0]-scrolloffset
                 # scroll a bit more than what is minimum required
-                # so we don't have to scroll everytime the user presses TAB
+                # so we don't have to scroll every time the user presses TAB
                 # which is very tireing to the eye
                 addoffset = self.GetSize()[0]/4
                 # but be careful at the end of the list
@@ -642,7 +642,7 @@ class TextEditMixin:
         ret = self.GetEventHandler().ProcessEvent(evt)
         if not ret or evt.IsAllowed():
             if self.IsVirtual():
-                # replace by whather you use to populate the virtual ListCtrl
+                # replace by whatever you use to populate the virtual ListCtrl
                 # data source
                 self.SetVirtualData(self.curRow, self.curCol, text)
             else:

--- a/wx/lib/mixins/rubberband.py
+++ b/wx/lib/mixins/rubberband.py
@@ -53,7 +53,7 @@ def normalizeBox(box):
 def boxToExtent(box):
     """
     Convert a box specification to an extent specification.
-    I put this into a seperate function after I realized that
+    I put this into a separate function after I realized that
     I had been implementing it wrong in several places.
     """
     b = normalizeBox(box)
@@ -74,7 +74,7 @@ def pointOnBox(x, y, box, thickness=1):
     of the box.  The thickness defines how thick the
     edge should be.  This is necessary for HCI reasons:
     For example, it's normally very difficult for a user
-    to manuever the mouse onto a one pixel border.
+    to maneuver the mouse onto a one pixel border.
     """
     outerBox = box
     innerBox = (box[0]+thickness, box[1]+thickness, box[2]-(thickness*2), box[3]-(thickness*2))

--- a/wx/lib/mixins/treemixin.py
+++ b/wx/lib/mixins/treemixin.py
@@ -108,7 +108,7 @@ class TreeAPIHarmonizer(object):
     def GetItemImage(self, item, which=wx.TreeItemIcon_Normal, column=-1):
         # CustomTreeCtrl always wants the which argument, so provide it
         # TreeListCtr.GetItemImage has a different order of arguments than
-        # the other tree controls. Hide the differenes.
+        # the other tree controls. Hide the differences.
         if self.GetColumnCount():
             args = (item, column, which)
         else:

--- a/wx/lib/ogl/basic.py
+++ b/wx/lib/ogl/basic.py
@@ -305,7 +305,7 @@ class Shape(ShapeEvtHandler):
 
     The :class:`Shape` is the top-level, abstract object that all other objects
     are derived from. All common functionality is represented by :class:`Shape`
-    members, and overriden members that appear in derived classes and have
+    members, and overridden members that appear in derived classes and have
     behaviour as documented for :class:`Shape`, are not documented separately.
     """
     GraphicsInSizeToContents = False
@@ -703,7 +703,7 @@ class Shape(ShapeEvtHandler):
         actualW = w
         actualH = h
         # Don't try to resize an object with more than one image (this
-        # case should be dealt with by overriden handlers)
+        # case should be dealt with by overridden handlers)
         if (region.GetFormatMode() & FORMAT_SIZE_TO_CONTENTS) and \
            len(region.GetFormattedText()) and \
            len(self._regions) == 1 and \
@@ -1901,7 +1901,7 @@ class Shape(ShapeEvtHandler):
         Assuming the attachment lies along a vertical or horizontal line,
         calculate the position on that point.
 
-        :param `pt1`: The first point of the line repesenting the edge of
+        :param `pt1`: The first point of the line representing the edge of
          the shape
         :param `pt2`: The second point of the line representing the edge of
          the shape
@@ -2839,9 +2839,9 @@ class RectangleShape(Shape):
 
     def SetHeight(self, h):
         """
-        Set the heigth.
+        Set the height.
 
-        :param `h`: heigth to be set
+        :param `h`: height to be set
 
         """
         self._height = h
@@ -3645,7 +3645,7 @@ class ShapeRegion(object):
 
     def SetMinSize(self, w, h):
         """
-        Set the minumum size.
+        Set the minimum size.
 
         :param `w`: the minimum width
         :Param `h`: the minimum height

--- a/wx/lib/ogl/bmpshape.py
+++ b/wx/lib/ogl/bmpshape.py
@@ -39,7 +39,7 @@ class BitmapShape(RectangleShape):
         Set the size.
 
         :param `w`: the width
-        :param `h`: the heigth
+        :param `h`: the height
         :param `recursive`: not used
 
         """

--- a/wx/lib/ogl/composit.py
+++ b/wx/lib/ogl/composit.py
@@ -48,7 +48,7 @@ class ConstraintType(object):
         """
         Default class constructor.
 
-        :param `theType`: one of the folowing
+        :param `theType`: one of the following
          ====================================== ================================
          Constraint type                        Description
          ====================================== ================================
@@ -542,7 +542,7 @@ class CompositeShape(RectangleShape):
         Set the size.
 
         :param `w`: the width
-        :param `h`: the heigth
+        :param `h`: the height
         :param `recursive`: size the children recursively
 
         """
@@ -765,7 +765,7 @@ class CompositeShape(RectangleShape):
         """
         Constrain the children.
 
-        :returns: True if constained otherwise False
+        :returns: True if constrained otherwise False
 
         """
         self.CalculateSize()
@@ -820,7 +820,7 @@ class CompositeShape(RectangleShape):
         """
         Check if division is descendant.
 
-        :param `division`: divison to check
+        :param `division`: division to check
         :returns: `True` if division is a descendant of this container.
 
         """
@@ -1143,7 +1143,7 @@ class DivisionShape(CompositeShape):
         #dc.DrawRectangle(x1, y1, self.GetWidth(), self.GetHeight())
 
     def OnDrawContents(self, dc):
-        """The draw contens handler."""
+        """The draw contents handler."""
         CompositeShape.OnDrawContents(self, dc)
 
     def OnMovePre(self, dc, x, y, oldx, oldy, display = True):
@@ -1210,7 +1210,7 @@ class DivisionShape(CompositeShape):
         Set the size.
 
         :param `w`: the width
-        :param `h`: the heigth
+        :param `h`: the height
         :param `recursive`: `True` recurse all children
 
         """

--- a/wx/lib/ogl/divided.py
+++ b/wx/lib/ogl/divided.py
@@ -170,7 +170,7 @@ class DividedShape(RectangleShape):
         Default class constructor.
 
         :param `w`: width of rectangle
-        :param `h`: heigth of rectangle
+        :param `h`: height of rectangle
 
         """
         RectangleShape.__init__(self, w, h)
@@ -240,7 +240,7 @@ class DividedShape(RectangleShape):
         Set the size.
 
         :param `w`: width of rectangle
-        :param `h`: heigth of rectangle
+        :param `h`: height of rectangle
         :param `recursive`: not implemented
 
         """

--- a/wx/lib/ogl/drawn.py
+++ b/wx/lib/ogl/drawn.py
@@ -807,7 +807,7 @@ class DrawnShape(RectangleShape):
         if flags and METAFLAGS_ATTACHMENTS:
             self.ClearAttachments()
             for i in range(len(pts)):
-                # TODO: AttachmentPoint does not excist as per PyLint, what should it be???
+                # TODO: AttachmentPoint does not exist as per PyLint, what should it be???
                 self._attachmentPoints.append(AttachmentPoint(i,pts[i][0],pts[i][1]))
         self._metafiles[self._currentAngle].DrawPolygon(pts, flags)
 

--- a/wx/lib/ogl/lines.py
+++ b/wx/lib/ogl/lines.py
@@ -225,7 +225,7 @@ class LabelShape(RectangleShape):
         :param `parent`: the parent an instance of :class:`Line`
         :param `region`: the shape region an instance of :class:`~lib.ogl.ShapeRegion`
         :param `w`: width in points
-        :param `h`: heigth in points
+        :param `h`: height in points
 
         """
         RectangleShape.__init__(self, w, h)
@@ -440,7 +440,7 @@ class LineShape(Shape):
         self._lineControlPoints.insert(len(self._lineControlPoints)-1, point)
 
     def DeleteLineControlPoint(self):
-        """Delete an arbitary point on the line."""
+        """Delete an arbitrary point on the line."""
         if len(self._lineControlPoints) < 3:
             return False
 
@@ -1090,7 +1090,7 @@ class LineShape(Shape):
         return True
 
     def OnMoveLink(self, dc, moveControlPoints = True):
-        """The move linke handler, called when a connected object has moved, to move the link to
+        """The move link handler, called when a connected object has moved, to move the link to
         correct position.
         """
         if not self._from or not self._to:
@@ -1487,7 +1487,7 @@ class LineShape(Shape):
          `ARROW_POSITION_START`                   arrow appears at the start
          ======================================== ==================================
 
-        :param `size`: specifies the lenght of the arrow
+        :param `size`: specifies the length of the arrow
         :param `xOffset`: specifies the offset from the end of the line
         :param `name`: specifies a name
         :param `mf`: mf can be a wxPseduoMetaFile, perhaps loaded from a simple Windows

--- a/wx/lib/ogl/oglmisc.py
+++ b/wx/lib/ogl/oglmisc.py
@@ -269,7 +269,7 @@ def CentreText(dc, text_list, xpos, ypos, width, height, formatMode):
 
 def DrawFormattedText(dc, text_list, xpos, ypos, width, height, formatMode):
     """
-    Draw formated text
+    Draw formatted text
 
     :param `dc`: the :class:`wx.MemoryDC`
     :param `text_list`: a list of texts
@@ -310,7 +310,7 @@ def DrawFormattedText(dc, text_list, xpos, ypos, width, height, formatMode):
 
 def RoughlyEqual(val1, val2, tol=0.00001):
     """
-    Check if values are roughtly equal
+    Check if values are roughly equal
 
     :param `val1`: the first value to check
     :param `val2`: the second value to check
@@ -356,7 +356,7 @@ def CheckLineIntersection(x1, y1, x2, y2, x3, y3, x4, y4):
     :param `x4`: x4 position
     :param `y4`: y4 position
 
-    :returns: a lenght ratio and a k line???
+    :returns: a length ratio and a k line???
 
     """
     denominator_term = (y4 - y3) * (x2 - x1) - (y2 - y1) * (x4 - x3)

--- a/wx/lib/pdfwin_old.py
+++ b/wx/lib/pdfwin_old.py
@@ -61,7 +61,7 @@ def get_acroversion():
 # http://partners.adobe.com/public/developer/en/acrobat/sdk/pdf/iac/IACOverview.pdf
 # http://partners.adobe.com/public/developer/en/acrobat/sdk/pdf/iac/IACReference.pdf
 #
-# Co-ordinates passed as parameters are in points (1/72 inch).
+# Coordinates passed as parameters are in points (1/72 inch).
 
 
 if get_acroversion() >= 7.0:

--- a/wx/lib/platebtn.py
+++ b/wx/lib/platebtn.py
@@ -23,7 +23,7 @@ keyword parameter.
 
 PB_STYLE_DEFAULT:
 Creates a flat label button with rounded corners, the highlight for mouse over
-and press states is based off of the hightlight color from the systems current
+and press states is based off of the highlight color from the systems current
 theme.
 
 PB_STYLE_GRADIENT:
@@ -177,7 +177,7 @@ class PlateButton(wx.Control):
         """Draw the bitmap if one has been set
 
         :param wx.GCDC `gc`: :class:`wx.GCDC` to draw with
-        :return: x cordinate to draw text at
+        :return: x coordinate to draw text at
 
         """
         if self.IsEnabled():
@@ -264,7 +264,7 @@ class PlateButton(wx.Control):
         """Draw the button"""
         # TODO using a buffered paintdc on windows with the nobg style
         #      causes lots of weird drawing. So currently the use of a
-        #      buffered dc is dissabled for this style.
+        #      buffered dc is disabled for this style.
         if PB_STYLE_NOBG & self._style:
             dc = wx.PaintDC(self)
         else:

--- a/wx/lib/plot/CHANGELOG.md
+++ b/wx/lib/plot/CHANGELOG.md
@@ -80,7 +80,7 @@ on 2016-07-05 and finished on [insert date here].
   <number> tick marks)
 + Added support for background and foreground colours (enabled via
   SetBackgroundColour/SetForegroundColour on a PlotCanvas instance)
-+ Changed PlotCanvas printing initialization from occuring in __init__ to
++ Changed PlotCanvas printing initialization from occurring in __init__ to
   occur on access. This will postpone any IPP and / or CUPS warnings
   which appear on stderr on some Linux systems until printing
   functionality is actually used.
@@ -108,7 +108,7 @@ on 2016-07-05 and finished on [insert date here].
 
 
 ## 2003-12-15 - Jeff Grimmett (grimmtooth@softhome.net)
-+ 2.5 compatability update.
++ 2.5 compatibility update.
 + Renamed to plot.py in the wx.lib directory.
 + Reworked test frame to work with wx demo framework. This saves a bit
   of tedious cut and paste, and the test app is excellent.

--- a/wx/lib/plot/examples/demo.py
+++ b/wx/lib/plot/examples/demo.py
@@ -968,7 +968,7 @@ class PlotDemoMainFrame(wx.Frame):
 
     def DrawPointLabel(self, dc, mDataDict):
         """
-        This is the fuction that defines how the pointLabels are plotted
+        This is the function that defines how the pointLabels are plotted
 
         :param dc: DC that will be passed
         :param mDataDict: Dictionary of data that you want to use

--- a/wx/lib/plot/plotcanvas.py
+++ b/wx/lib/plot/plotcanvas.py
@@ -86,7 +86,7 @@ class PlotCanvas(wx.Panel):
         self.Bind(wx.EVT_SCROLL_LINEUP, self.OnScroll)
         self.Bind(wx.EVT_SCROLL_LINEDOWN, self.OnScroll)
 
-        # set curser as cross-hairs
+        # set cursor as cross-hairs
         self.defaultCursor = wx.Cursor(wx.CURSOR_ARROW)
         self.HandCursor = wx.Cursor(wx.CURSOR_SIZING)
         self.GrabHandCursor = wx.Cursor(wx.CURSOR_SIZING)
@@ -325,7 +325,7 @@ class PlotCanvas(wx.Panel):
         """
         Saves the file to the type specified in the extension. If no file
         name is specified a dialog box is provided.  Returns True if
-        sucessful, otherwise False.
+        successful, otherwise False.
 
         .bmp  Save a Windows bitmap file.
         .xbm  Save an X bitmap file.

--- a/wx/lib/plot/polyobjects.py
+++ b/wx/lib/plot/polyobjects.py
@@ -272,7 +272,7 @@ class PolyPoints(object):
 
     def boundingBox(self):
         """
-        Returns the bouding box for the entire dataset as a tuple with this
+        Returns the bounding box for the entire dataset as a tuple with this
         format::
 
             ((minX, minY), (maxX, maxY))
@@ -305,7 +305,7 @@ class PolyPoints(object):
             # no curves to draw
             return
 
-        # TODO: Can we remove the if statement alltogether? Does
+        # TODO: Can we remove the if statement altogether? Does
         #       scaleAndShift ever get called when the current value equals
         #       the new value?
 
@@ -679,7 +679,7 @@ class PolyBarsBase(PolyPoints):
         PolyPoints.__init__(self, points, attr)
 
     def _scaleAndShift(self, data, scale=(1, 1), shift=(0, 0)):
-        """same as override method, but retuns a value."""
+        """same as override method, but returns a value."""
         scaled = scale * data + shift
         return scaled
 
@@ -975,7 +975,7 @@ class PolyBoxPlot(PolyPoints):
             p = self._points
             pxy = np.array(pntXY)
 
-        # determine distnace for each point
+        # determine distance for each point
         d = np.sqrt(np.add.reduce((p - pxy) ** 2, 1))  # sqrt(dx^2+dy^2)
         pntIndex = np.argmin(d)
         dist = d[pntIndex]
@@ -1050,7 +1050,7 @@ class PolyBoxPlot(PolyPoints):
         return outliers
 
     def _scaleAndShift(self, data, scale=(1, 1), shift=(0, 0)):
-        """same as override method, but retuns a value."""
+        """same as override method, but returns a value."""
         scaled = scale * data + shift
         return scaled
 
@@ -1070,7 +1070,7 @@ class PolyBoxPlot(PolyPoints):
         This is because
 
         + The whiskers are drawn as single line rather than two lines
-        + The median line must be visable over the box if the box has a fill.
+        + The median line must be visible over the box if the box has a fill.
 
         Other than that, the draw order can be changed.
         """
@@ -1460,7 +1460,7 @@ class PlotPrintout(wx.Printout):
 #        print("DC GetSize", dc.GetSize())
 #        print("GetPageSizePixels", self.GetPageSizePixels())
         # Note PPIScreen does not give the correct number
-        # Calulate everything for printer and then scale for preview
+        # Calculate everything for printer and then scale for preview
         PPIPrinter = self.GetPPIPrinter()        # printer dots/inch (w,h)
         # PPIScreen= self.GetPPIScreen()          # screen dots/inch (w,h)
         dcSize = dc.GetSize()                    # DC size

--- a/wx/lib/plot/utils.py
+++ b/wx/lib/plot/utils.py
@@ -32,7 +32,7 @@ class DisplaySide(object):
     Used for fine-tuning the axis, ticks, and values of a graph.
 
     This class somewhat mimics a collections.namedtuple factory function in
-    that it is an iterable and can have indiviual elements accessible by name.
+    that it is an iterable and can have individual elements accessible by name.
     It differs from a namedtuple in a few ways:
 
     - it's mutable

--- a/wx/lib/printout.py
+++ b/wx/lib/printout.py
@@ -288,7 +288,7 @@ class PrintTableDraw(wx.ScrolledWindow, PrintBase):
                 for x in self.data:     #becomes one column
                     data.append([x])
             else:
-                data = [self.data]      #becames one row
+                data = [self.data]      #becomes one row
             self.data = data
             first_value = data[0]
         try:
@@ -609,7 +609,7 @@ class PrintTableDraw(wx.ScrolledWindow, PrintBase):
 
     def DrawGridLine(self):
         if self.draw == True \
-        and len(self.column) > 2:    #supress grid lines if only one column
+        and len(self.column) > 2:    #suppress grid lines if only one column
             try:
                 size = self.row_line_size[self.data_cnt]
             except:
@@ -630,7 +630,7 @@ class PrintTableDraw(wx.ScrolledWindow, PrintBase):
 
     def DrawColumns(self):
         if self.draw == True \
-        and len(self.column) > 2:   #surpress grid line if only one column
+        and len(self.column) > 2:   #suppress grid line if only one column
             col = 0
             for val in self.column:
                 try:

--- a/wx/lib/pubsub/__init__.py
+++ b/wx/lib/pubsub/__init__.py
@@ -20,6 +20,6 @@ __all__ = [
 
 import wx
 import warnings
-warnings.warn('wx.lib.pubsub has been deprecated, plese migrate your '
+warnings.warn('wx.lib.pubsub has been deprecated, please migrate your '
               'code to use pypubsub, available on PyPI.',
               wx.wxPyDeprecationWarning)

--- a/wx/lib/pubsub/core/topicmgr.py
+++ b/wx/lib/pubsub/core/topicmgr.py
@@ -237,7 +237,7 @@ class TopicManager:
         return self.getTopic(name, okIfNone=True) is not None
         
     def hasTopicDefinition(self, name):
-        """Determine if there is a definition avaiable for topic 'name'. Return
+        """Determine if there is a definition available for topic 'name'. Return
         true if there is, false otherwise. Note: a topic may have a
         definition without being in use, and vice versa."""
         # in already existing Topic object:

--- a/wx/lib/pubsub/core/topicobj.py
+++ b/wx/lib/pubsub/core/topicobj.py
@@ -172,7 +172,7 @@ class Topic(PublisherMixin):
         return self.__validator is not None
 
     def filterMsgArgs(self, msgKwargs, check=False):
-        """Get the MDS docstrings for each of the spedified kwargs."""
+        """Get the MDS docstrings for each of the specified kwargs."""
         filteredArgs = self.__msgArgs.filterArgs(msgKwargs)
         # if no check of args yet, do it now:
         if check:
@@ -356,7 +356,7 @@ class Topic(PublisherMixin):
 
     #############################################################
     #
-    # Impementation
+    # Implementation
     #
     #############################################################
 

--- a/wx/lib/pubsub/setuparg1.py
+++ b/wx/lib/pubsub/setuparg1.py
@@ -42,6 +42,6 @@ to minimize the chance of introducing bugs in your application.
 def enforceArgName(commonName):
     """This will configure pubsub to require that all listeners use
     the same argument name (*commonName*) as first parameter. This
-    is a ueful first step in migrating an application that has been
+    is a useful first step in migrating an application that has been
     using *arg1* protocol to the more powerful *kwargs* protocol. """
     policies.setMsgDataArgName(1, commonName)

--- a/wx/lib/pubsub/setupkwargs.py
+++ b/wx/lib/pubsub/setupkwargs.py
@@ -24,6 +24,6 @@ def transitionFromArg1(commonName):
     """Utility function to assist migrating an application from using 
     the arg1 messaging protocol to using the kwargs protocol. Call this 
     after having run and debugged your application with ``setuparg1.enforceArgName(commonName)``. See the migration docs
-    for more detais. 
+    for more details. 
     """
     policies.setMsgDataArgName(2, commonName)

--- a/wx/lib/pubsub/utils/notification.py
+++ b/wx/lib/pubsub/utils/notification.py
@@ -288,7 +288,7 @@ def useNotifyByPubsubMessage(publisher=None, all=True, **kwargs):
     
     The publisher is rarely needed:
 
-    * The publisher must be specfied if pubsub is not installed
+    * The publisher must be specified if pubsub is not installed
       on the system search path (ie from pubsub import ... would fail or
       import wrong pubsub -- such as if pubsub is within wxPython's
       wx.lib package). Then pbuModule is the pub module to use::

--- a/wx/lib/pydocview.py
+++ b/wx/lib/pydocview.py
@@ -557,7 +557,7 @@ class DocMDIParentFrameMixIn:
                         window.SetDefaultSize((window._sizeBeforeHidden[0], window._sizeBeforeHidden[0] - self.GetEmbeddedWindow(EMBEDDED_WINDOW_BOTTOMRIGHT).GetSize()[1]))
                 else:
                     window.SetDefaultSize(window._sizeBeforeHidden)
-                    # If it is not the size of the full parent sashwindow set the other window's size so that if it gets shown it will have a cooresponding size
+                    # If it is not the size of the full parent sashwindow set the other window's size so that if it gets shown it will have a corresponding size
                     if window._sizeBeforeHidden[1] < parentSashWindow.GetClientSize()[1]:
                         otherWindowSize = (-1, parentSashWindow.GetClientSize()[1] - window._sizeBeforeHidden[1])
                         if window == self.GetEmbeddedWindow(EMBEDDED_WINDOW_BOTTOMLEFT):
@@ -1863,7 +1863,7 @@ class DocApp(wx.App):
         """
         Returns the instance of a particular type of service that has been installed
         into the DocApp.  For example, "wx.GetApp().GetService(pydocview.OptionsService)"
-        returns the isntance of the OptionsService that is running within the DocApp.
+        returns the instance of the OptionsService that is running within the DocApp.
         """
         for service in self._services:
             if isinstance(service, type):

--- a/wx/lib/resizewidget.py
+++ b/wx/lib/resizewidget.py
@@ -39,7 +39,7 @@ _RWLayoutNeededEvent, EVT_RW_LAYOUT_NEEDED = wx.lib.newevent.NewCommandEvent()
 
 # TODO: Add a style flag that indicates that the ResizeWidget should
 # try to adjust the layout itself by looking up the sizer and
-# containment hierachy.  Maybe also a style that says that it is okay
+# containment hierarchy.  Maybe also a style that says that it is okay
 # to adjust the size of top-level windows too.
 
 #-----------------------------------------------------------------------------
@@ -309,7 +309,7 @@ class ResizeWidget(wx.Panel):
         return False
 
 
-    #=== Overriden virtuals from the base class ===
+    #=== Overridden virtuals from the base class ===
     def AddChild(self, child):
         """
         Add the child to manage.

--- a/wx/lib/softwareupdate.py
+++ b/wx/lib/softwareupdate.py
@@ -85,7 +85,7 @@ class SoftwareUpdate(object):
         base URL (with a trailing '/') for the location of the update
         packages, or an instance of a class derived from the
         esky.finder.VersionFinder class is required. A custom VersionFinder
-        can be used to find and fetch the newer verison of the software in
+        can be used to find and fetch the newer version of the software in
         some other way, if desired.
 
         Call this method from the app's OnInit method.
@@ -188,7 +188,7 @@ class SoftwareUpdate(object):
             newest, chLogTxt = result
             if newest is None:
                 if not silentUnlessUpdate:
-                    MultiMessageBox("You are already running the newest verison of %s." %
+                    MultiMessageBox("You are already running the newest version of %s." %
                                     self.GetAppDisplayName(),
                                     self._caption, parent=parentWindow, icon=self._icon,
                                     style=wx.OK|SOT)
@@ -196,7 +196,7 @@ class SoftwareUpdate(object):
             self._parentWindow = parentWindow
 
             resp = MultiMessageBox("A new version of %s is available.\n\n"
-                   "You are currently running verison %s; version %s is now "
+                   "You are currently running version %s; version %s is now "
                    "available for download.  Do you wish to install it now?"
                    % (self.GetAppDisplayName(), active, newest),
                    self._caption, msg2=chLogTxt, style=wx.YES_NO|SOT,
@@ -226,9 +226,9 @@ class SoftwareUpdate(object):
 
             try:
                 # Let Esky handle all the rest of the update process so we can
-                # take advantage of the error checking and priviledge elevation
-                # (if neccessary) that they have done so we don't have to worry
-                # about that ourselves like we would if we broke down the proccess
+                # take advantage of the error checking and privilege elevation
+                # (if necessary) that they have done so we don't have to worry
+                # about that ourselves like we would if we broke down the process
                 # into component steps.
                 self._esky.auto_update(self._updateProgress)
 
@@ -268,7 +268,7 @@ class SoftwareUpdate(object):
                 info.exe = exe
 
                 # Make sure the CWD not in the current version's appdir, so it can
-                # hopefully be cleaned up either as we exit or as the next verison
+                # hopefully be cleaned up either as we exit or as the next version
                 # is starting.
                 os.chdir(os.path.dirname(exe))
 

--- a/wx/lib/splitter.py
+++ b/wx/lib/splitter.py
@@ -31,7 +31,7 @@ class MultiSplitterWindow(wx.Panel):
     that deal with the child windows managed by the splitter, and also
     those that deal with the sash positions.  In most cases you will
     need to pass an index value to tell the class which window or sash
-    you are refering to.
+    you are referring to.
 
     The concept of the sash position is also different than in
     wx.SplitterWindow.  Since the wx.Splitterwindow has only one sash

--- a/wx/lib/stattext.py
+++ b/wx/lib/stattext.py
@@ -196,7 +196,7 @@ class GenStaticText(wx.Control):
           in the specified state.
 
         .. note:: Note that when a parent window is disabled, all of its
-           children are disabled as well and they are reenabled again when
+           children are disabled as well and they are re-enabled again when
            the parent is.
 
         .. note:: Overridden from :class:`wx.Control`.

--- a/wx/lib/utils.py
+++ b/wx/lib/utils.py
@@ -1,6 +1,6 @@
 #----------------------------------------------------------------------
 # Name:        wx.lib.utils
-# Purpose:     Miscelaneous utility functions
+# Purpose:     Miscellaneous utility functions
 #
 # Author:      Robin Dunn
 #

--- a/wx/lib/wxpTag.py
+++ b/wx/lib/wxpTag.py
@@ -58,13 +58,13 @@ be converted from strings to alternate datatypes.  They are:
     colours      Any value of the form "#123ABC" will automatically be
                  converted to a wxColour object.
 
-    Py Types     Any value begining with "(", "[" or "{" are expected to
+    Py Types     Any value beginning with "(", "[" or "{" are expected to
                  be a Python tuple, list, or dictionary and eval()
                  will be used to convert them to that type.  If the
                  eval() fails then the original string value will be
                  preserved.
 
-    wx Types     Any value begining with "wx" is expected to be an attempt
+    wx Types     Any value beginning with "wx" is expected to be an attempt
                  to create a wxPython object, such as a wxSize, etc.
                  The eval() will be used to try and construct the
                  object and if it fails then the original string value

--- a/wx/py/CHANGES.txt
+++ b/wx/py/CHANGES.txt
@@ -102,7 +102,7 @@ Modified crust.py to use a switch so it can load either a Shell or a Slices_Shel
 0.9.5 (12/23/2005)
 ------------------
 
-Applied a series of enhancments by Franz Steinaeusler, Adi Sieker, and
+Applied a series of enhancements by Franz Steinaeusler, Adi Sieker, and
 Sebastian Haase, up until their 7-31-2005 version.  (Their next
 version broke some existing functionality, and added some confusing
 hacks, and I didn't feel that the incremental gains were worth the
@@ -624,7 +624,7 @@ Changed default font size under Linux to::
     'lnsize' : 10,
 
 Changed ``Shell`` to expect a parameter referencing an Interpreter
-class, rather than an intepreter instance, to facilitate subclassing
+class, rather than an interpreter instance, to facilitate subclassing
 of Interpreter, which effectively broke when the Editor class was
 eliminated.
 

--- a/wx/py/editwindow.py
+++ b/wx/py/editwindow.py
@@ -271,7 +271,7 @@ class EditWindow(stc.StyledTextCtrl):
             start = self.GetSelection()[1]
             loc = textstring.find(findstring, start)
 
-        # if it wasn't found then restart at begining
+        # if it wasn't found then restart at beginning
         if loc == -1 and start != 0:
             if backward:
                 start = end

--- a/wx/py/filling.py
+++ b/wx/py/filling.py
@@ -207,7 +207,7 @@ class FillingTree(wx.TreeCtrl):
             parent = self.GetItemParent(item)
             obj = self.GetItemData(parent)
         # Apply dictionary syntax to dictionary items, except the root
-        # and first level children of a namepace.
+        # and first level children of a namespace.
         if ((isinstance(obj, dict)
             or 'BTrees' in six.text_type(type(obj))
             and hasattr(obj, 'keys'))

--- a/wx/py/frame.py
+++ b/wx/py/frame.py
@@ -178,9 +178,9 @@ class Frame(wx.Frame):
                  'Include attributes visible to __getattr__ and __setattr__',
                  wx.ITEM_CHECK)
         m.Append(ID_AUTOCOMP_SINGLE, 'Include Single &Underscores\tCtrl+Shift+U',
-                 'Include attibutes prefixed by a single underscore', wx.ITEM_CHECK)
+                 'Include attributes prefixed by a single underscore', wx.ITEM_CHECK)
         m.Append(ID_AUTOCOMP_DOUBLE, 'Include &Double Underscores\tCtrl+Shift+D',
-                 'Include attibutes prefixed by a double underscore', wx.ITEM_CHECK)
+                 'Include attributes prefixed by a double underscore', wx.ITEM_CHECK)
         m = self.calltipsMenu = wx.Menu()
         m.Append(ID_CALLTIPS_SHOW, 'Show Call &Tips\tCtrl+Shift+T',
                  'Show call tips with argument signature and docstring', wx.ITEM_CHECK)

--- a/wx/py/introspect.py
+++ b/wx/py/introspect.py
@@ -281,7 +281,7 @@ def getRoot(command, terminator=None):
                 # start represents the last known good point in the line.
                 start = token[2][1]
         elif len(tokenstring) == 1 and tokenstring in ('[({])}'):
-            # Remember, we're working backwords.
+            # Remember, we're working backwards.
             # So prefix += tokenstring would be wrong.
             if prefix in emptyTypes and tokenstring in ('[({'):
                 # We've already got an empty type identified so now we

--- a/wx/py/path.py
+++ b/wx/py/path.py
@@ -26,7 +26,7 @@ def ls(str='*',fullpath=False):
 
 # This prints the results of running a command in the GUI shell but be warned!
 # This is a blocking call, and if you open any kind of interactive
-# command-line program like python or bash, the shell will permanantly
+# command-line program like python or bash, the shell will permanently
 # freeze!
 # If you want this kind of behavior to be available, please use ipython
 # This is NOT a feature or goal of the Py project!

--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -1569,7 +1569,7 @@ class Shell(editwindow.EditWindow):
 ##         self.GetData()
 ##         if self.textdo.GetTextLength() > 1:
 ##             text = self.textdo.GetText()
-##             # *** Do somethign with the dragged text here...
+##             # *** Do something with the dragged text here...
 ##             self.textdo.SetText('')
 ##         else:
 ##             filenames = str(self.filename.GetFilenames())

--- a/wx/py/sliceshell.py
+++ b/wx/py/sliceshell.py
@@ -3795,7 +3795,7 @@ class SlicesShell(editwindow.EditWindow):
 ##         self.GetData()
 ##         if self.textdo.GetTextLength() > 1:
 ##             text = self.textdo.GetText()
-##             # *** Do somethign with the dragged text here...
+##             # *** Do something with the dragged text here...
 ##             self.textdo.SetText('')
 ##         else:
 ##             filenames = str(self.filename.GetFilenames())

--- a/wx/svg/_nanosvg.c
+++ b/wx/svg/_nanosvg.c
@@ -21618,7 +21618,7 @@ static int __Pyx_check_binary_version(void) {
     if (ctversion[0] != rtversion[0] || ctversion[2] != rtversion[2]) {
         char message[200];
         PyOS_snprintf(message, sizeof(message),
-                      "compiletime version %s of module '%.100s' "
+                      "compile time version %s of module '%.100s' "
                       "does not match runtime version %s",
                       ctversion, __Pyx_MODULE_NAME, rtversion);
         return PyErr_WarnEx(NULL, message, 1);

--- a/wx/tools/genaxmodule.py
+++ b/wx/tools/genaxmodule.py
@@ -31,7 +31,7 @@ def main(args=None):
         print(__doc__)
         sys.exit(1)
 
-    # unfortunatly we need to make an app, frame and an instance of
+    # unfortunately we need to make an app, frame and an instance of
     # the ActiceX control in order to get the TypeInfo about it...
     app = wx.App()
     f = wx.Frame(None, -1, "")

--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -239,7 +239,7 @@ def __init_resources():
 def __gettext_strings():
     # This is a dummy function that lists all the strings that are used in
     # the XRC file in the _("a string") format to be recognized by GNU
-    # gettext utilities (specificaly the xgettext utility) and the
+    # gettext utilities (specifically the xgettext utility) and the
     # mki18n.py script.  For more information see:
     # http://wiki.wxpython.org/index.cgi/Internationalization
 

--- a/wx/tools/wxget.py
+++ b/wx/tools/wxget.py
@@ -24,7 +24,7 @@ Usage:
 
 Where URL is a file URL and the optional DEST_DIR is a destination directory to
 download to, (default is to prompt the user).
-The --trusted option can be used to surpress certificate checks.
+The --trusted option can be used to suppress certificate checks.
 """
 from __future__ import (division, absolute_import, print_function, unicode_literals)
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #NNNN

$ [`codespell --ignore-words-list="actualy,alo,ans,anumber,apoints,attch,ba,chec,composit,currenty,datas,doed,doubleclick,ede,fo,fof,hist,hve,iif,inout,nd,nin,noe,nwo,ond,originaly,ot,poer,sade,splitted,startin,sxl,te,thex,ue,wit" --skip="*.bak,*.po" -w`](https://pypi.org/project/codespell/)

