### PR TITLE
pypubsub: Replace deprecated inspect.getargspec

### DIFF
--- a/wx/lib/pubsub/core/callables.py
+++ b/wx/lib/pubsub/core/callables.py
@@ -12,7 +12,7 @@ CallArgsInfo regarding its autoTopicArgName data member.
 
 """
 
-from inspect import getargspec, ismethod, isfunction
+from inspect import ismethod, isfunction, signature, Parameter
 
 from .. import py2and3
 
@@ -133,19 +133,26 @@ class CallArgsInfo:
         self.autoTopicArgName = None."""
 
         #args, firstArgIdx, defaultVals, acceptsAllKwargs
-        (allParams, varParamName, varOptParamName, defaultVals) = getargspec(func)
-        if defaultVals is None:
-            defaultVals = []
-        else:
-            defaultVals = list(defaultVals)
+        allParams = []
+        defaultVals = []
+        varParamName = None
+        varOptParamName = None
+        for argName, param in signature(func).parameters.items():
+            if param.default != Parameter.empty:
+                defaultVals.append(param.default)
+            if param.kind == Parameter.VAR_POSITIONAL:
+                varParamName = argName
+            elif param.kind == Parameter.VAR_KEYWORD:
+                varOptParamName = argName
+            else:
+                allParams.append(argName)
 
         self.acceptsAllKwargs      = (varOptParamName is not None)
         self.acceptsAllUnnamedArgs = (varParamName    is not None)
-
         self.allParams = allParams
-        del self.allParams[0:firstArgIdx] # does nothing if firstArgIdx == 0
 
         self.numRequired = len(self.allParams) - len(defaultVals)
+        assert len(self.allParams) >= len(defaultVals)
         assert self.numRequired >= 0
 
         # if listener wants topic, remove that arg from args/defaultVals


### PR DESCRIPTION
inspect.getargspec was removed in Python 3.11.  This is a backport of:
https://github.com/schollii/pypubsub/commit/089c7a73f85c76a3aa22e4b10c71db1bf65a8637
