### PR TITLE
Fixed integer division in Python 3

### DIFF
--- a/wx/lib/stattext.py
+++ b/wx/lib/stattext.py
@@ -302,7 +302,7 @@ class GenStaticText(wx.Control):
             if style & wx.ALIGN_RIGHT:
                 x = width - w
             if style & wx.ALIGN_CENTER:
-                x = (width - w)/2
+                x = (width - w)//2
             dc.DrawText(line, x, y)
             y += h
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

This fixes integer division using the // operator instead of /

This bug was breaking fsleyes on Python 3.10/Fedora 35 for me.

