### PR TITLE
macOS: use default SDK to check if universal capable

### DIFF
--- a/.azure/ci-macos-job.yml
+++ b/.azure/ci-macos-job.yml
@@ -3,7 +3,7 @@ jobs:
   timeoutInMinutes: 90
   displayName: 'MacOS CI'
   pool:
-    vmImage: 'macOS-1015'
+    vmImage: 'macOS-11'
   strategy:
     matrix:
       Py37:


### PR DESCRIPTION
@RobinD42 let me know what you think about this.  The reason the macOS CI was failing is because its default SDK (for some reason) is MacOSX10.15.sdk, but it has newer ones installed.  Thus, the build script was determining that universal was supported, but then tried to use it with the 10.15 SDK, which failed.  This solution seems like it should work?