### PR TITLE
add Python 3.6 back

### DIFF
--- a/.azure/ci-linux-job.yml
+++ b/.azure/ci-linux-job.yml
@@ -28,6 +28,7 @@ jobs:
       versionSpec: '$(python.version)'
 
   - script: |
+      sudo apt-get update
       sudo apt-get install -y build-essential
       sudo apt-get install -y libgtk-3-dev libjpeg-dev libtiff-dev \
               libsdl2-dev libgstreamer-plugins-base1.0-dev libnotify-dev \

--- a/.azure/ci-linux-job.yml
+++ b/.azure/ci-linux-job.yml
@@ -6,6 +6,8 @@ jobs:
     vmImage: 'Ubuntu 20.04'
   strategy:
     matrix:
+      Py36:
+        python.version: '3.6'
       Py37:
         python.version: '3.7'
       Py38:

--- a/.azure/ci-windows-job.yml
+++ b/.azure/ci-windows-job.yml
@@ -6,6 +6,10 @@ jobs:
     vmImage: 'windows-2019'
   strategy:
     matrix:
+      Py36_x86:
+        python.version: '3.6'
+        python.arch: x86
+        addToPath: true
       Py37_x86:
         python.version: '3.7'
         python.arch: x86
@@ -23,6 +27,10 @@ jobs:
         python.arch: x86
         addToPath: true
 
+      Py36_x64:
+        python.version: '3.6'
+        python.arch: x64
+        addToPath: true
       Py37_x64:
         python.version: '3.7'
         python.arch: x64


### PR DESCRIPTION
It's kinda icky but 3.6 is still supported on some distros and 4.1.2 would have a lot of fixes from wx 3.1.5, so I think it'd be better if 4.1.2 is the last release for Py 3.6 instead of 4.1.1 from 2020.