### PR TITLE
Making explicit float->int type casting for DC.DrawXXX

### DIFF
--- a/wx/lib/printout.py
+++ b/wx/lib/printout.py
@@ -64,18 +64,18 @@ class PrintBase(object):
                 if self.draw == True and txtdraw == True:
                     test_out = self.TestFull(vout)
                     if self.align == wx.ALIGN_LEFT:
-                        self.DC.DrawText(test_out, self.indent+self.pcell_left_margin, y)
+                        self.DC.DrawText(test_out, int(self.indent+self.pcell_left_margin), int(y))
 
                     elif self.align == wx.ALIGN_CENTRE:
                         diff = self.GetCellDiff(test_out, self.region)
-                        self.DC.DrawText(test_out, self.indent+diff/2, y)
+                        self.DC.DrawText(test_out, int(self.indent+diff/2), int(y))
 
                     elif self.align == wx.ALIGN_RIGHT:
                         diff = self.GetCellDiff(test_out, self.region)
-                        self.DC.DrawText(test_out, self.indent+diff, y)
+                        self.DC.DrawText(test_out, int(self.indent+diff), int(y))
 
                     else:
-                        self.DC.DrawText(test_out, self.indent+self.pcell_left_margin, y)
+                        self.DC.DrawText(test_out, int(self.indent+self.pcell_left_margin), int(y))
                 text = remain
                 y = y + self.space
         return y - self.space + self.pt_space_after
@@ -152,18 +152,18 @@ class PrintBase(object):
                 if self.draw == True and txtdraw == True:
                     test_out = vout
                     if align == wx.ALIGN_LEFT:
-                        self.DC.DrawText(test_out, indent, y)
+                        self.DC.DrawText(test_out, int(indent), int(y))
 
                     elif align == wx.ALIGN_CENTRE:
                         diff = self.GetCellDiff(test_out, pagew)
-                        self.DC.DrawText(test_out, indent+diff/2, y)
+                        self.DC.DrawText(test_out, int(indent+diff/2), int(y))
 
                     elif align == wx.ALIGN_RIGHT:
                         diff = self.GetCellDiff(test_out, pagew)
-                        self.DC.DrawText(test_out, indent+diff, y)
+                        self.DC.DrawText(test_out, int(indent+diff), int(y))
 
                     else:
-                        self.DC.DrawText(test_out, indent, y_out)
+                        self.DC.DrawText(test_out, int(indent), int(y_out))
                 text = remain
                 y = y + y_line
         return y - y_line
@@ -531,8 +531,8 @@ class PrintTableDraw(wx.ScrolledWindow, PrintBase):
         brush = wx.Brush(colour, wx.BRUSHSTYLE_SOLID)
         self.DC.SetBrush(brush)
         height = self.label_space + self.label_pt_space_before + self.label_pt_space_after
-        self.DC.DrawRectangle(self.column[0], self.y,
-                              self.end_x-self.column[0]+1, height)
+        self.DC.DrawRectangle(int(self.column[0]), int(self.y),
+                              int(self.end_x-self.column[0]+1), int(height))
 
     def ColourRowCells(self, height):
         if self.draw == False:
@@ -550,7 +550,7 @@ class PrintTableDraw(wx.ScrolledWindow, PrintBase):
 
             start_x = self.column[col]
             width = self.column[col+1] - start_x + 2
-            self.DC.DrawRectangle(start_x, self.y, width, height)
+            self.DC.DrawRectangle(int(start_x), int(self.y), int(width), int(height))
             col = col + 1
 
     def PrintRow(self, row_val, draw = True, align = wx.ALIGN_LEFT):
@@ -626,7 +626,7 @@ class PrintTableDraw(wx.ScrolledWindow, PrintBase):
 
             y_out = self.y
 #            y_out = self.y + self.pt_space_before + self.pt_space_after     # adjust for extra spacing
-            self.DC.DrawLine(self.column[0], y_out, self.end_x, y_out)
+            self.DC.DrawLine(int(self.column[0]), int(y_out), int(self.end_x), int(y_out))
 
     def DrawColumns(self):
         if self.draw == True \
@@ -648,7 +648,7 @@ class PrintTableDraw(wx.ScrolledWindow, PrintBase):
                 indent = val
 
                 self.DC.SetPen(wx.Pen(colour, size))
-                self.DC.DrawLine(indent, self.y_start, indent, self.y)
+                self.DC.DrawLine(int(indent), int(self.y_start), int(indent), int(self.y))
                 col = col + 1
 
     def DrawText(self):


### PR DESCRIPTION
Used DC.DrawXXX functions expect integer coordinates, but this module freely mixes both float and integer values. A quick fix is to add explicit type casting in all DC.DrawXXX calls (this pull request). (The long term solution is possibly to control numeric types in the calling modules or have DC.DrawXXX methods handle float type as well.)

Fixes #2261

