### PR TITLE
Fixes method typo in AUI_DockingWindowMgr

### DIFF
--- a/demo/AUI_DockingWindowMgr.py
+++ b/demo/AUI_DockingWindowMgr.py
@@ -1093,7 +1093,7 @@ class SettingsPanel(wx.Panel):
         else:
             return
 
-        self._frame.GetDockArt().SetColor(var, dlg.GetColourData().GetColour())
+        self._frame.GetDockArt().SetColour(var, dlg.GetColourData().GetColour())
         self._frame.DoUpdate()
         self.UpdateColors()
 


### PR DESCRIPTION
Fixes typo (.SetColor -> .SetColour) in demo module demo/AUI_DockingWindowMgr.py.

Fixes #2278

