### PR TITLE
Since numpy 1.20 the aliases `np.int` and `np.float` are deprecated (…

### DIFF
--- a/samples/floatcanvas/BouncingBall.py
+++ b/samples/floatcanvas/BouncingBall.py
@@ -49,7 +49,7 @@ class MovingObjectMixin: # Borrowed from MovingElements.py
 
 class Ball(MovingObjectMixin, FloatCanvas.Circle):
     def __init__(self, XY, Velocity, Radius=2.0, **kwargs):
-        self.Velocity = np.asarray(Velocity, np.float).reshape((2,))
+        self.Velocity = np.asarray(Velocity, float).reshape((2,))
         self.Radius = Radius
         self.Moving = False
         FloatCanvas.Circle.__init__(self, XY, Diameter=Radius*2, FillColor="red", **kwargs)

--- a/samples/floatcanvas/PixelBitmap.py
+++ b/samples/floatcanvas/PixelBitmap.py
@@ -49,7 +49,7 @@ class PixelBitmap:
         else:
             raise FC.FloatCanvasError("PixelBitmap takes only a wx.Bitmap or a wx.Image as input")
 
-        self.XY = np.asarray(XY, dtype=np.int).reshape((2,))
+        self.XY = np.asarray(XY, dtype=int).reshape((2,))
         self.Position = Position
 
         (self.Width, self.Height) = self.Bitmap.GetWidth(), self.Bitmap.GetHeight()

--- a/wx/lib/plot/polyobjects.py
+++ b/wx/lib/plot/polyobjects.py
@@ -616,7 +616,7 @@ class PolyMarker(PolyPoints):
     def _circle(self, dc, coords, size=1):
         fact = 2.5 * size
         wh = 5.0 * size
-        rect = np.zeros((len(coords), 4), np.float) + [0.0, 0.0, wh, wh]
+        rect = np.zeros((len(coords), 4), float) + [0.0, 0.0, wh, wh]
         rect[:, 0:2] = coords - [fact, fact]
         dc.DrawEllipseList(rect.astype(np.int32))
 
@@ -627,7 +627,7 @@ class PolyMarker(PolyPoints):
     def _square(self, dc, coords, size=1):
         fact = 2.5 * size
         wh = 5.0 * size
-        rect = np.zeros((len(coords), 4), np.float) + [0.0, 0.0, wh, wh]
+        rect = np.zeros((len(coords), 4), float) + [0.0, 0.0, wh, wh]
         rect[:, 0:2] = coords - [fact, fact]
         dc.DrawRectangleList(rect.astype(np.int32))
 
@@ -1199,7 +1199,7 @@ class PolyBoxPlot(PolyPoints):
         size = 0.5
         fact = 2.5 * size
         wh = 5.0 * size
-        rect = np.zeros((len(pt_data), 4), np.float) + [0.0, 0.0, wh, wh]
+        rect = np.zeros((len(pt_data), 4), float) + [0.0, 0.0, wh, wh]
         rect[:, 0:2] = pt_data - [fact, fact]
         dc.DrawRectangleList(rect.astype(np.int32))
 


### PR DESCRIPTION
Since numpy 1.20 the aliases `np.int` and `np.float` are deprecated (see https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated). The buildin types should be used instead. Since numpy 1.24 an AttributeError exception is thrown when `np.int` or `np.float` is used.