### PR TITLE
Fixes for flatmenu.py Remove and DestroyItem

### DIFF
--- a/wx/lib/agw/flatmenu.py
+++ b/wx/lib/agw/flatmenu.py
@@ -4096,7 +4096,7 @@ class FlatMenuButton(object):
         :param `input2`: if not ``None``, it is an integer representing the button `y` position.
         """
 
-        if type(input) == type(1):
+        if type(input1) == type(1):
             self._pos = wx.Point(input1, input2)
         else:
             self._pos = input1
@@ -4112,7 +4112,7 @@ class FlatMenuButton(object):
         :param `input2`: if not ``None``, it is an integer representing the button height.
         """
 
-        if type(input) == type(1):
+        if type(input1) == type(1):
             self._size = wx.Size(input1, input2)
         else:
             self._size = input1
@@ -6646,7 +6646,7 @@ class FlatMenu(FlatMenuBase):
         :param `item`: can be either a menu item identifier or a plain :class:`FlatMenuItem`.
         """
 
-        if type(item) != type(1):
+        if not isinstance(item, (wx.StandardID, int)):
             item = item.GetId()
 
         return self._RemoveById(item)
@@ -6673,7 +6673,7 @@ class FlatMenu(FlatMenuBase):
         :param `item`: can be either a menu item identifier or a plain :class:`FlatMenuItem`.
         """
 
-        if type(item) != type(1):
+        if not isinstance(item, (wx.StandardID, int)):
             item = item.GetId()
 
         self._DestroyById(item)


### PR DESCRIPTION
FlatMenu fix for passing ids to Remove and DestroyItem.  This is necessary since GetId() now returns a wx.StandardID, so just checking against the int type no longer works.  The Clear function passes ids using the GetId function, so that function was broken.

Also fixed some typos in Move and SetSize.

