### PR TITLE
Fix invisible text in lib.plot with dark theme

### DIFF
--- a/wx/lib/plot/plotcanvas.py
+++ b/wx/lib/plot/plotcanvas.py
@@ -71,6 +71,7 @@ class PlotCanvas(wx.Panel):
         self.border = (1, 1)
 
         self.SetBackgroundColour("white")
+        self.SetForegroundColour("black")
 
         # Create some mouse events for zooming
         self.canvas.Bind(wx.EVT_LEFT_DOWN, self.OnMouseLeftDown)


### PR DESCRIPTION
This fixes invisible white text on white background with dark themes.

Alternatively, the white background could be removed and use the theme's background.