### PR TITLE
UltimateListCtrl - Fix floor division so floats are not passed to wx.Rect()

### DIFF
--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -5265,7 +5265,7 @@ class UltimateListHeaderWindow(wx.Control):
                 xAligned = x + cw - wLabel - HEADER_OFFSET_X
 
             elif align == ULC_FORMAT_CENTER:
-                xAligned = x + wcheck + (cw - wLabel)/2
+                xAligned = x + wcheck + (cw - wLabel)//2
 
             # if we have an image, draw it on the right of the label
             if imageList:
@@ -5603,7 +5603,7 @@ class UltimateListHeaderWindow(wx.Control):
 
         w, h = self.GetClientSize()
         ix, iy = self._owner.GetCheckboxImageSize()
-        rect = wx.Rect(theX + HEADER_OFFSET_X, HEADER_OFFSET_Y + (h - 4 - iy)/2, ix, iy)
+        rect = wx.Rect(theX + HEADER_OFFSET_X, HEADER_OFFSET_Y + (h - 4 - iy)//2, ix, iy)
 
         if rect.Contains(pos):
             # User clicked on the checkbox


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #2240

This PR is intended to fix two issues with the UltimateListCtrl related to the use of single division operator returning a float in python >=3.10 which is then passed to wx.Rect.

The issues involve:
1. Use of ULC_FORMAT_CENTER in the format parameter of an InsertColumn() call.
2. Use of a checkbox in a column heading.

