### PR TITLE
IntCtrl: Change default colour to wx.NullColour

### DIFF
--- a/wx/lib/intctrl.py
+++ b/wx/lib/intctrl.py
@@ -398,7 +398,7 @@ class IntCtrl(wx.TextCtrl):
                 name = "integer",
                 min=None, max=None,
                 limited = 0, allow_none = 0, allow_long = 0,
-                default_color = wx.BLACK, oob_color = wx.RED,
+                default_color = wx.NullColour, oob_color = wx.RED,
         ):
         """
         Default constructor


### PR DESCRIPTION
Fixes #2199.

The problem is that the default colour is currently wx.BLACK which will basically be invisible if the user has a dark theme. Use ``wx.NullColour`` instead so that it can just use the default text colour for the user's theme.

Note that this does not fix the second part of issue #2199 (the colours still don't change if the control is disabled) but I feel this should be a separate issue now.