### PR TITLE
Allow overriding wxSizer.InformFirstDirection()

### DIFF
--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -434,6 +434,10 @@ def fixSizerClass(klass):
     removeVirtuals(klass)
     klass.find('CalcMin').isVirtual = True
     klass.find('RepositionChildren').isVirtual = True
+    try:
+        klass.find('InformFirstDirection').isVirtual = True
+    except extractors.ExtractorError:
+        pass
 
     # in the wxSizer class it is pure-virtual
     if klass.name == 'wxSizer':


### PR DESCRIPTION
It seems this is required in order to implement a non-trivial custom Sizer.

Fixes #2452.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #NNNN

