### PR TITLE
Add wxDC.DrawLinesFromBuffer to draw directly from numpy array memory using the Buffer protocol

### DIFF
--- a/demo/DrawLinesFromBuffer.py
+++ b/demo/DrawLinesFromBuffer.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+import time
+
+import wx
+
+npts = 100000
+
+def TestLinesFromBuffer(dc, log):
+    global npts
+    try:
+        import numpy as np
+        start = time.time()
+
+        w, h = dc.GetSize()
+
+        vs = np.linspace(0, 1, npts).reshape((npts, 1))
+
+        x1 = np.cos(vs * 12 * np.pi) * w/2 * vs + w/2
+        x2 = np.cos(vs * 16 * np.pi) * w/2 * vs + w/2
+        y1 = np.sin(vs * 12 * np.pi) * w/2 * vs + h/2
+        y2 = np.sin(vs * 16 * np.pi) * w/2 * vs + h/2
+        
+
+        pts1 = np.append(x1, y1, 1).astype('int32')
+        pts2 = np.append(x2, y2, 1).astype('int32')
+
+        dc.SetPen(wx.BLACK_PEN)
+        t1 = time.time()
+        dc.DrawLines(pts1)
+        t2 = time.time()
+        
+        dc.SetPen(wx.RED_PEN)
+        t3 = time.time()
+        dc.DrawLinesFromBuffer(pts2)
+        t4 = time.time()
+        
+        log.write("%s pts: %s seconds with DrawLines %s seconds with DrawLinesFromBuffer\n" % (npts, t2 - t1, t4 - t3))
+
+    except ImportError:
+        log.write("Couldn't import numpy")
+        pass
+
+
+
+# Class used for all the various sample pages; the mechanics are the same
+# for each one with regards to the notebook. The only difference is
+# the function we use to draw on it.
+class DrawPanel(wx.Panel):
+    def __init__(self, parent, drawFun, log):
+        wx.Panel.__init__(self, parent, -1)
+        self.SetBackgroundColour(wx.WHITE)
+
+        self.log = log
+        self.drawFun = drawFun
+        self.Bind(wx.EVT_PAINT, self.OnPaint)
+
+    def OnSize(self, evt):
+        self.Refresh()
+
+    def OnPaint(self, evt):
+        dc = wx.PaintDC(self)
+        dc.Clear()
+        self.drawFun(dc,self.log)
+
+
+#----------------------------------------------------------------------
+
+def runTest(frame, nb, log):
+    global npts
+    
+    panel = wx.Panel(nb, -1)
+    vsizer = wx.BoxSizer(wx.VERTICAL)
+    hsizer = wx.BoxSizer(wx.HORIZONTAL)
+    hsizer.Add(wx.StaticText(panel, -1, "# of Points"), 0, wx.ALIGN_CENTER|wx.ALL, 5)
+    npts_ctrl = wx.TextCtrl(panel, -1, str(npts))
+    hsizer.Add(npts_ctrl, 0, wx.ALIGN_CENTER|wx.ALL, 5)
+    
+    button = wx.Button(panel, -1, "Refresh")
+    hsizer.Add(button, 0, wx.ALIGN_CENTER|wx.ALL, 5)
+    vsizer.Add(hsizer, 0, wx.ALIGN_CENTER, 0)
+    
+    win = DrawPanel(panel, TestLinesFromBuffer, log)
+    vsizer.Add(win, 1, wx.GROW, 0)
+    panel.SetSizer(vsizer)
+    
+    def update_npts(evt):
+        global npts
+        
+        val = npts_ctrl.GetValue()
+        try:
+            npts = int(val)
+        except ValueError:
+            log.write("Error converting %s to an int" % (val))
+        win.Refresh()
+    button.Bind(wx.EVT_BUTTON, update_npts)
+    
+    return panel
+
+#----------------------------------------------------------------------
+
+
+overview = """\
+
+The DrawLinesFromBuffer function has been added to wx.DC to provide 
+a way to draw directly from a numpy array or other object that implements
+the python buffer protocol.  
+
+<pre>
+    DrawLinesFromBuffer(pyBuff)
+</pre>
+
+If called with an object that doesn't support
+the python buffer protocol, or if the underlying element size does not
+match the size of a wxPoint, a TypeError exception is raised.
+"""
+
+
+if __name__ == '__main__':
+    import sys,os
+    import run
+    run.main(['', os.path.basename(sys.argv[0])] + sys.argv[1:])
+

