### PR TITLE
Fix PlotCanvas point label drawing on Linux

### DIFF
--- a/wx/lib/plot/plotcanvas.py
+++ b/wx/lib/plot/plotcanvas.py
@@ -2228,7 +2228,7 @@ class PlotCanvas(wx.Panel):
         """Draws and erases pointLabels"""
         width = self._Buffer.GetWidth()
         height = self._Buffer.GetHeight()
-        if sys.platform != "darwin":
+        if sys.platform not in ("darwin", "linux"):
             tmp_Buffer = wx.Bitmap(width, height)
             dcs = wx.MemoryDC()
             dcs.SelectObject(tmp_Buffer)
@@ -2242,7 +2242,7 @@ class PlotCanvas(wx.Panel):
         dc = wx.BufferedDC(dc, self._Buffer)
         # this will erase if called twice
         dc.Blit(0, 0, width, height, dcs, 0, 0, self._logicalFunction)
-        if sys.platform == "darwin":
+        if sys.platform in ("darwin", "linux"):
             self._Buffer = tmp_Buffer
 
     def _drawLegend(self, dc, graphics, rhsW, topH, legendBoxWH,


### PR DESCRIPTION
Switch to using the same point label drawing method as darwin.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #2075.

