### PR TITLE
Fix overflow check for wxUIntPtr type

### DIFF
--- a/unittests/test_listctrl.py
+++ b/unittests/test_listctrl.py
@@ -185,7 +185,7 @@ class listctrl_Tests(wtc.WidgetTestCase):
     def test_listctrlItemData02(self):
         lc = self._makeListCtrl()
         with self.assertRaises(OverflowError):
-            lc.SetItemData(0, wx._core._LONG_MAX + 100)
+            lc.SetItemData(0, wx._core._LLONG_MAX + 100)
 
 
     def test_listctrlDeleteAllColumns(self):


### PR DESCRIPTION
long is 32bit on 32-bit archs and on Win64 (see
https://en.cppreference.com/w/cpp/language/types ). As SIP uses
PyLong_AsLongLong internally and uses an extra bounds check only if
explicitly enabled("sip.enableoverflowchecking(True)"), the overflow
only triggers when it also overflows `long long`, i.e. when
_LONG_MAX == _LLONG_MAX.
