### PR TITLE
Fix issue #2157: wx.py.shell.Shell.OnHistorySearch

### DIFF
--- a/wx/py/editwindow.py
+++ b/wx/py/editwindow.py
@@ -297,3 +297,12 @@ class EditWindow(stc.StyledTextCtrl):
         # show and select the found text
         self.ShowPosition(loc)
         self.SetSelection(loc, loc + len(findstring))
+
+    def SetSelection(self, from_, to_):
+        """Selects the text starting at the first position up to
+        (but not including) the character at the last position.
+        """
+        # (override) Patch for miss-insertion position when from_ > to_.
+        # Note: This is needed until the stc SetSelection bug is fixed.
+        self.SetAnchor(from_)
+        self.SetCurrentPos(to_)

--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -854,8 +854,8 @@ class Shell(editwindow.EditWindow):
         or (self.historyIndex >= len(self.history)-2):
             searchOrder = range(len(self.history))
         else:
-            searchOrder = range(self.historyIndex+1, len(self.history)) + \
-                          range(self.historyIndex)
+            ls = list(range(len(self.history)))
+            searchOrder = ls[self.historyIndex+1:] + ls[:self.historyIndex]
         for i in searchOrder:
             command = self.history[i]
             if command[:len(searchText)] == searchText:

--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -1518,7 +1518,14 @@ class Shell(editwindow.EditWindow):
         menu = self.GetContextMenu()
         self.PopupMenu(menu)
 
-
+    def SetSelection(self, from_, to_):
+        """Selects the text starting at the first position up to
+        (but not including) the character at the last position.
+        """
+        # (override) Patch for miss-insertion position when from_ > to_.
+        # Note: This is needed until the stc SetSelection bug is fixed.
+        self.SetAnchor(from_)
+        self.SetCurrentPos(to_)
 
 
 ## NOTE: The DnD of file names is disabled until we can figure out how

--- a/wx/py/shell.py
+++ b/wx/py/shell.py
@@ -1518,14 +1518,7 @@ class Shell(editwindow.EditWindow):
         menu = self.GetContextMenu()
         self.PopupMenu(menu)
 
-    def SetSelection(self, from_, to_):
-        """Selects the text starting at the first position up to
-        (but not including) the character at the last position.
-        """
-        # (override) Patch for miss-insertion position when from_ > to_.
-        # Note: This is needed until the stc SetSelection bug is fixed.
-        self.SetAnchor(from_)
-        self.SetCurrentPos(to_)
+
 
 
 ## NOTE: The DnD of file names is disabled until we can figure out how

--- a/wx/py/sliceshell.py
+++ b/wx/py/sliceshell.py
@@ -2270,8 +2270,8 @@ class SlicesShell(editwindow.EditWindow):
         or (self.historyIndex >= len(self.history)-2):
             searchOrder = range(len(self.history))
         else:
-            searchOrder = range(self.historyIndex+1, len(self.history)) + \
-                          range(self.historyIndex)
+            ls = list(range(len(self.history)))
+            searchOrder = ls[self.historyIndex+1:] + ls[:self.historyIndex]
         for i in searchOrder:
             command = self.history[i]
             if command[:len(searchText)] == searchText:

--- a/wx/py/sliceshell.py
+++ b/wx/py/sliceshell.py
@@ -3751,6 +3751,14 @@ class SlicesShell(editwindow.EditWindow):
         """Return True if contents have changed."""
         return self.GetModify() or self.NeedsCheckForSave
 
+    def SetSelection(self, from_, to_):
+        """Selects the text starting at the first position up to
+        (but not including) the character at the last position.
+        """
+        # (override) Patch for miss-insertion position when from_ > to_.
+        # Note: This is needed until the stc SetSelection bug is fixed.
+        self.SetAnchor(from_)
+        self.SetCurrentPos(to_)
 
 
 ## NOTE: The DnD of file names is disabled until we can figure out how

--- a/wx/py/sliceshell.py
+++ b/wx/py/sliceshell.py
@@ -3751,14 +3751,6 @@ class SlicesShell(editwindow.EditWindow):
         """Return True if contents have changed."""
         return self.GetModify() or self.NeedsCheckForSave
 
-    def SetSelection(self, from_, to_):
-        """Selects the text starting at the first position up to
-        (but not including) the character at the last position.
-        """
-        # (override) Patch for miss-insertion position when from_ > to_.
-        # Note: This is needed until the stc SetSelection bug is fixed.
-        self.SetAnchor(from_)
-        self.SetCurrentPos(to_)
 
 
 ## NOTE: The DnD of file names is disabled until we can figure out how


### PR DESCRIPTION
This PR fixes the problem of `wx.py.shell.Shell: OnHistorySearch`.
The first commit fixes TypeError for range + range.
The second commit add patches for the bug of `stc.StyledTextCtrl.SetSelection` related to the issue #2156.
The second commit is not necessary if the `stc.StyledText.SetSelection` bug is fixed, so I'm not sure if this is the best way to fix the current issue #2157.

Fixes #2157

