### PR TITLE
UltimateListCtrl - Fix arg type error when drawing image in column header

### DIFF
--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -5273,7 +5273,7 @@ class UltimateListHeaderWindow(wx.Control):
                     if img >= 0:
                         imageList.Draw(img, dc,
                                        xAligned + wLabel - (ix + HEADER_IMAGE_MARGIN_IN_REPORT_MODE)*(indx+1),
-                                       HEADER_OFFSET_Y + (h - 4 - iy)/2,
+                                       HEADER_OFFSET_Y + (h - 4 - iy)//2,
                                        wx.IMAGELIST_DRAW_TRANSPARENT)
 
                         cw -= ix + HEADER_IMAGE_MARGIN_IN_REPORT_MODE


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #2416

This PR is intended to fix the expression used to calculate arg 4 of a call to imageList.Draw() so that it returns an int and not a float.

