### PR TITLE
Fix `pyext_PATTERN` - wxPython fails to build wheel and test install

### DIFF
--- a/.azure/ci-windows-job.yml
+++ b/.azure/ci-windows-job.yml
@@ -98,3 +98,8 @@ jobs:
       python -m pip install dist/wxPython-*.whl
       python -c "import wx; print(wx.version());"
     displayName: 'build wheel and test install'
+
+  - task: PublishPipelineArtifact@1
+    inputs:
+      targetPath: dist
+      artifactName: wxPython-py$(python.version)-win_$(python.arch)


### PR DESCRIPTION
- Add CI for Python 3.11
- Fix `pyext_PATTERN` - wxPython fails to [build wheel and test install](https://dev.azure.com/oleksis/wxPython/_build/results?buildId=87&view=logs&j=1673e16c-f486-5fbe-9e06-af58c9e250b7&t=3090b2c6-64dc-5dc7-25af-6813b4fbbe19&l=17537) with Python 3.11
- `sysconfig.get_config_var('EXT_SUFFIX')` [waf/issues/2386](https://gitlab.com/ita1024/waf/-/issues/2386#note_949703225)
- [Publish Windows artifacts](https://dev.azure.com/oleksis/wxPython/_build/results?buildId=88&view=artifacts&pathAsName=false&type=publishedArtifacts)

Fixes #2297, #2298
