### PR TITLE
unicode() is removed in Python 3

### DIFF
--- a/build.py
+++ b/build.py
@@ -1065,7 +1065,7 @@ def _removeSidebar(path):
         tag = soup.find('div', 'document')
         if tag:
             tag.attrs['class'] = ['document-no-sidebar']
-        text = unicode(soup) if PY2 else str(soup)
+        text = str(soup)
         with textfile_open(filename, 'wt') as f:
             f.write(text)
 

--- a/buildtools/backports/textwrap3.py
+++ b/buildtools/backports/textwrap3.py
@@ -17,9 +17,6 @@
 
 from __future__ import print_function
 import re
-import sys
-
-_PY2 = sys.version_info[0] == 2
 
 __all__ = ['TextWrapper', 'wrap', 'fill', 'dedent', 'indent', 'shorten']
 
@@ -32,10 +29,7 @@ def _translate(s, mapping):
     Could alternatively just shift up to unicode, which is what most strings should
     be anyway, but that path is fraught with danger of causing downstream errors.
     """
-    if _PY2 and isinstance(s, str):
-        return str(unicode(s).translate(mapping))
-    else:
-        return s.translate(mapping) # default path
+    return s.translate(mapping) # default path
 
 # Hardcode the recognized whitespace characters to the US-ASCII
 # whitespace characters.  The main reason for doing this is that

--- a/demo/SVGImage_Bitmap.py
+++ b/demo/SVGImage_Bitmap.py
@@ -2,7 +2,6 @@
 import sys
 import os
 import glob
-import six
 
 import wx
 from wx.svg import SVGimage
@@ -26,8 +25,6 @@ class SVGBitmapDisplay(wx.Panel):
 
 
     def UpdateSVG(self, svg_filename):
-        if six.PY2 and isinstance(svg_filename, unicode):
-            svg_filename = svg_filename.encode(sys.getfilesystemencoding())
         img = SVGimage.CreateFromFile(svg_filename)
         bmp = img.ConvertToScaledBitmap(self.bmp_size, self)
         self.statbmp.SetBitmap(bmp)

--- a/demo/SVGImage_Render.py
+++ b/demo/SVGImage_Render.py
@@ -2,7 +2,6 @@
 import sys
 import os
 import glob
-import six
 
 import wx
 from wx.svg import SVGimage
@@ -26,8 +25,6 @@ class SVGRenderPanel(wx.Panel):
 
 
     def SetSVGFile(self, svg_filename):
-        if six.PY2 and isinstance(svg_filename, unicode):
-            svg_filename = svg_filename.encode(sys.getfilesystemencoding())
         self._img = SVGimage.CreateFromFile(svg_filename)
         self.Refresh()
 

--- a/demo/agw/Windows7Explorer_Contents.py
+++ b/demo/agw/Windows7Explorer_Contents.py
@@ -3,8 +3,6 @@
 import sys
 import os
 import wx
-import six
-import time
 import datetime
 import operator
 
@@ -30,9 +28,6 @@ sys.path.append(os.path.split(dirName)[0])
 # helper function to make sure we don't convert unicode objects to strings
 # or vice versa when converting lists and None values to text.
 convert = str
-if six.PY2:
-    if 'unicode' in wx.PlatformInfo:
-        convert = unicode
 
 
 def FormatFileSize(size):

--- a/sphinxtools/librarydescription.py
+++ b/sphinxtools/librarydescription.py
@@ -1,24 +1,16 @@
-import sys
 import os
 import re
 
-if sys.version_info < (3,):
-    from StringIO import StringIO
-else:
-    from io import StringIO
+from io import StringIO
 
 from inspect import getmro, getclasstree, getdoc, getcomments
 
 from .utilities import makeSummary, chopDescription, writeSphinxOutput, PickleFile
-from .utilities import findControlImages, formatExternalLink, isPython3
+from .utilities import findControlImages, formatExternalLink
 from .constants import object_types, MODULE_TO_ICON, DOXY_2_REST, SPHINXROOT
 from . import templates
 
 EPYDOC_PATTERN = re.compile(r'\S+{\S+}', re.DOTALL)
-
-if sys.version_info < (3,):
-    reload(sys)
-    sys.setdefaultencoding('utf-8')
 
 
 def make_class_tree(tree):
@@ -1016,11 +1008,7 @@ class Property(ChildrenBase):
 class Attribute(ChildrenBase):
 
     def __init__(self, name, specs, value):
-
-        if isPython3():
-            specs = str(specs)
-        else:
-            specs = unicode(specs)
+        specs = str(specs)
 
         start, end = specs.find("'"), specs.rfind("'")
         specs = specs[start+1:end]

--- a/sphinxtools/modulehunter.py
+++ b/sphinxtools/modulehunter.py
@@ -26,10 +26,6 @@ from .utilities import isPython3, PickleFile
 from .constants import object_types, EXCLUDED_ATTRS, MODULE_TO_ICON
 from .constants import CONSTANT_RE
 
-if sys.version_info < (3,):
-    reload(sys)
-    sys.setdefaultencoding('utf-8')
-
 if isPython3():
     MethodTypes = (classmethod, types.MethodType, types.ClassMethodDescriptorType)
 else:
@@ -155,10 +151,7 @@ def analyze_params(obj, signature):
             pvalue = pvalue.strip()
             if pname in pevals:
                 try:
-                    if isPython3():
-                        peval = str(pevals[pname])
-                    else:
-                        peval = unicode(pevals[pname])
+                    peval = str(pevals[pname])
                 except UnicodeDecodeError:
                     peval = repr(pevals[pname])
                 except TypeError:

--- a/sphinxtools/postprocess.py
+++ b/sphinxtools/postprocess.py
@@ -9,7 +9,6 @@
 #---------------------------------------------------------------------------
 
 # Standard library imports
-import sys
 import os
 import re
 import glob
@@ -24,9 +23,6 @@ from .utilities import wx2Sphinx, PickleFile
 from .constants import HTML_REPLACE, TODAY, SPHINXROOT, SECTIONS_EXCLUDE
 from .constants import CONSTANT_INSTANCES, WIDGETS_IMAGES_ROOT, SPHINX_IMAGES_ROOT
 from .constants import DOCSTRING_KEY
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 
 # ----------------------------------------------------------------------- #
 
@@ -750,7 +746,7 @@ def removeHeaderImage(text, options):
     tag = soup.find('div', 'headerimage')
     if tag:
         tag.extract()
-        text = unicode(soup) if PY2 else str(soup)
+        text = str(soup)
     return text
 
 
@@ -762,7 +758,7 @@ def tweakModuleIndex(text):
         href = tag['href'].split('.html#')
         if len(href) == 2 and href[0] == href[1]:
             tag['href'] = href[0] + '.html'
-    return unicode(soup) if PY2 else str(soup)
+    return str(soup)
 
 
 def tooltipsOnInheritance(text, class_summary):

--- a/unittests/test_arraystring.py
+++ b/unittests/test_arraystring.py
@@ -1,14 +1,11 @@
 import unittest
 import wx
-import six
 
 #---------------------------------------------------------------------------
 
-if not six.PY3:
-    alt = unicode
-else:
-    def alt(s):
-        return bytes(s, 'utf-8')
+
+def alt(s):
+    return bytes(s, 'utf-8')
 
 
 class ArrayString(unittest.TestCase):

--- a/unittests/test_string.py
+++ b/unittests/test_string.py
@@ -10,78 +10,27 @@ from unittests import wtc
 class String(unittest.TestCase):
 
     if hasattr(wx, 'testStringTypemap'):
-        if not six.PY3:
-            def test_StringTypemapsPy2(self):
-                utf  = '\xc3\xa9l\xc3\xa9phant'     # utf-8 string
-                uni  = utf.decode('utf-8')          # convert to unicode
-                iso  = uni.encode('iso-8859-1')     # make a string with a different encoding
+        def test_StringTypemapsPy3(self):
+            utf  = b'\xc3\xa9l\xc3\xa9phant'    # utf-8 bytes
+            uni  = utf.decode('utf-8')          # convert to unicode
+            iso  = uni.encode('iso-8859-1')     # make a string with a different encoding
 
+            # ascii
+            result = wx.testStringTypemap(b'hello')
+            self.assertTrue(type(result) == str)
+            self.assertTrue(result == 'hello')
 
-                # wx.testStringTypemap() will accept a parameter that
-                # is a Unicode object or an 'ascii' or 'utf-8' string object,
-                # which will then be converted to a wxString. The return
-                # value is a Unicode object that has been converted from a
-                # wxString that is a copy of the wxString created for the
-                # parameter.
+            # unicode should pass through unmodified
+            result = wx.testStringTypemap(uni)
+            self.assertTrue(result == uni)
 
-                # ascii
-                result = wx.testStringTypemap('hello')
-                self.assertTrue(type(result) == unicode)
-                self.assertTrue(result == unicode('hello'))
+            # utf-8 is converted
+            result = wx.testStringTypemap(utf)
+            self.assertTrue(result == uni)
 
-                # unicode should pass through unmodified
-                result = wx.testStringTypemap(uni)
-                self.assertTrue(result == uni)
-
-                # utf-8 is converted
-                result = wx.testStringTypemap(utf)
-                self.assertTrue(result == uni)
-
-                # can't auto-convert this
-                with self.assertRaises(UnicodeDecodeError):
-                    result = wx.testStringTypemap(iso)
-
-                # utf-16-be
-                val = "\x00\xe9\x00l\x00\xe9\x00p\x00h\x00a\x00n\x00t"
-                with self.assertRaises(UnicodeDecodeError):
-                    result = wx.testStringTypemap(val)
-                result = wx.testStringTypemap( val.decode('utf-16-be'))
-                self.assertTrue(result == uni)
-
-                # utf-32-be
-                val = "\x00\x00\x00\xe9\x00\x00\x00l\x00\x00\x00\xe9\x00\x00\x00p\x00\x00\x00h\x00\x00\x00a\x00\x00\x00n\x00\x00\x00t"
-                with self.assertRaises(UnicodeDecodeError):
-                    result = wx.testStringTypemap(val)
-                result = wx.testStringTypemap(val.decode('utf-32-be'))
-                self.assertTrue(result == uni)
-
-                # utf-8 with BOM
-                #val = "\xef\xbb\xbfHello"
-                #result = wx.testStringTypemap(val)
-                #self.assertTrue(result == u'\ufeffHello')
-
-        else:
-            def test_StringTypemapsPy3(self):
-                utf  = b'\xc3\xa9l\xc3\xa9phant'    # utf-8 bytes
-                uni  = utf.decode('utf-8')          # convert to unicode
-                iso  = uni.encode('iso-8859-1')     # make a string with a different encoding
-
-                # ascii
-                result = wx.testStringTypemap(b'hello')
-                self.assertTrue(type(result) == str)
-                self.assertTrue(result == 'hello')
-
-                # unicode should pass through unmodified
-                result = wx.testStringTypemap(uni)
-                self.assertTrue(result == uni)
-
-                # utf-8 is converted
-                result = wx.testStringTypemap(utf)
-                self.assertTrue(result == uni)
-
-                # can't auto-convert this
-                with self.assertRaises(UnicodeDecodeError):
-                    result = wx.testStringTypemap(iso)
+            # can't auto-convert this
+            with self.assertRaises(UnicodeDecodeError):
+                result = wx.testStringTypemap(iso)
 
 
 #---------------------------------------------------------------------------

--- a/unittests/test_wxdatetime.py
+++ b/unittests/test_wxdatetime.py
@@ -1,6 +1,5 @@
 import unittest
 import wx
-import six
 from unittests import wtc
 import datetime
 import time
@@ -45,12 +44,8 @@ class datetime_Tests(wtc.WidgetTestCase):
 
     def test_datetimeGetAmPm(self):
         am, pm = wx.DateTime.GetAmPmStrings()
-        if six.PY3:
-            base = str
-        else:
-            base = unicode
-        self.assertTrue(isinstance(am, base) and am != "")
-        self.assertTrue(isinstance(pm, base) and pm != "")
+        self.assertTrue(isinstance(am, str) and am != "")
+        self.assertTrue(isinstance(pm, str) and pm != "")
 
 
     def test_datetimeProperties(self):

--- a/wx/py/interpreter.py
+++ b/wx/py/interpreter.py
@@ -56,14 +56,6 @@ class Interpreter(InteractiveInterpreter):
         commandBuffer until we have a complete command. If not, we
         delete that last list."""
 
