### PR TITLE
fix: Correct types of arguments to ScrolledWindow.SetScrollbars

### DIFF
--- a/demo/Mask.py
+++ b/demo/Mask.py
@@ -56,7 +56,7 @@ class TestMaskWindow(wx.ScrolledWindow):
         mask = wx.Mask(self.bmp_withcolourmask, wx.WHITE)
         self.bmp_withcolourmask.SetMask(mask)
 
-        self.SetScrollbars(20, 20, 700/20, 460/20)
+        self.SetScrollbars(20, 20, 700//20, 460//20)
 
         self.Bind(wx.EVT_PAINT, self.OnPaint)
 

--- a/demo/OGL.py
+++ b/demo/OGL.py
@@ -272,7 +272,7 @@ class TestWindow(ogl.ShapeCanvas):
 
         maxWidth  = 1000
         maxHeight = 1000
-        self.SetScrollbars(20, 20, maxWidth/20, maxHeight/20)
+        self.SetScrollbars(20, 20, maxWidth//20, maxHeight//20)
 
         self.log = log
         self.frame = frame

--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -9654,8 +9654,8 @@ class UltimateListMainWindow(wx.ScrolledWindow):
                 self._linesPerPage = clientHeight//lineHeight
 
                 self.SetScrollbars(SCROLL_UNIT_X, lineHeight,
-                                   (self.GetHeaderWidth()-decrement)/SCROLL_UNIT_X,
-                                   (entireHeight + lineHeight - 1)/lineHeight,
+                                   (self.GetHeaderWidth()-decrement)//SCROLL_UNIT_X,
+                                   (entireHeight + lineHeight - 1)//lineHeight,
                                    self.GetScrollPos(wx.HORIZONTAL),
                                    self.GetScrollPos(wx.VERTICAL),
                                    True)
@@ -9676,8 +9676,8 @@ class UltimateListMainWindow(wx.ScrolledWindow):
                     decrement = SCROLL_UNIT_X
 
                 self.SetScrollbars(SCROLL_UNIT_X, SCROLL_UNIT_Y,
-                                   (self.GetHeaderWidth()-decrement)/SCROLL_UNIT_X,
-                                   (entireHeight + SCROLL_UNIT_Y - 1)/SCROLL_UNIT_Y,
+                                   (self.GetHeaderWidth()-decrement)//SCROLL_UNIT_X,
+                                   (entireHeight + SCROLL_UNIT_Y - 1)//SCROLL_UNIT_Y,
                                    self.GetScrollPos(wx.HORIZONTAL),
                                    self.GetScrollPos(wx.VERTICAL),
                                    True)
@@ -9728,8 +9728,8 @@ class UltimateListMainWindow(wx.ScrolledWindow):
                         line._gi.ExtendWidth(widthMax)
 
                 self.SetScrollbars(SCROLL_UNIT_X, lineHeight,
-                                   (x + SCROLL_UNIT_X)/SCROLL_UNIT_X,
-                                   (y + lineHeight)/lineHeight,
+                                   (x + SCROLL_UNIT_X)//SCROLL_UNIT_X,
+                                   (y + lineHeight)//lineHeight,
                                    self.GetScrollPos(wx.HORIZONTAL),
                                    self.GetScrollPos(wx.VERTICAL),
                                    True)
@@ -9797,7 +9797,7 @@ class UltimateListMainWindow(wx.ScrolledWindow):
                             break  # Everything fits, no second try required.
 
                 self.SetScrollbars(SCROLL_UNIT_X, lineHeight,
-                                   (entireWidth + SCROLL_UNIT_X)/SCROLL_UNIT_X,
+                                   (entireWidth + SCROLL_UNIT_X)//SCROLL_UNIT_X,
                                    0,
                                    self.GetScrollPos(wx.HORIZONTAL),
                                    0,


### PR DESCRIPTION
The third and fourth arguments to ScrolledWindow.SetScrollbars are of integer
types and therefore need to be computed with expressions that result in an
integer. This PR removes the remaining places in the code where
ScrolledWindow.SetScrollbars was called with the float result of ordinary division,
eliminating warnings that the library was generating. The library should not
generate warnings in ordinary operation.

Thanks for reviewing and merging.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->


