### PR TITLE
Fix unbinding of events in FIFO order

### DIFF
--- a/etg/event.py
+++ b/etg/event.py
@@ -239,10 +239,13 @@ def run():
                         // is evaluated. (!!!)
                         if (PyObject_RichCompareBool(cb->m_func, func, Py_EQ) == 1) {
                             delete cb;
-                            entry->m_callbackUserData = NULL;
+                            // Set callback data to a known value instead of NULL to
+                            // ensure Disconnect() removes the correct handler.
+                            entry->m_callbackUserData = new wxObject();
                             // Now Disconnect should work
                             return self->Disconnect(id, lastId, eventType,
-                                                    (wxObjectEventFunction)&wxPyCallback::EventThunker);
+                                                    (wxObjectEventFunction)&wxPyCallback::EventThunker,
+                                                    entry->m_callbackUserData);
                         }
                     }
                     entry = self->GetNextDynamicEntry(cookie);

--- a/unittests/test_event.py
+++ b/unittests/test_event.py
@@ -241,6 +241,28 @@ class Events(wtc.WidgetTestCase):
 
 
 
+    def test_eventUnbinding5(self):
+        "Unbind in same order of binding"
+
+        class Frame(wx.Frame):
+            def __init__(self, *args, **kw):
+                wx.Frame.__init__(self, *args, **kw)
+                self.btn = wx.Button(self, label="Hello, wxPython!")
+                self.btn.Bind(wx.EVT_BUTTON, self.onButton1)
+                self.btn.Bind(wx.EVT_BUTTON, self.onButton2)
+            def onButton1(self, evt):
+                evt.Skip()
+            def onButton2(self, evt):
+                evt.Skip()
+
+        frm = Frame(None)
+        ub1 = frm.btn.Unbind(wx.EVT_BUTTON, handler=frm.onButton1)
+        ub2 = frm.btn.Unbind(wx.EVT_BUTTON, handler=frm.onButton2)
+
+        assert ub1, "Expected Unbind() success"
+        assert ub2, "Expected Unbind() success"
+
+
     def test_DropFilesEvent_tweaks(self):
         evt = wx.DropFilesEvent(123, 'one two three four five'.split())
         self.assertTrue(evt.NumberOfFiles == 5)


### PR DESCRIPTION
When binding events to multiple methods and then unbinding them later,
in the same order they were bound, the wrong method would get unbound.

For example:
    self.btn.Bind(wx.EVT_BUTTON, self.onButton1)
    self.btn.Bind(wx.EVT_BUTTON, self.onButton1)
followed by:
    self.btn.Unbind(wx.EVT_BUTTON, handler=self.onButton2)
    self.btn.Unbind(wx.EVT_BUTTON, handler=self.onButton1)
works, but the reverse fails:
    self.btn.Unbind(wx.EVT_BUTTON, handler=self.onButton1)
    self.btn.Unbind(wx.EVT_BUTTON, handler=self.onButton2)

The reason is that the wxPython Disconnect() method called the wxWidgets
Disconnect() method with the userData parameter set to NULL.  In this
case, wxWidgets performs no filtering based on the userData parameter
and this could result in the wrong handler getting disconnected.

Fix this by setting the userData to a known value before calling
wxWidgets Disconnect() method so that it will disconnect the correct
handler.

This commit also adds a test that verifies the fix.

Fixes #2027.


