### PR TITLE
Don't crush pie filling

### DIFF
--- a/wx/py/filling.py
+++ b/wx/py/filling.py
@@ -125,6 +125,9 @@ class FillingTree(wx.TreeCtrl):
                 d[key] = obj[n]
         if otype not in COMMONTYPES:
             for key in introspect.getAttributeNames(obj):
+                if wx.Platform == '__WXMSW__':
+                    if key == 'DropTarget': # Windows bug fix.
+                        continue
                 # Believe it or not, some attributes can disappear,
                 # such as the exc_traceback attribute of the sys
                 # module. So this is nested in a try block.


### PR DESCRIPTION
Fixes #2043 (#1959)

Prevents `py.filling` from crashing when referencing `DropTarget`.
(due to Windows fatal exception: access violation)

This PR is for Windows only.