--- a/demo/DrawLinesFromBuffer.py
+++ b/demo/DrawLinesFromBuffer.py
@@ -22,8 +22,9 @@ def TestLinesFromBuffer(dc, log):
         y2 = np.sin(vs * 16 * np.pi) * w/2 * vs + h/2
         
 
-        pts1 = np.append(x1, y1, 1).astype('int32')
-        pts2 = np.append(x2, y2, 1).astype('int32')
+        # Data has to be the same size as a C integer
+        pts1 = np.append(x1, y1, 1).astype('intc')
+        pts2 = np.append(x2, y2, 1).astype('intc')
 
         dc.SetPen(wx.BLACK_PEN)
         t1 = time.time()
@@ -110,9 +111,16 @@ the python buffer protocol.
     DrawLinesFromBuffer(pyBuff)
 </pre>
 
+The buffer object needs to provide an array of C integers organized as 
+x, y point pairs.  The size of a C integer is platform dependent.
+With numpy, the intc data type will provide the appropriate element size.
+
 If called with an object that doesn't support
 the python buffer protocol, or if the underlying element size does not
-match the size of a wxPoint, a TypeError exception is raised.
+match the size of a C integer, a TypeError exception is raised.  If 
+the buffer provided has float data with the same element size as a 
+C integer, no error will be raised, but the lines will not be drawn
+in the appropriate places.
 """
 
 

--- a/demo/demodata.py
+++ b/demo/demodata.py
@@ -50,6 +50,7 @@ _treeList = [
         'ActivityIndicator',
         'GenericCheckBox',
         'CheckListCtrl',
+        'DrawLinesFromBuffer',
     ]),
 
     # managed windows == things with a (optional) caption you can close
@@ -275,6 +276,7 @@ _treeList = [
         'Cairo_Snippets',
         'ColourDB',
         'DragScroller',
+        'DrawLinesFromBuffer',
         'DrawXXXList',
         'FileHistory',
         'FontEnumerator',

--- a/etg/dc.py
+++ b/etg/dc.py
@@ -310,9 +310,9 @@ def run():
         '(PyObject* textList, PyObject* pyPoints, PyObject* foregroundList, PyObject* backgroundList)',
         body="return wxPyDrawTextList(*self, textList, pyPoints, foregroundList, backgroundList);")
 
-    c.addCppMethod('PyObject*', '_DrawLinesBuffer',
+    c.addCppMethod('PyObject*', '_DrawLinesFromBuffer',
         '(PyObject* pyBuff)',
-        body="return wxPyDrawLinesBuffer(*self, pyBuff);")
+        body="return wxPyDrawLinesFromBuffer(*self, pyBuff);")
 
     c.addPyMethod('DrawPointList', '(self, points, pens=None)',
         doc="""\
@@ -478,7 +478,7 @@ def run():
             """)
 
 
-    c.addPyMethod('DrawLinesBuffer', '(self, pyBuff)',
+    c.addPyMethod('DrawLinesFromBuffer', '(self, pyBuff)',
         doc="""\
             Implementation of DrawLines that can use numpy arrays, or anything else that uses the
             python buffer protocol, directly.
@@ -486,7 +486,7 @@ def run():
             :param pyBuff:    A python buffer containing integer pairs
             """,
         body="""\
