### PR TITLE
MNT: Remove legacy macOS logic, and use wx.SystemSettings to select default colours

### DIFF
--- a/wx/lib/agw/aui/aui_utilities.py
+++ b/wx/lib/agw/aui/aui_utilities.py
@@ -26,15 +26,6 @@ import wx
 from .aui_constants import *
 
 
-if wx.Platform == "__WXMAC__":
-    try:
-        import Carbon.Appearance
-    except ImportError:
-        CARBON = False
-    else:
-        CARBON = True
-
-
 def BlendColour(fg, bg, alpha):
     """
     Blends the two colour component `fg` and `bg` into one colour component, adding
@@ -183,18 +174,7 @@ def GetBaseColour():
     mimicking as closely as possible the platform UI colours.
     """
 
-    if wx.Platform == "__WXMAC__":
-        k = Carbon.Appearance.kThemeBrushToolbarBackground if CARBON else 52
-        if hasattr(wx, 'MacThemeColour'):
-            base_colour = wx.MacThemeColour(k)
-        else:
-            brush = wx.Brush(wx.BLACK)
-            brush.MacSetTheme(k)
-            base_colour = brush.GetColour()
-
-    else:
-
-        base_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DFACE)
+    base_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_3DFACE)
 
     # the base_colour is too pale to use as our base colour,
     # so darken it a bit
@@ -666,7 +646,3 @@ def CopyAttributes(newArt, oldArt):
             setattr(newArt, attr, getattr(oldArt, attr))
 
     return newArt
-
-
-
-

--- a/wx/lib/agw/aui/dockart.py
+++ b/wx/lib/agw/aui/dockart.py
@@ -208,7 +208,7 @@ class AuiDefaultDockArt(object):
 
         self._active_caption_gradient_colour = LightContrastColour(wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHT))
         self._active_caption_text_colour = wx.SystemSettings.GetColour(wx.SYS_COLOUR_HIGHLIGHTTEXT)
-        self._inactive_caption_text_colour = wx.BLACK
+        self._inactive_caption_text_colour =  wx.SystemSettings.GetColour(wx.SYS_COLOUR_GRAYTEXT)
 
 
     def SetDefaultColours(self, base_colour=None):

--- a/wx/lib/agw/aui/tabart.py
+++ b/wx/lib/agw/aui/tabart.py
@@ -30,13 +30,6 @@ __date__ = "31 March 2009"
 
 import wx
 
-if wx.Platform == '__WXMAC__':
-    try:
-        import Carbon.Appearance
-    except ImportError:
-        CARBON = False
-    else:
-        CARBON = True
 
 from .aui_utilities import BitmapFromBits, StepColour, IndentPressedBitmap, ChopText
 from .aui_utilities import GetBaseColour, DrawMACCloseButton, LightColour, TakeScreenShot
@@ -158,22 +151,9 @@ class AuiDefaultTabArt(object):
         self._active_windowlist_bmp = BitmapFromBits(nb_list_bits, 16, 16, active_colour)
         self._disabled_windowlist_bmp = BitmapFromBits(nb_list_bits, 16, 16, disabled_colour)
 
-        if wx.Platform == "__WXMAC__":
-            k = Carbon.Appearance.kThemeBrushFocusHighlight if CARBON else 19
-            # Get proper highlight colour for focus rectangle from the
-            # current Mac theme.  kThemeBrushFocusHighlight is
-            # available on Mac OS 8.5 and higher
-            if hasattr(wx, 'MacThemeColour'):
-                c = wx.MacThemeColour(k)
-            else:
-                brush = wx.Brush(active_colour)
-                brush.MacSetTheme(k)
-                c = brush.GetColour()
-            self._focusPen = wx.Pen(c, 2, wx.PENSTYLE_SOLID)
-        else:
-            self._focusPen = wx.Pen(active_colour, 1, wx.PENSTYLE_USER_DASH)
-            self._focusPen.SetDashes([1, 1])
-            self._focusPen.SetCap(wx.CAP_BUTT)
+        self._focusPen = wx.Pen(active_colour, 1, wx.PENSTYLE_USER_DASH)
+        self._focusPen.SetDashes([1, 1])
+        self._focusPen.SetCap(wx.CAP_BUTT)
 
 
     def SetBaseColour(self, base_colour):
@@ -2767,5 +2747,3 @@ class ChromeTabArt(AuiDefaultTabArt):
         dc.DestroyClippingRegion()
 
         return out_tab_rect, out_button_rect, x_extent
-
-


### PR DESCRIPTION
This PR contains a couple of small adjustments to the `wx.lib.agw.aui` codebase to improve appearance on macOS when using a dark appearance. The previous logic uses some legacy calls to the Carbon API, which don't seem to work on a modern version of macOS. The proposed logic uses the standard `wx.SystemSettings` class to set default values for some colours.

Using this test program:

```python
#!/usr/bin/env python

import wx
import wx.lib.agw.aui as aui

app   = wx.App()
frame = wx.Frame(None)
panel = wx.Panel(frame)
mgr   = aui.AuiManager(panel)
sizer = wx.BoxSizer(wx.HORIZONTAL)

sizer.Add(panel, flag=wx.EXPAND, proportion=1)
frame.SetSizer(sizer)
frame.SetSize((600, 400))

pane1 = wx.Panel(panel)
pane2 = wx.Panel(panel)
pane3 = wx.Panel(panel)

mgr.AddPane(pane1, aui.AuiPaneInfo().Caption('pane1').BestSize(200, 400).CentrePane())
mgr.AddPane(pane2, aui.AuiPaneInfo().Caption('pane2').BestSize(200, 400).Left())
mgr.AddPane(pane3, aui.AuiPaneInfo().Caption('pane3').BestSize(200, 400).Right())

mgr.Update()

frame.Show()
app.MainLoop()
```

Before these changes:

![image](https://user-images.githubusercontent.com/236128/136556237-f65b2850-227d-4ba5-8c48-cd8543dbc8b1.png)


After these changes:

![image](https://user-images.githubusercontent.com/236128/136556260-d16aa96d-ae35-41f1-8316-2f0f2fb69070.png)

