### PR TITLE
Only require attrdict3 on Windows

### DIFF
--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -27,8 +27,6 @@ from distutils.dep_util  import newer
 
 import distutils.sysconfig
 
-from attrdict import AttrDict
-
 runSilently = False
 
 #----------------------------------------------------------------------
@@ -991,6 +989,8 @@ def getMSVCInfo(PYTHON, arch, set_env=False):
     global MSVCinfo
     if MSVCinfo is not None:
         return MSVCinfo
+
+    from attrdict import AttrDict
 
     # Note that it starts with a monkey-patch in setuptools.msvc to
     # workaround this issue: pypa/setuptools#1902

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -21,4 +21,4 @@ Jinja2==2.10
 markupsafe==1.1.1
 doc2dash==2.3.0
 beautifulsoup4
-attrdict3
+attrdict3 ; sys_platform == 'win32'


### PR DESCRIPTION
It's only used on Windows, so only require it there.
