### PR TITLE
Added sip.voidptr->int type casting in wx_pycairo.py

### DIFF
--- a/wx/lib/wxcairo/wx_pycairo.py
+++ b/wx/lib/wxcairo/wx_pycairo.py
@@ -112,7 +112,7 @@ def _FontFaceFromFont(font):
 
     elif 'wxMSW' in wx.PlatformInfo:
         fontfaceptr = voidp( cairoLib.cairo_win32_font_face_create_for_hfont(
-            ctypes.c_ulong(font.GetHFONT())) )
+            ctypes.c_ulong(int(font.GetHFONT()))) )
         fontface = pycairoAPI.FontFace_FromFontFace(fontfaceptr)
 
     elif 'wxGTK' in wx.PlatformInfo:


### PR DESCRIPTION
The module wx\lib\wxcairo\wx_pycairo.py needs explicit sip.voidptr to int type casting.

Fixes #2263

