### PR TITLE
Changed float division to integer division in lib-agw-aui-dockart.py

### DIFF
--- a/wx/lib/agw/aui/dockart.py
+++ b/wx/lib/agw/aui/dockart.py
@@ -612,7 +612,7 @@ class AuiDefaultDockArt(object):
         draw_text = ChopText(dc, text, variable)
 
         if captionLeft:
-            dc.DrawRotatedText(draw_text, rect.x+(rect.width/2)-(h/2)-1, rect.y+rect.height-3-caption_offset, 90)
+            dc.DrawRotatedText(draw_text, rect.x+(rect.width//2)-(h//2)-1, rect.y+rect.height-3-caption_offset, 90)
         else:
             dc.DrawText(draw_text, rect.x+3+caption_offset, rect.y+(rect.height//2)-(h//2)-1)
 


### PR DESCRIPTION
wx.DC.DrawXXX expect numeric arguments to be integers, but floats are passed due to float division. Changed float division to integer division.


Fixes #2283

