### PR TITLE
wx.agw.aui: don't uninitialize the AuiManager if the window close event is vetoed

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -4038,7 +4038,6 @@ class AuiManager(wx.EvtHandler):
         self.Bind(wx.EVT_TIMER, self.OnHintFadeTimer, self._hint_fadetimer)
         self.Bind(wx.EVT_TIMER, self.SlideIn, self._preview_timer)
         self.Bind(wx.EVT_WINDOW_DESTROY, self.OnDestroy)
-        self.Bind(wx.EVT_CLOSE, self.OnClose)
         if '__WXGTK__' in wx.PlatformInfo:
             self.Bind(wx.EVT_WINDOW_CREATE, self.DoUpdateEvt)
 
@@ -4283,6 +4282,7 @@ class AuiManager(wx.EvtHandler):
         self.UnInit()
 
         self._frame = managed_window
+        self._frame.Bind(wx.EVT_CLOSE, self.OnClose)
         self._frame.PushEventHandler(self)
 
         # if the owner is going to manage an MDI parent frame,
@@ -4406,8 +4406,7 @@ class AuiManager(wx.EvtHandler):
         """
 
         event.Skip()
-        if event.GetEventObject() == self._frame:
-            wx.CallAfter(self.UnInit)
+        wx.CallAfter(self.UnInit)
 
     def OnDestroy(self, event):
         """Called when the managed window is destroyed. Makes sure that :meth:`UnInit`


### PR DESCRIPTION
Fixes #2313. 

Ssucessfully tested with wxPython demo example wxPython-demo-4.2.1/demo/agw/AUI.py file with modified `AuiFrame()` class `OnClose()` close event method handler.

```python
    def OnClose(self, event):
       dlg = wx.MessageDialog(
            self,
            'Do you really want to close this window?',
            'Confirm',
            wx.YES_NO | wx.NO_DEFAULT | wx.ICON_QUESTION
       ).ShowModal()
       if dlg == wx.ID_NO:
           event.Veto()
           return
       self.timer.Stop()
       event.Skip()
```

