### PR TITLE
Allows the environmental setting of CC_NAME to change compiler to gcc or clang

### DIFF
--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -71,7 +71,10 @@ class Configuration(object):
     WXDLLVER = None
     # Version part of wxWidgets LIB/DLL names
 
-    COMPILER = 'msvc'
+    if os.getenv('CC_NAME') in ['gcc', 'clang']:
+        COMPILER = 'mingw32'
+    else:
+        COMPILER = 'msvc'
     # Used to select which compiler will be used on Windows.  This not
     # only affects distutils, but also some of the default flags and
     # other assumptions in this script.  Current supported values are


### PR DESCRIPTION
from the Windows default of msvc.

I am updating the MSys2 wxPython package and after the MSys2 waf package change I needed to create a patch that works with the new waf command. We use gcc and clang under windows to build the package. This commit allows the export of CC_NAME to pick gcc or clang as the compiler.

See [MSys2 MinGW PR](https://github.com/msys2/MINGW-packages/pull/11982)

Tim S.

