### PR TITLE
Use new tarfile.extractall() filter for safer tarfile extraction

### DIFF
--- a/build.py
+++ b/build.py
@@ -28,6 +28,7 @@ import tempfile
 import datetime
 import shlex
 import textwrap
+import warnings
 
 try:
     import pathlib
@@ -1403,7 +1404,11 @@ def cmd_sip(options, args):
         tf_name = glob.glob(tmpdir + '/*.tar*')[0]
         tf_dir = os.path.splitext(os.path.splitext(tf_name)[0])[0]
         with tarfile.open(tf_name) as tf:
-            tf.extractall(tmpdir)
+            try:
+                tf.extractall(tmpdir, filter='data')
+            except TypeError:
+                warnings.warn('Falling back to less safe tarfile.extractall')
+                tf.extractall(tmpdir)
         shutil.move(tf_dir, cfg.SIPINC)
 
 

--- a/wx/tools/wxget_docs_demo.py
+++ b/wx/tools/wxget_docs_demo.py
@@ -33,6 +33,7 @@ import os
 import subprocess
 import webbrowser
 import tarfile
+import warnings
 if sys.version_info >= (3,):
     from urllib.error import HTTPError
     import urllib.request as urllib2
@@ -84,7 +85,11 @@ def unpack_cached(cached, dest_dir):
     """ Unpack from the cache."""
     print('Unpack', cached, 'to', dest_dir)
     with tarfile.open(cached, "r:*") as tf:
-        tf.extractall(dest_dir)
+        try:
+            tf.extractall(dest_dir, filter='data')
+        except TypeError:
+            warnings.warn('Falling back to less safe tarfile.extractall')
+            tf.extractall(dest_dir)
     dest_dir = os.listdir(dest_dir)[0]
     return dest_dir
 


### PR DESCRIPTION
The tarfile.extractall() filter argument was introduced in the most recent CPython releases (e.g., 3.11.4) to avoid potential security issues when extracting from potentially hostile tarballs.  Let's use this option if it is available and provide a warning if it is now.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #NNNN

