### PR TITLE
BF: Sizer proportion parameter must be an integer

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -5580,7 +5580,7 @@ class AuiManager(wx.EvtHandler):
         # finally, add the pane sizer to the dock sizer
         if pane.HasBorder():
             # allowing space for the pane's border
-            sizer_item = cont.Add(horz_pane_sizer, pane_proportion,
+            sizer_item = cont.Add(horz_pane_sizer, int(round(pane_proportion)),
                                   wx.EXPAND | wx.ALL, pane_border_size)
             part = AuiDockUIPart()
             part.type = AuiDockUIPart.typePaneBorder
@@ -5592,7 +5592,7 @@ class AuiManager(wx.EvtHandler):
             part.sizer_item = sizer_item
             uiparts.append(part)
         else:
-            sizer_item = cont.Add(horz_pane_sizer, pane_proportion, wx.EXPAND)
+            sizer_item = cont.Add(horz_pane_sizer, int(round(pane_proportion)), wx.EXPAND)
 
         return uiparts
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Howdy, this PR fixes a small bug in the `wx/lib/agw/aui/framemanager.py` - a floating point value is being passed as the `proportion` parameter to the `BoxSizer.Add()` method, which causes an error when trying to re-size a panel (on macOS):

```
Traceback (most recent call last):                                                             
  File "<env>/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 9285, in OnMotion
    self.OnMotion_Resize(event)                                                                
  File "<env>/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 9512, in OnMotion_Resize
    self.DoEndResizeAction(event)                                                              
  File "<env>/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 9134, in DoEndResizeAction
    return self.RestrictResize(clientPt, screenPt, createDC=False)                             
  File "<env>/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 9236, in RestrictResize
    self.Update()                                                                              
  File "<env>/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 6388, in Update
    self.DoUpdate()                                                                            
  File "<env>/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 6462, in DoUpdate
    sizer = self.LayoutAll(self._panes, self._docks, self._uiparts, False)                     
  File "<env>/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 6324, in LayoutAll
    uiparts = self.LayoutAddDock(cont, row, uiparts, spacer_only)                              
  File "<env>/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 5948, in LayoutAddDock
    uiparts = self.LayoutAddPane(dock_sizer, dock, pane, uiparts, spacer_only)                 
  File "<env>/lib/python3.10/site-packages/wx/lib/agw/aui/framemanager.py", line 5817, in LayoutAddPane
    sizer_item = cont.Add(horz_pane_sizer, pane_proportion,                                    
TypeError: Sizer.Add(): arguments did not match any overloaded call:                           
  overload 1: argument 1 has unexpected type 'BoxSizer'                                        
  overload 2: argument 1 has unexpected type 'BoxSizer'                                        
  overload 3: argument 2 has unexpected type 'float'                                           
  overload 4: argument 2 has unexpected type 'float'                                           
  overload 5: argument 1 has unexpected type 'BoxSizer'                                        
  overload 6: argument 1 has unexpected type 'BoxSizer'                                        
  overload 7: argument 1 has unexpected type 'BoxSizer'                                        
  overload 8: argument 1 has unexpected type 'BoxSizer'                                        
  overload 9: argument 1 has unexpected type 'BoxSizer'      
```
