### PR TITLE
listctrl TextEditMixin

### DIFF
--- a/wx/lib/mixins/listctrl.py
+++ b/wx/lib/mixins/listctrl.py
@@ -461,7 +461,7 @@ class TextEditMixin:
 
     def make_editor(self, col_style=wx.LIST_FORMAT_LEFT):
 
-        style =wx.TE_PROCESS_ENTER|wx.TE_PROCESS_TAB|wx.TE_RICH2
+        style =wx.TE_PROCESS_ENTER|wx.TE_PROCESS_TAB
         style |= {wx.LIST_FORMAT_LEFT: wx.TE_LEFT,
                   wx.LIST_FORMAT_RIGHT: wx.TE_RIGHT,
                   wx.LIST_FORMAT_CENTRE : wx.TE_CENTRE

--- a/wx/lib/mixins/listctrl.py
+++ b/wx/lib/mixins/listctrl.py
@@ -588,7 +588,7 @@ class TextEditMixin:
                 # scroll a bit more than what is minimum required
                 # so we don't have to scroll every time the user presses TAB
                 # which is very tireing to the eye
-                addoffset = self.GetSize()[0]/4
+                addoffset = self.GetSize()[0]//4
                 # but be careful at the end of the list
                 if addoffset + scrolloffset < self.GetSize()[0]:
                     offset += addoffset


### PR DESCRIPTION
Fixes #2271

This PR includes two commits that fix the two issues mentioned in #2271
One is simple. Fixed /4 --> //4 to avoid TypeError.
The other one is simple too. Removed TE_RICH2 style to avoid selection disappearing on a second focus.
But I suspect that someone dislikes removing the style. 

I found that there is another way to fix this issue as follows:
https://github.com/wxWidgets/Phoenix/blob/7c4d21d7786c15cd5afeb3b931a035e73b40e514/wx/lib/mixins/listctrl.py#L575-L576
```diff
@@ -575,2 +575,2 @@ class TextEditMixin:
-        if self.GetColumn(col).Align != self.col_style:
-            self.make_editor(self.GetColumn(col).Align)
+        # Make new editor even not if self.GetColumn(col).Align != self.col_style:
+        self.make_editor(self.GetColumn(col).Align)
```
What do you think?
