### PR TITLE
Autoconvert to wx.BitmapBundle

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,13 +18,13 @@ Pip:    ``pip install wxPython==4.1.2``
 
 New and improved in this release:
 
-* Yes, it's been a long time since the last release. I'm not dead, just on an
+* Yes, it's been a VERY long time since the last release. I'm not dead, just on an
   extended break. It took me a while to get up to speed on a new job, and then
   there was a seemingly perpetual crunch-mode to get the product through a couple
   releases. I can't say that things are fully back to normal yet, but at least I
   now know what I'm doing. Mostly. <wink>
 
-* This release is built using wxWidgets code very near the wxWidgets' 3.1.5
+* This release is built using wxWidgets code very near the wxWidgets' 3.1.6
   release tag.
 
 * Tweaked the build scripts a bit to ensure that on non-Windows platforms that
@@ -53,6 +53,15 @@ New and improved in this release:
 * Fix PyProgress on Windows by avoiding invalid sizer flags (#1985)
 
 * Fix 'More Grid Features' in demo
+
+* Many of the widgets which deal with bitmaps have been changed to use a
+  wx.BitmapBundle object instead. This is the mechanism which wxWidgets has
+  implemented for adapting to things like Hi-DPI displays. Essentially you can
+  load a list of bitmaps of different sizes into a wx.BitmapBundle, and the
+  widget can choose one based on the display density. Existing code should be
+  able to continue to pass a wx.Bitmap to the widget constructor or to methods
+  like SetBitmap, as wxPython will automatically convert from a wx.Bitmap to a
+  wx.BitmapBundle where it is needed.
 
 
 

--- a/etg/bmpbndl.py
+++ b/etg/bmpbndl.py
@@ -58,6 +58,7 @@ def run():
 
         // Otherwise, a conversion is needed
         int state = 0;
+        // TODO: A macro for these nearly identical statements would be a good idea...
         if (sipCanConvertToType(sipPy, sipType_wxBitmap, SIP_NO_CONVERTORS)) {
             wxBitmap* obj = reinterpret_cast<wxBitmap*>(
                 sipConvertToType(sipPy, sipType_wxBitmap, sipTransferObj, SIP_NO_CONVERTORS, &state, sipIsErr));

--- a/etg/bmpbndl.py
+++ b/etg/bmpbndl.py
@@ -40,6 +40,52 @@ def run():
 
     c.find('FromSVG').findOverload('char *data, const wxSize &sizeDef').ignore()
 
+    # Allow on-the-fly creation of a wx.BitmapBundle from a wx.Bitmap, wx.Icon
+    # or a wx.Image
+    c.convertFromPyObject = """\
+        // Check for type compatibility
+        if (!sipIsErr) {
+            if (sipCanConvertToType(sipPy, sipType_wxBitmap, SIP_NO_CONVERTORS))
+                return 1;
+            if (sipCanConvertToType(sipPy, sipType_wxIcon, SIP_NO_CONVERTORS))
+                return 1;
+            if (sipCanConvertToType(sipPy, sipType_wxImage, SIP_NO_CONVERTORS))
+                return 1;
+            if (sipCanConvertToType(sipPy, sipType_wxBitmapBundle, SIP_NO_CONVERTORS))
+                return 1;
+            return 0;
+        }
+
+        // Otherwise, a conversion is needed
+        int state = 0;
+        if (sipCanConvertToType(sipPy, sipType_wxBitmap, SIP_NO_CONVERTORS)) {
+            wxBitmap* obj = reinterpret_cast<wxBitmap*>(
+                sipConvertToType(sipPy, sipType_wxBitmap, sipTransferObj, SIP_NO_CONVERTORS, &state, sipIsErr));
+            *sipCppPtr = new wxBitmapBundle(*obj);
+            sipReleaseType(obj, sipType_wxBitmap, state);
+            return sipGetState(sipTransferObj);
+        }
+        if (sipCanConvertToType(sipPy, sipType_wxIcon, SIP_NO_CONVERTORS)) {
+            wxIcon* obj = reinterpret_cast<wxIcon*>(
+                sipConvertToType(sipPy, sipType_wxIcon, sipTransferObj, SIP_NO_CONVERTORS, &state, sipIsErr));
+            *sipCppPtr = new wxBitmapBundle(*obj);
+            sipReleaseType(obj, sipType_wxIcon, state);
+            return sipGetState(sipTransferObj);
+        }
+        if (sipCanConvertToType(sipPy, sipType_wxImage, SIP_NO_CONVERTORS)) {
+            wxImage* obj = reinterpret_cast<wxImage*>(
+                sipConvertToType(sipPy, sipType_wxImage, sipTransferObj, SIP_NO_CONVERTORS, &state, sipIsErr));
+            *sipCppPtr = new wxBitmapBundle(*obj);
+            sipReleaseType(obj, sipType_wxImage, state);
+            return sipGetState(sipTransferObj);
+        }
+
+        // The final option is that it is already a wxBitmapBundle, so just fetch the pointer and return
+        *sipCppPtr = reinterpret_cast<wxBitmapBundle*>(
+            sipConvertToType(sipPy, sipType_wxBitmapBundle, sipTransferObj, SIP_NO_CONVERTORS, 0, sipIsErr));
+        return 0; // not a new instance
+        """
+
 
     c = module.find('wxBitmapBundleImpl')
     assert isinstance(c, etgtools.ClassDef)

--- a/unittests/test_bmpbndl.py
+++ b/unittests/test_bmpbndl.py
@@ -26,6 +26,24 @@ class bmpbndl_Tests(wtc.WidgetTestCase):
         b4 = wx.BitmapBundle(wx.Image(pngFile))
         self.assertTrue( b4.IsOk() )
 
+    def test_BitmapBundleVector(self):
+        bmps = [wx.Bitmap(16,16,32),
+                wx.Bitmap(24,24,32),
+                wx.Bitmap(32,32,32),
+                wx.Bitmap(64,64,32)]
+        bb = wx.BitmapBundle.FromBitmaps(bmps)
+        self.assertTrue( bb.IsOk() )
+        b = bb.GetBitmap((32,32))
+        self.assertTrue(b.IsOk())
+        self.assertEquals(b.GetSize(), wx.Size(32,32))
+
+    def test_BitmapBundle_ImplicitCtor(self):
+        "Ensure that a wx.Bitmap can still be used where a wx.BitmapBundle is needed"
+        bmp = wx.Bitmap(pngFile)
+        btn = wx.Button(self.frame, -1, "Hello")
+        btn.SetBitmap(bmp)
+
+
 #---------------------------------------------------------------------------
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add a `convertFromPyObject` for wx.BitmapBundle so we can still pass a wx.Bitmap (or icon or image) where a wx.BitmapBundle is expected.

A few other wx.BitmapBundle related tweaks are also included.