### PR TITLE
agw: Fix TypeError caused by floats with Python 3.10 extensions.

### DIFF
--- a/wx/lib/agw/pygauge.py
+++ b/wx/lib/agw/pygauge.py
@@ -367,12 +367,12 @@ class PyGauge(wx.Window):
             drawString = self._drawIndicatorText_formatString.format(drawValue)
             rect = self.GetClientRect()
             (textWidth, textHeight, descent, extraLeading) = dc.GetFullTextExtent(drawString)
-            textYPos = (rect.height-textHeight)/2
+            textYPos = (rect.height-textHeight)//2
 
             if textHeight > rect.height:
                 textYPos = 0-descent+extraLeading
 
-            textXPos = (rect.width-textWidth)/2
+            textXPos = (rect.width-textWidth)//2
 
             if textWidth>rect.width:
                 textXPos = 0


### PR DESCRIPTION
This fixes the following error:

   File "/lib/python3.10/site-packages/wx/lib/agw/pygauge.py", line 380, in OnPaint
       dc.DrawText(drawString, textXPos, textYPos)
   TypeError: DC.DrawText(): arguments did not match any overloaded call:
     overload 1: argument 2 has unexpected type 'float'
     overload 2: argument 2 has unexpected type 'float'
   TimeLeft: 3.0

Visible when using Python 3.10 or newer.

See: https://github.com/wxWidgets/Phoenix/issues/2038#issuecomment-1530004477.
