### PR TITLE
Reduce FillingTree overheads

### DIFF
--- a/wx/py/filling.py
+++ b/wx/py/filling.py
@@ -106,10 +106,7 @@ class FillingTree(wx.TreeCtrl):
 
     def objHasChildren(self, obj):
         """Return true if object has children."""
-        if self.objGetChildren(obj):
-            return True
-        else:
-            return False
+        return type(obj) not in COMMONTYPES
 
     def objGetChildren(self, obj):
         """Return dictionary with attributes or contents of object."""

--- a/wx/py/filling.py
+++ b/wx/py/filling.py
@@ -125,6 +125,9 @@ class FillingTree(wx.TreeCtrl):
                 d[key] = obj[n]
         if otype not in COMMONTYPES:
             for key in introspect.getAttributeNames(obj):
+                if wx.Platform == '__WXMSW__':
+                    if key == 'DropTarget': # Windows bug fix.
+                        continue
                 # Believe it or not, some attributes can disappear,
                 # such as the exc_traceback attribute of the sys
                 # module. So this is nested in a try block.

--- a/wx/py/filling.py
+++ b/wx/py/filling.py
@@ -151,6 +151,22 @@ class FillingTree(wx.TreeCtrl):
         """
         return True
 
+    @staticmethod
+    def format(obj):
+        """Format function that determines how the item is displayed.
+        
+        You can overwrite this like:
+        >>> FillingTree.format = staticmethod(pprint.pformat)
+        """
+        if isinstance(obj, six.string_types):
+            value = repr(obj)
+        else:
+            try:
+                value = six.text_type(obj)
+            except Exception:
+                value = ''
+        return 'Value: ' + value
+
     def addChildren(self, item):
         self.DeleteChildren(item)
         obj = self.GetItemData(item)
@@ -188,13 +204,7 @@ class FillingTree(wx.TreeCtrl):
         text = ''
         text += self.getFullName(item)
         text += '\n\nType: ' + six.text_type(otype)
-        try:
-            value = six.text_type(obj)
-        except Exception:
-            value = ''
-        if isinstance(obj, six.string_types):
-            value = repr(obj)
-        text += u'\n\nValue: ' + value
+        text += '\n\n' + self.format(obj)
         if otype not in SIMPLETYPES:
             try:
                 text += '\n\nDocstring:\n\n"""' + \

--- a/wx/py/filling.py
+++ b/wx/py/filling.py
@@ -173,10 +173,17 @@ class FillingTree(wx.TreeCtrl):
                 item, cookie = self.GetNextChild(root, cookie)
         obj = self.GetItemData(item)
         children = self.objGetChildren(obj)
+        # Show string dictionary items with single quotes, except
+        # for the first level of items, if they represent a namespace.
+        # cf. addChildren
+        if (isinstance(obj, dict)
+            and (item != self.root
+                 or item == self.root and not self.rootIsNamespace)):
+            children = dict((repr(k), v) for k, v in children.items())
         items = dict((self.GetItemText(i), i) for i in _gen(item))
         A = set(items)
         B = set(children)
-        for key in A - B:
+        for key in (A - B):
             self.Delete(items[key])
         for key in (B & A):
             i = items[key]

--- a/wx/py/filling.py
+++ b/wx/py/filling.py
@@ -135,10 +135,21 @@ class FillingTree(wx.TreeCtrl):
                     # such as the exc_traceback attribute of the sys
                     # module. So this is nested in a try block.
                     try:
-                        d[key] = getattr(obj, key)
+                        v = getattr(obj, key)
+                        if self.filter(v):
+                            d[key] = v
                     except Exception:
                         pass
         return d
+
+    @staticmethod
+    def filter(obj):
+        """Filter function that determines whether the item is displayed.
+        
+        You can overwrite this like:
+        >>> FillingTree.filter = staticmethod(inspect.ismethod)
+        """
+        return True
 
     def addChildren(self, item):
         self.DeleteChildren(item)

--- a/wx/py/filling.py
+++ b/wx/py/filling.py
@@ -13,6 +13,7 @@ from . import images
 import inspect
 from . import introspect
 import types
+import warnings
 
 
 COMMONTYPES = [getattr(types, t) for t in dir(types) \
@@ -124,17 +125,19 @@ class FillingTree(wx.TreeCtrl):
                 key = '[' + six.text_type(n) + ']'
                 d[key] = obj[n]
         if otype not in COMMONTYPES:
-            for key in introspect.getAttributeNames(obj):
-                if wx.Platform == '__WXMSW__':
-                    if key == 'DropTarget': # Windows bug fix.
-                        continue
-                # Believe it or not, some attributes can disappear,
-                # such as the exc_traceback attribute of the sys
-                # module. So this is nested in a try block.
-                try:
-                    d[key] = getattr(obj, key)
-                except Exception:
-                    pass
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                for key in introspect.getAttributeNames(obj):
+                    if wx.Platform == '__WXMSW__':
+                        if key == 'DropTarget': # Windows bug fix.
+                            continue
+                    # Believe it or not, some attributes can disappear,
+                    # such as the exc_traceback attribute of the sys
+                    # module. So this is nested in a try block.
+                    try:
+                        d[key] = getattr(obj, key)
+                    except Exception:
+                        pass
         return d
 
     def addChildren(self, item):


### PR DESCRIPTION
This PR fixes FillingTree overheads and adds some customization features.

Prevent crash when referencing `DropTarget` (Windows bug fix) cf. #1959, #2043.
Suppress unnecessary deprecation warning messages.
Provide some customizable options:
- filter function of tree items
- formt function for value text

Reduce some overheads:
- Prevent call `display` => `addChildren` (=> `DeleteChildren`) => `objGetChildren`. Use`updateChildren`.
- Prevent call `objHasChildren` => `objGetChildren`. Use type check only.

The following video clip shows the effect of the fix.
Before:

https://user-images.githubusercontent.com/83063554/205479618-10afa088-697d-4569-af84-a3c74aa43cbe.mp4

After:

https://user-images.githubusercontent.com/83063554/205479629-903c7f7b-5dfe-4bc1-8bde-0f52a05adfa7.mp4

