### PR TITLE
Popup ctl respects the parameters passed to init

### DIFF
--- a/wx/lib/popupctl.py
+++ b/wx/lib/popupctl.py
@@ -148,12 +148,6 @@ class PopupDialog(wx.Dialog):
 
 class PopupControl(wx.Control):
     def __init__(self,*_args,**_kwargs):
-        if 'value' in _kwargs:
-            del _kwargs['value']
-        style = _kwargs.get('style', 0)
-        if (style & wx.BORDER_MASK) == 0:
-            style |= wx.BORDER_NONE
-            _kwargs['style'] = style
         wx.Control.__init__(self, *_args, **_kwargs)
 
         self.textCtrl = wx.TextCtrl(self, wx.ID_ANY, '', pos = (0,0))


### PR DESCRIPTION
Remove code from python-only `poupctl` that overrides values passed to `__init__` by end user.

The value of this pull request is three fold:
1) Simplifies code by removing unnecessary lines
2) Library code should not assume that it knows better than the end user the style in which the control should be displayed
3) Library code should not assume that library user passes style as a keyword argument and not as a positional argument. This is important as it breaks GUI development tools such as wxFormBuilder which pass style possitionnally.
