### PR TITLE
Fix zerodivision errors in pdfviewer when windows are extremely small

### DIFF
--- a/wx/lib/pdfviewer/viewer.py
+++ b/wx/lib/pdfviewer/viewer.py
@@ -335,7 +335,9 @@ class pdfViewer(wx.ScrolledWindow):
             if not have_cairo:
                 self.font_scale_size = 1.0 / device_scale
 
-        self.winwidth, self.winheight = self.GetClientSize()
+        clientSize = self.GetClientSize()
+        clientSize.IncTo((1,1)) # Ensure non-zero dimensions to avoid zero-size bitmaps
+        self.winwidth, self.winheight = clientSize
         self.Ypage = self.pageheight + self.nom_page_gap
         if self.zoomscale > 0.0:
             self.scale = self.zoomscale * device_scale
@@ -344,8 +346,6 @@ class pdfViewer(wx.ScrolledWindow):
                 self.scale = self.winwidth / self.pagewidth
             else:                           # fit page
                 self.scale = self.winheight / self.pageheight
-        if self.scale == 0.0: # this could happen if the window was not yet initialized
-            self.scale = 1.0
         self.Xpagepixels = int(round(self.pagewidth*self.scale))
         self.Ypagepixels = int(round(self.Ypage*self.scale))
 
@@ -355,9 +355,9 @@ class pdfViewer(wx.ScrolledWindow):
         nlo = idiv * self.scrollrate
         nhi = (idiv + 1) * self.scrollrate
         if nhi - self.Ypagepixels < self.Ypagepixels - nlo:
-            self.Ypagepixels = nhi
+            self.Ypagepixels = max(nhi, 1)  # Avoid Ypagepixels==0 -> zerodivision error
         else:
-            self.Ypagepixels = nlo
+            self.Ypagepixels = max(nlo, 1)  # Avoid Ypagepixels==0 -> zerodivision error
         self.page_gap = self.Ypagepixels/self.scale - self.pageheight
 
         self.maxwidth = max(self.winwidth, self.Xpagepixels)


### PR DESCRIPTION
This fixes the error:
```
  File "/Users/mysuser/virtualenv/cytopar/lib/python3.11/site-packages/wx/lib/pdfviewer/viewer.py", line 217, in LoadFile
    self.CalculateDimensions()      # to get initial visible page range
    ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/myuser/virtualenv/cytopar/lib/python3.11/site-packages/wx/lib/pdfviewer/viewer.py", line 371, in CalculateDimensions
    self.frompage = int(min(self.y0/self.Ypagepixels, self.numpages-1))
                            ~~~~~~~^~~~~~~~~~~~~~~~~
ZeroDivisionError: division by zero
```

which can be observed by trying to resize a window containing a `pdfviewer` to extremely small sizes.

I remark that this PR expands on a previous PR of mine a few years ago, which handled the case when window client sizes were exactly zero on initialization https://github.com/wxWidgets/Phoenix/pull/1519 but did not consider cases where window client sizes were very small, which would, through rounding from floating point to int, also result in ZeroDivision errors as shown above.


