### PR TITLE
Add `attrdict3` module to requirements

### DIFF
--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -3,3 +3,4 @@ numpy < 1.17 ; python_version <= '2.7'
 numpy ; python_version >= '3.0'
 pillow
 six
+attrdict3


### PR DESCRIPTION
When installing wxPython (`pip install wxPython`) I get the error below, if I install `attrdict3` module before (`pip install attrdict3`) it solves the problem.
```
File "/tmp/pip-install-uf_cqxb4/wxpython_d8d3cb6703ff478bb9453f8f4a8e9ab8/buildtools/config.py", line 30, in <module>
           from attrdict import AttrDict
       ModuleNotFoundError: No module named 'attrdict'
       [end of output]
```

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #NNNN

