### PR TITLE
Use wx.DF_UNICODETEXT instead of wx.DF_TEXT

### DIFF
--- a/docs/sphinx/rest_substitutions/snippets/python/converted/wx.Clipboard.1.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/converted/wx.Clipboard.1.py
@@ -6,7 +6,7 @@
 
 
         # Test if text content is available
-        not_empty = wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_TEXT))
+        not_empty = wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_UNICODETEXT))
 
 
         # Read some text

--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -1361,7 +1361,7 @@ class Shell(editwindow.EditWindow):
         """Replace selection with clipboard contents."""
         if self.CanPaste() and wx.TheClipboard.Open():
             ps2 = str(sys.ps2)
-            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_TEXT)):
+            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_UNICODETEXT)):
                 data = wx.TextDataObject()
                 if wx.TheClipboard.GetData(data):
                     self.ReplaceSelection('')
@@ -1380,7 +1380,7 @@ class Shell(editwindow.EditWindow):
         """Replace selection with clipboard contents, run commands."""
         text = ''
         if wx.TheClipboard.Open():
-            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_TEXT)):
+            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_UNICODETEXT)):
                 data = wx.TextDataObject()
                 if wx.TheClipboard.GetData(data):
                     text = data.GetText()

--- a/wx/py/sliceshell.py
+++ b/wx/py/sliceshell.py
@@ -3429,7 +3429,7 @@ class SlicesShell(editwindow.EditWindow):
         #ADD UNDO
         if self.CanPaste() and wx.TheClipboard.Open():
             ps2 = str(sys.ps2)
-            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_TEXT)):
+            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_UNICODETEXT)):
                 data = wx.TextDataObject()
                 if wx.TheClipboard.GetData(data):
                     self.ReplaceSelection('')
@@ -3459,7 +3459,7 @@ class SlicesShell(editwindow.EditWindow):
         """Replace selection with clipboard contents, run commands."""
         text = ''
         if wx.TheClipboard.Open():
-            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_TEXT)):
+            if wx.TheClipboard.IsSupported(wx.DataFormat(wx.DF_UNICODETEXT)):
                 data = wx.TextDataObject()
                 if wx.TheClipboard.GetData(data):
                     text = data.GetText()


### PR DESCRIPTION
wx.DF_TEXT doesn't work on macOS and Unicode should be available under all platforms.

Fixes #2042 

