### PR TITLE
MNT: Coerce argument types in call to DC.DrawText

### DIFF
--- a/wx/lib/stattext.py
+++ b/wx/lib/stattext.py
@@ -303,7 +303,7 @@ class GenStaticText(wx.Control):
                 x = width - w
             if style & wx.ALIGN_CENTER:
                 x = (width - w)//2
-            dc.DrawText(line, x, y)
+            dc.DrawText(line, int(x), int(y))
             y += h
 
 
@@ -319,4 +319,3 @@ class GenStaticText(wx.Control):
 
 
 #----------------------------------------------------------------------
-


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

A small and hopefully obvious fix to`wx.lib.stattext` which addresses the following error:

```
Traceback (most recent call last):
File "<envdir>/lib/python3.10/site-packages/wx/lib/stattext.py", line 306, in OnPaint                                                                                   
    dc.DrawText(line, x, y)                                                                                                                                                                    
TypeError: DC.DrawText(): arguments did not match any overloaded call:                                                                                                                         
  overload 1: argument 2 has unexpected type 'float'                                                                                                                                           
  overload 2: argument 2 has unexpected type 'float'                                                                                                                                           
Traceback (most recent call last):  
```

Without this patch, I'm experiencing this error on macOS 10.15 / wxpython 4.1.1.

Thanks!
