### PR TITLE
Return new wxBitmap for GetDisabledBitmap()

### DIFF
--- a/etg/menuitem.py
+++ b/etg/menuitem.py
@@ -136,11 +136,12 @@ def run():
 
 
     c.find('GetDisabledBitmap').type = 'const wxBitmap*'
+    c.find('GetDisabledBitmap').transferBack = True  # Python takes ownership of the return value
     c.find('GetDisabledBitmap').setCppCode("""\
         #ifdef __WXMSW__
-            return &self->GetDisabledBitmap();
+            return new wxBitmap(self->GetDisabledBitmap());
         #else
-            return &wxNullBitmap;
+            return new wxBitmap(wxNullBitmap);
         #endif
         """)
 


### PR DESCRIPTION
error: taking the address of a temporary object of type 'wxBitmap'

This issue was detected by the clang64 compiler; but, it likely needs
fixed for all compilers.

Fixes #2159

