### PR TITLE
docs: fix missing GetKeyCode() call in GetKeyCode() example

### DIFF
--- a/docs/sphinx/rest_substitutions/snippets/python/converted/wx.KeyEvent.GetKeyCode.1.py
+++ b/docs/sphinx/rest_substitutions/snippets/python/converted/wx.KeyEvent.GetKeyCode.1.py
@@ -11,6 +11,7 @@
                     else:
 
                         # It's a special key, deal with all the known ones:
+                        keycode = event.GetKeyCode()
                         if keycode in [wx.WXK_LEFT, wx.WXK_RIGHT]:
                             # move cursor ...
                             MoveCursor()


### PR DESCRIPTION
See doc of [KeyEvent.GetKeyCode() ](https://www.wxpython.org/Phoenix/docs/html/wx.KeyEvent.html?highlight=getkeycode#wx.KeyEvent.GetKeyCode) .

The code snippet only mentions GetUnicodeKey(), but not GetKeyCode(). It doesn't make sense that in case keycode == `wx.WXK_NONE` it's compared to various other constants. 

Fixes #2095