-        # In case the command is unicode try encoding it
-        if not six.PY3:
-            if type(command) == unicode:
-                try:
-                    command = command.encode('utf-8')
-                except UnicodeEncodeError:
-                    pass # otherwise leave it alone
-
         if not self.more:
             try: del self.commandBuffer[-1]
             except IndexError: pass

--- a/wx/py/tests/test_introspect.py
+++ b/wx/py/tests/test_introspect.py
@@ -394,21 +394,6 @@ class GetBaseObjectTestCase(unittest.TestCase):
             # Class with no init.
             (Bar, Bar, 0),
         ]
-        if not PY3:
-            values.extend([
-            # Byte-compiled code.
-            (ham.func_code, ham.func_code, 0),
-            # Class with init.
-            (Foo, Foo.__init__.im_func, 1),
-            # Bound method.
-            (spam.foo, spam.foo.im_func, 1),
-            # Bound method with self named something else (spam).
-            (spam.bar, spam.bar.im_func, 1),
-            # Unbound method. (Do not drop the self argument.)
-            (eggs, eggs.im_func, 0),
-            # Callable instance.
-            (spam, spam.__call__.im_func, 1),
-            ])
         for object, baseObject, dropSelf in values:
             result = introspect.getBaseObject(object)
             self.assertEqual(result, (baseObject, dropSelf))
@@ -674,16 +659,6 @@ class GetAttributeNamesTestCase(GetAttributeTestCase):
             # BrokenStr instance.
             brokenStr,
         ]
-        if not PY3:
-            self.items.extend([
-                long(123),
-                unicode(""),
-                xrange(0),
-                # Byte-compiled code.
-                ham.func_code,
-                # Buffer.
-                buffer(''),
-            ])
 
     def tearDown(self):
         self.items = None


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes [`flake8 . --count --exclude=./buildtools/backports/six.py,./wx/lib/pubsub/py2and3.py --select=F82 --show-source --statistics | grep unicode`](https://pypi.org/project/flake8/)

