### PR TITLE
Patch out GTK specific function from wx 3.2.1

### DIFF
--- a/etg/app.py
+++ b/etg/app.py
@@ -212,6 +212,12 @@ def run():
         #endif
         """)
 
+    c.find('GTKAllowDiagnosticsControl').setCppCode("""\
+        #ifdef __WXGTK__
+            wxApp::GTKAllowDiagnosticsControl();
+        #endif
+        """)
+           
     c.find('GetGUIInstance').ignore()
 
 


### PR DESCRIPTION
This is a new GTK specific function added in wx 3.2.1 that results in build errors on Windows due to it's inclusion in the interface header but not windows itself.