### PR TITLE
Bugfix. Display correct labels in GridWithLabelRenderersMixin when the grid contains frozen rows or columns

### DIFF
--- a/wx/lib/mixins/gridlabelrenderer.py
+++ b/wx/lib/mixins/gridlabelrenderer.py
@@ -95,12 +95,14 @@ class GridWithLabelRenderersMixin(object):
     def _onPaintRowLabels(self, evt):
         window = evt.GetEventObject()
         dc = wx.PaintDC(window)
+        gridWindow = self.GetGridWindow()
 
-        rows = self.CalcRowLabelsExposed(window.GetUpdateRegion())
+        rows = self.CalcRowLabelsExposed(window.GetUpdateRegion(), gridWindow)
         if rows == [-1]:
             return
 
-        x, y = self.CalcUnscrolledPosition((0,0))
+        offset = self.GetGridWindowOffset(gridWindow)
+        x, y = self.CalcUnscrolledPosition(offset)
         pt = dc.GetDeviceOrigin()
         dc.SetDeviceOrigin(pt.x, pt.y-y)
         for row in rows:
@@ -119,12 +121,14 @@ class GridWithLabelRenderersMixin(object):
     def _onPaintColLabels(self, evt):
         window = evt.GetEventObject()
         dc = wx.PaintDC(window)
+        gridWindow = self.GetGridWindow()
 
-        cols = self.CalcColLabelsExposed(window.GetUpdateRegion())
+        cols = self.CalcColLabelsExposed(window.GetUpdateRegion(), gridWindow)
         if cols == [-1]:
             return
 
-        x, y = self.CalcUnscrolledPosition((0,0))
+        offset = self.GetGridWindowOffset(gridWindow)
+        x, y = self.CalcUnscrolledPosition(offset)
         pt = dc.GetDeviceOrigin()
         dc.SetDeviceOrigin(pt.x-x, pt.y)
         for col in cols:


### PR DESCRIPTION
### Background

In commit [04f7f1fd32a9f061bb5ad41d709a9e9ea7fe76c8](https://github.com/wxWidgets/wxWidgets/commit/04f7f1fd32a9f061bb5ad41d709a9e9ea7fe76c8) wxWidgets added support for freezing columns and rows in a `Grid` but this support was never extended to the python `GridWithLabelRenderersMixin` that allows using custom pure-python column and row label renderers.

### Problem

Currently, when trying to use both features simultaneously (frozen rows/columns and custom pure-python renderers) the renderers display the wrong labels. This was first reported at https://discuss.wxpython.org/t/wxgrid-column-labels-duplicated-when-using-frozen-columns-and-custom-label-renderer/35490/3 where one can see multiple examples of the  problem. Here is a self-contained example of the problem (complete test code for this image below).
![image](https://github.com/wxWidgets/Phoenix/assets/23492126/2d0d4d6b-d352-4ec0-af0c-c979bbba5fa5)

### Solution
This PR changes the Python rendering hooks mimicking the C++ changes made in the original wxWidgets [commit](https://github.com/wxWidgets/wxWidgets/commit/04f7f1fd32a9f061bb5ad41d709a9e9ea7fe76c8#diff-9cc98f8a208062a88ee5102d3c0252b0d1a6d17c3d78c224e81b5656ccb93850) (methods `wxGridRowLabelWindow::OnPaint` and `wxGridColLabelWindow::OnPaint`). Now the correct labels are shown for each row and column
![image](https://github.com/wxWidgets/Phoenix/assets/23492126/647de18d-7804-4ce9-9c40-041422367a7f)

### Future work
Notice in the figure above, that a problem remains: The labels for the frozen columns and rows do not use the custom renderers. This is a separate issue that should be addressed in a separate PR.

### Test
<details><summary>The images above, before and after the solution, were captured using the following test program:</summary>

```python
import wx
import wx.grid as grid
import wx.lib.mixins.gridlabelrenderer as glr

#----------------------------------------------------------------------

class MyGrid(grid.Grid, glr.GridWithLabelRenderersMixin):
    def __init__(self, *args, **kw):
        grid.Grid.__init__(self, *args, **kw)
        glr.GridWithLabelRenderersMixin.__init__(self)


class MyRowLabelRenderer(glr.GridLabelRenderer):
    def __init__(self, bgcolor):
        self._bgcolor = bgcolor

    def Draw(self, grid, dc, rect, row):
        dc.SetBrush(wx.Brush(self._bgcolor))
        dc.SetPen(wx.TRANSPARENT_PEN)
        dc.DrawRectangle(rect)
        hAlign, vAlign = grid.GetRowLabelAlignment()
        text = grid.GetRowLabelValue(row)
        self.DrawBorder(grid, dc, rect)
        self.DrawText(grid, dc, rect, text, hAlign, vAlign)


class MyColLabelRenderer(glr.GridLabelRenderer):
    def __init__(self, bgcolor):
        self._bgcolor = bgcolor

    def Draw(self, grid, dc, rect, col):
        dc.SetBrush(wx.Brush(self._bgcolor))
        dc.SetPen(wx.TRANSPARENT_PEN)
        dc.DrawRectangle(rect)
        hAlign, vAlign = grid.GetColLabelAlignment()
        text = grid.GetColLabelValue(col)
        self.DrawBorder(grid, dc, rect)
        self.DrawText(grid, dc, rect, text, hAlign, vAlign)

class TestFrame(wx.Frame):
    def __init__(self):
        super().__init__(None, title="Freeze rows/columns with custom label renderers")

        ROWS = 7
        COLS = 7

        g = MyGrid(self, size=(500,200))
        g.CreateGrid(ROWS, COLS)
        
        # Set some sample data in the grid
        for row in range(ROWS):
            for col in range(COLS):
                g.SetCellValue(row, col, f"{chr(ord('A')+col)}-{1+row}")   

        for row in range(0, ROWS, 3): 
            g.SetRowLabelRenderer(row+0, MyRowLabelRenderer('#ffe0e0'))
            g.SetRowLabelRenderer(row+1, MyRowLabelRenderer('#e0ffe0'))
            g.SetRowLabelRenderer(row+2, MyRowLabelRenderer('#e0e0ff'))

        for col in range(0, COLS, 3):
            g.SetColLabelRenderer(col+0, MyColLabelRenderer('#e0ffe0'))
            g.SetColLabelRenderer(col+1, MyColLabelRenderer('#e0e0ff'))
            g.SetColLabelRenderer(col+2, MyColLabelRenderer('#ffe0e0'))

        self.Sizer = wx.BoxSizer()
        self.Sizer.Add(g, 1, wx.EXPAND)

        g.FreezeTo(2,1)

app = wx.App()
frm = TestFrame()
frm.Show()
app.MainLoop()

```
</details>