-            return  self._DrawLinesBuffer(pyBuff)
+            return  self._DrawLinesFromBuffer(pyBuff)
             """)
 
 

--- a/etg/dc.py
+++ b/etg/dc.py
@@ -310,6 +310,9 @@ def run():
         '(PyObject* textList, PyObject* pyPoints, PyObject* foregroundList, PyObject* backgroundList)',
         body="return wxPyDrawTextList(*self, textList, pyPoints, foregroundList, backgroundList);")
 
+    c.addCppMethod('PyObject*', '_DrawLinesBuffer',
+        '(PyObject* pyBuff)',
+        body="return wxPyDrawLinesBuffer(*self, pyBuff);")
 
     c.addPyMethod('DrawPointList', '(self, points, pens=None)',
         doc="""\
@@ -475,6 +478,16 @@ def run():
             """)
 
 
+    c.addPyMethod('DrawLinesBuffer', '(self, pyBuff)',
+        doc="""\
+            Implementation of DrawLines that can use numpy arrays, or anything else that uses the
+            python buffer protocol, directly.
+
+            :param pyBuff:    A python buffer containing integer pairs
+            """,
+        body="""\
+            return  self._DrawLinesBuffer(pyBuff)
+            """)
 
 
     #-----------------------------------------------------------------

--- a/etg/dc.py
+++ b/etg/dc.py
@@ -481,7 +481,19 @@ def run():
     c.addPyMethod('DrawLinesFromBuffer', '(self, pyBuff)',
         doc="""\
             Implementation of DrawLines that can use numpy arrays, or anything else that uses the
