### PR TITLE
Fix shell getMultilineCommand

### DIFF
--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -946,7 +946,7 @@ class Shell(editwindow.EditWindow):
             startpos = self.GetCurrentPos() + ps1size
             line += 1
             self.GotoLine(line)
-            while self.GetCurLine()[0][:ps2size] == ps2:
+            while self.GetCurLine()[0][:ps2size] == ps2 and line < self.LineCount:
                 line += 1
                 self.GotoLine(line)
             stoppos = self.GetCurrentPos()


### PR DESCRIPTION
This PR fixes a bug in the shell. 
When `getMultilineCommand` is called programmatically at the current prompt, it gets stuck in an endless loop.

