### PR TITLE
OSX: remove check of SetFrontProcess() before App is fully initialized

### DIFF
--- a/src/app_ex.cpp
+++ b/src/app_ex.cpp
@@ -335,11 +335,7 @@ bool wxPyApp::IsDisplayAvailable()
         //
         // [NSRunningApplication activateIgnoringOtherApps: YES]  ??
         // 
-        if (GetCurrentProcess(&psn) < 0 || SetFrontProcess(&psn) < 0) {
-            rv = false;
-        } else {
-            rv = true;
-        }
+        rv = true;
     }
     return rv;
 #endif


### PR DESCRIPTION

Fixes #2250 

This simply removes the calls to `GetCurrentProcess()` and `SetFrontProcess()` from `IsDisplayInitialized()`.   These two functions are deprecated, and `SetFrontProcess()` returns a value of -606 for non-framework builds of Python (notably including Anaconda Python), which then falsely raises an exception that the Application cannot draw to the screen.

With current wxWidgets on MacOSX, 

    [NSApp activateIgnoringOtherApps: YES];

and related calls to `[NSApp ...]` are called by `applicationDidFinishLaunching()`, which allows drawing to the screen.  This method is not called from wxPython until `CallOnInit()` time, which is much later in the initialization step than `IsDisplayInitialized()`.   I do not know if this approach is acceptable for cases where the application truly does not have write access to the screen, but relying on calls to deprecated functions is probably not that reliable anyway, and it appears that  `SetFrontProcess()` is often giving "false negative" results.

This fix would also satisfy the long-standing (getting close to 8 years old!) issue raised with Anaconda Python:  https://github.com/ContinuumIO/anaconda-issues/issues/199


