### PR TITLE
Add self-guard in scrolledpanel:_SetupAfter

### DIFF
--- a/wx/lib/scrolledpanel.py
+++ b/wx/lib/scrolledpanel.py
@@ -154,9 +154,10 @@ class ScrolledPanel(wx.ScrolledWindow):
 
 
     def _SetupAfter(self, scrollToTop):
-        self.SetVirtualSize(self.GetBestVirtualSize())
-        if scrollToTop:
-            self.Scroll(0,0)
+        if self:
+            self.SetVirtualSize(self.GetBestVirtualSize())
+            if scrollToTop:
+                self.Scroll(0,0)
 
 
     def OnChildFocus(self, evt):


### PR DESCRIPTION
This PR adds `if self:` statement to `_SetupAfter` function to avoid RuntimeError when the object is destroyed before `CallAfter`.

Fixes #2045
