### PR TITLE
Reenabled TreeListCtrl demo in TreeMixin

### DIFF
--- a/demo/TreeMixin.py
+++ b/demo/TreeMixin.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import wx
-import wx.adv
+import wx.gizmos as gizmos
 import wx.lib.agw.customtreectrl
 try:
     import treemixin
@@ -126,31 +126,31 @@ class VirtualTreeCtrl(DemoTreeMixin, wx.TreeCtrl):
     pass
 
 
-# class VirtualTreeListCtrl(DemoTreeMixin, wx.adv.TreeListCtrl):
-#     def __init__(self, *args, **kwargs):
-#         kwargs['style'] = wx.TR_DEFAULT_STYLE | wx.TR_FULL_ROW_HIGHLIGHT
-#         super(VirtualTreeListCtrl, self).__init__(*args, **kwargs)
-#         self.AppendColumn('Column 0')
-#         self.AppendColumn('Column 1')
-#         for art in wx.ART_TIP, wx.ART_WARNING:
-#             self.imageList.Add(wx.ArtProvider.GetBitmap(art, wx.ART_OTHER,
-#                                                         (16, 16)))
-#
-#     def OnGetItemText(self, indices, column=0):
-#         # Return a different label depending on column.
-#         return '%s, column %d'%\
-#             (super(VirtualTreeListCtrl, self).OnGetItemText(indices), column)
-#
-#     def OnGetItemImage(self, indices, which, column=0):
-#         # Also change the image of the other columns when the item has
-#         # children.
-#         if column == 0:
-#             return super(VirtualTreeListCtrl, self).OnGetItemImage(indices,
-#                                                                    which)
-#         elif self.OnGetChildrenCount(indices):
-#             return 4
-#         else:
-#             return 3
+class VirtualTreeListCtrl(DemoTreeMixin, gizmos.TreeListCtrl):
+    def __init__(self, *args, **kwargs):
+        kwargs['style'] = wx.TR_DEFAULT_STYLE | wx.TR_FULL_ROW_HIGHLIGHT
+        super(VirtualTreeListCtrl, self).__init__(*args, **kwargs)
+        self.AddColumn('Column 0')
+        self.AddColumn('Column 1')
+        for art in wx.ART_TIP, wx.ART_WARNING:
+            self.imageList.Add(wx.ArtProvider.GetBitmap(art, wx.ART_OTHER,
+                                                        (16, 16)))
+
+    def OnGetItemText(self, indices, column=0):
+        # Return a different label depending on column.
+        return '%s, column %d'%\
+            (super(VirtualTreeListCtrl, self).OnGetItemText(indices), column)
+
+    def OnGetItemImage(self, indices, which, column=0):
+        # Also change the image of the other columns when the item has
+        # children.
+        if column == 0:
+            return super(VirtualTreeListCtrl, self).OnGetItemImage(indices,
+                                                                   which)
+        elif self.OnGetChildrenCount(indices):
+            return 4
+        else:
+            return 3
 
 
 class VirtualCustomTreeCtrl(DemoTreeMixin,
@@ -192,7 +192,7 @@ class TreeNotebook(wx.Notebook):
         super(TreeNotebook, self).__init__(*args, **kwargs)
         self.trees = []
         for class_, title in [(VirtualTreeCtrl, 'TreeCtrl'),
-                              #(VirtualTreeListCtrl, 'TreeListCtrl'),
+                              (VirtualTreeListCtrl, 'TreeListCtrl'),
                               (VirtualCustomTreeCtrl, 'CustomTreeCtrl')]:
             tree = class_(self, treemodel=treemodel, log=log)
             self.trees.append(tree)


### PR DESCRIPTION
Replaced a TreeListCtrl to wx.gizmos, and updated and uncommented the associated code (also changed AppendColumn to AddColumn). Note, this code does not work as is with wx.dataview.TreeListCtrl.

Fixes #2275