-            python buffer protocol, directly.
+            python buffer protocol directly without any element conversion.  This provides a 
+            significant performance increase over the standard DrawLines function.
+            
+            The pyBuff argument needs to provide an array of C integers organized as 
+            x, y point pairs.  The size of a C integer is platform dependent.
+            With numpy, the intc data type will provide the appropriate element size.
+
+            If called with an object that doesn't support
+            the python buffer protocol, or if the underlying element size does not
+            match the size of a C integer, a TypeError exception is raised.  If 
+            the buffer provided has float data with the same element size as a 
+            C integer, no error will be raised, but the lines will not be drawn
+            in the appropriate places.
 
             :param pyBuff:    A python buffer containing integer pairs
             """,

--- a/src/dc_ex.cpp
+++ b/src/dc_ex.cpp
@@ -9,7 +9,6 @@
 // Licence:     wxWindows license
 //--------------------------------------------------------------------------
 
-
 typedef bool (*wxPyDrawListOp_t)(wxDC& dc, PyObject* coords);
 
 PyObject* wxPyDrawXXXList(wxDC& dc, wxPyDrawListOp_t doDraw,
@@ -466,3 +465,45 @@ error0:
     PyErr_SetString(PyExc_TypeError, "Expected a sequence of length-2 sequences or wx.Points.");
     return NULL;
 }
+
+
+PyObject* wxPyDrawLinesBuffer(wxDC& dc, PyObject* pyBuff)
+{
+    wxPyBlock_t blocked = wxPyBeginBlockThreads();
+    Py_buffer view;
+    PyObject* retval;
+
+
+    if (!PyObject_CheckBuffer(pyBuff)) {
+        goto err0;
+    }
+    
+    if (PyObject_GetBuffer(pyBuff, &view, PyBUF_CONTIG) < 0) {
+        goto err1;
+    }
+    
+    dc.DrawLines(view.len / view.itemsize / 2, (wxPoint *)view.buf);
+    
+    PyBuffer_Release(&view);
+
+    Py_INCREF(Py_None);
+    retval = Py_None;
+    goto exit;
+
+
+ err0:
+    PyErr_SetString(PyExc_TypeError, "Expected a buffer object");
+    retval = NULL;
+    goto exit;
+    
+  err1:
+    retval = NULL;
+    goto exit;
+
+
+
+ exit:
+    wxPyEndBlockThreads(blocked);
+    return retval;
+}
+

--- a/unittests/test_dcDrawLinesFromBuffer.py
+++ b/unittests/test_dcDrawLinesFromBuffer.py
@@ -1,0 +1,64 @@
+import unittest
+from unittests import wtc
+import wx
+import random
+try:
+    import numpy as np
+    haveNumpy = True
+except ImportError:
+    haveNumpy = False
+
+#---------------------------------------------------------------------------
+
+w = 600
+h = 400
+
+def makeRandomLines():
+    lines = []
+
+    for i in range(num):
+        x1 = random.randint(0, w)
+        y1 = random.randint(0, h)
+        x2 = random.randint(0, w)
+        y2 = random.randint(0, h)
+        lines.append( (x1,y1, x2,y2) )
+
+    return lines
+
+
+
+
+
+#---------------------------------------------------------------------------
+
+
+class dcDrawLists_Tests(wtc.WidgetTestCase):
+
+    @unittest.skipIf(not haveNumpy, "Numpy required for this test")
+    def test_dcDrawLinesFromBuffer(self):
+        pnl = wx.Panel(self.frame)
+        self.frame.SetSize((w,h))
+        dc = wx.ClientDC(pnl)
+        dc.SetPen(wx.Pen("BLACK", 1))
+
+        xs = np.linspace(0, w, w + 1)
+        ys = np.sin(xs / w * 2 * np.pi)
+        
+        xs.shape = xs.size, 1
+        ys.shape = ys.size, 1
+        pts = np.append(xs, ys, 1)
+
+        dc.DrawLinesFromBuffer(pts.astype('int32'))
+        self.assertRaises(TypeError, dc.DrawLinesFromBuffer, pts.astype('int64'))
+        self.assertRaises(TypeError, dc.DrawLinesFromBuffer, pts.tolist())
+        del dc
+
+
+
+
+
+
+#---------------------------------------------------------------------------
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unittests/test_dcDrawLinesFromBuffer.py
+++ b/unittests/test_dcDrawLinesFromBuffer.py
@@ -48,8 +48,9 @@ class dcDrawLists_Tests(wtc.WidgetTestCase):
         ys.shape = ys.size, 1
         pts = np.append(xs, ys, 1)
 
-        dc.DrawLinesFromBuffer(pts.astype('int32'))
-        self.assertRaises(TypeError, dc.DrawLinesFromBuffer, pts.astype('int64'))
+        dc.DrawLinesFromBuffer(pts.astype('intc'))
+        self.assertRaises(TypeError, dc.DrawLinesFromBuffer, 
+                          pts.astype('int64') if np.intc(1).nbytes != np.int64(1).nbytes else pts.astype('int32'))
         self.assertRaises(TypeError, dc.DrawLinesFromBuffer, pts.tolist())
         del dc
 


### PR DESCRIPTION
When wxDC.DrawLines is called, it takes the list passed to it and creates a new wx.PointList, looping through the list and converting each element to a wx.Point.  For numpy arrays with the int32 type this adds unnecessary overhead as the memory is already structured as pairs of 32 bit integers and we can just cast the underlying memory buffer to the wxPoint * type and call DrawLines directly.  Doing this results in significant speed increases (>10x) particularly when there are a lot of points involved.

This pull request adds the DrawLinesFromBuffer function to the wx.DC class.  This function would use the python buffer protocol to access the underlying memory of an object and call DrawLines on it directly.  It checks to make sure each element is the right size, but doesn't check that it is the correct type.  An example usage would be:

        xs = numpy.linspace(0, 500, 10000)
        ys = 150 + numpy.sin(xs / 20) * 150
        xs.shape = xs.size, 1
        ys.shape = ys.size, 1
        pts = numpy.append(xs, ys, 1).astype('int32')
        dc.DrawLinesFromBuffer(pts)

Another approach might be to modify DrawLines to check if the passed object supports the buffer protocol and do it that way, but that could break currently functional code if somebody is passing something that supports the buffer protocol to DrawLines that isn't the correct type.  