### PR TITLE
Enable customization of layout of pdfviewer button panel

### DIFF
--- a/wx/lib/pdfviewer/buttonpanel.py
+++ b/wx/lib/pdfviewer/buttonpanel.py
@@ -49,6 +49,30 @@ class pdfButtonPanel(bp.ButtonPanel):
                                 agwStyle=bp.BP_USE_GRADIENT, alignment=bp.BP_ALIGN_LEFT)
         self.SetProperties()
         self.CreateButtons()
+        
+    def GetPanelItems(self):
+        """
+        Return the buttons that should be displayed. A subclass can customize this
+        """
+        return [
+          ('btn', images.PrintIt.GetBitmap(), wx.ITEM_NORMAL, "Print", self.OnPrint),
+          ('sep',),
+          ('btn', images.SaveIt.GetBitmap(), wx.ITEM_NORMAL, "Save", self.OnSave),
+          ('sep',),
+          ('btn', images.First.GetBitmap(), wx.ITEM_NORMAL, "First page", self.OnFirst),
+          ('btn', images.Prev.GetBitmap(), wx.ITEM_NORMAL, "Previous page", self.OnPrev),
+          ('btn', images.Next.GetBitmap(), wx.ITEM_NORMAL, "Next page", self.OnNext),
+          ('btn', images.Last.GetBitmap(), wx.ITEM_NORMAL, "Last page", self.OnLast),
+          ('Ctrl', self.pagelabel),
+          ('ctrl', self.page),
+          ('ctrl', self.maxlabel),
+          ('sep',),
+          ('btn', images.ZoomOut.GetBitmap(), wx.ITEM_NORMAL, "Zoom out", self.OnZoomOut),
+          ('btn', images.ZoomIn.GetBitmap(), wx.ITEM_NORMAL, "Zoom in", self.OnZoomIn),
+          ('ctrl', self.zoom),
+          ('btn', images.Width.GetBitmap(), wx.ITEM_NORMAL, "Fit page width", self.OnWidth),
+          ('btn', images.Height.GetBitmap(), wx.ITEM_NORMAL, "Fit page height", self.OnHeight),
+          ]
 
     def CreateButtons(self):
         """
@@ -73,25 +97,7 @@ class pdfButtonPanel(bp.ButtonPanel):
             self.zoom.Append(item[0], item[1])      # string value and client data
         self.Bind(wx.EVT_COMBOBOX, self.OnZoomSet, self.zoom)
         self.Bind(wx.EVT_TEXT_ENTER, self.OnZoomSet, self.zoom)
-        panelitems = [
-          ('btn', images.PrintIt.GetBitmap(), wx.ITEM_NORMAL, "Print", self.OnPrint),
-          ('sep',),
-          ('btn', images.SaveIt.GetBitmap(), wx.ITEM_NORMAL, "Save", self.OnSave),
-          ('sep',),
-          ('btn', images.First.GetBitmap(), wx.ITEM_NORMAL, "First page", self.OnFirst),
-          ('btn', images.Prev.GetBitmap(), wx.ITEM_NORMAL, "Previous page", self.OnPrev),
-          ('btn', images.Next.GetBitmap(), wx.ITEM_NORMAL, "Next page", self.OnNext),
-          ('btn', images.Last.GetBitmap(), wx.ITEM_NORMAL, "Last page", self.OnLast),
-          ('Ctrl', self.pagelabel),
-          ('ctrl', self.page),
-          ('ctrl', self.maxlabel),
-          ('sep',),
-          ('btn', images.ZoomOut.GetBitmap(), wx.ITEM_NORMAL, "Zoom out", self.OnZoomOut),
-          ('btn', images.ZoomIn.GetBitmap(), wx.ITEM_NORMAL, "Zoom in", self.OnZoomIn),
-          ('ctrl', self.zoom),
-          ('btn', images.Width.GetBitmap(), wx.ITEM_NORMAL, "Fit page width", self.OnWidth),
-          ('btn', images.Height.GetBitmap(), wx.ITEM_NORMAL, "Fit page height", self.OnHeight),
-          ]
+        panelitems = self.GetPanelItems()
 
         self.Freeze()
         for item in panelitems:


### PR DESCRIPTION
This PR enables customizing the appearance of the button panel of the pure-python pdfviewer widget.

A subclass can now easily change the order in which the buttons appear or their icons, remove some of the default buttons and even add new buttons and new functionality by overloading the new method `GetPanelItems`. 

In terms of actual code changes, the PR is minimal, as it simply moves the layout definition to its own method `GetPanelItems` instead of hard-coding it inside the method that performs the actual layout. The PR is completely backward compatible as the default implementation of `GetPanelItems` is exactly what was hardcoded before.
