### PR TITLE
Improve Python type-stubs

### DIFF
--- a/etg/_core.py
+++ b/etg/_core.py
@@ -291,11 +291,16 @@ def run():
             """)
 
 
+    module.addPyCode('import typing', order=10)
     module.addPyCode("""\
-            _T = TypeVar('_T')
-            _P = ParamSpec('_P')
-    """)
-    module.addPyFunction('CallAfter', '(callableObj: Callable[_P, _T], *args: _P.args, **kw: _P.kwargs) -> None', doc="""\
+        _T = typing.TypeVar('_T')
+        try:
+            _P = typing.ParamSpec('_P')
+        except AttributeError:
+            import typing_extensions
+            _P = typing_extensions.ParamSpec('_P')
+        """)
+    module.addPyFunction('CallAfter', '(callableObj: typing.Callable[_P, _T], *args: _P.args, **kw: _P.kwargs) -> None', doc="""\
             Call the specified function after the current and pending event
             handlers have been completed.  This is also good for making GUI
             method calls from non-GUI threads.  Any extra positional or
@@ -326,7 +331,7 @@ def run():
             wx.PostEvent(app, evt)""")
 
 
-    module.addPyClass('CallLater', ['Generic[_P, _T]'],
+    module.addPyClass('CallLater', ['typing.Generic[_P, _T]'],
         doc="""\
             A convenience class for :class:`wx.Timer`, that calls the given callable
             object once after the given amount of milliseconds, passing any
@@ -346,7 +351,7 @@ def run():
             """,
         items = [
             PyCodeDef('__instances = {}'),
-            PyFunctionDef('__init__', '(self, millis, callableObj: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs) -> None',
+            PyFunctionDef('__init__', '(self, millis, callableObj: typing.Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs) -> None',
                 doc="""\
                     Constructs a new :class:`wx.CallLater` object.
 
@@ -370,7 +375,7 @@ def run():
 
             PyFunctionDef('__del__', '(self)', 'self.Stop()'),
 
-            PyFunctionDef('Start', '(self, millis: int | None=None, *args: _P.args, **kwargs: _P.kwargs) -> None',
+            PyFunctionDef('Start', '(self, millis: typing.Optional[int]=None, *args: _P.args, **kwargs: _P.kwargs) -> None',
                 doc="""\
                     (Re)start the timer
 

--- a/etg/_core.py
+++ b/etg/_core.py
@@ -291,7 +291,11 @@ def run():
             """)
 
 
-    module.addPyFunction('CallAfter', '(callableObj, *args, **kw)', doc="""\
+    module.addPyCode("""\
+            _T = TypeVar('_T')
+            _P = ParamSpec('_P')
+    """)
+    module.addPyFunction('CallAfter', '(callableObj: Callable[_P, _T], *args: _P.args, **kw: _P.kwargs) -> None', doc="""\
             Call the specified function after the current and pending event
             handlers have been completed.  This is also good for making GUI
             method calls from non-GUI threads.  Any extra positional or
@@ -322,7 +326,7 @@ def run():
             wx.PostEvent(app, evt)""")
 
 
-    module.addPyClass('CallLater', ['object'],
+    module.addPyClass('CallLater', ['Generic[_P, _T]'],
         doc="""\
             A convenience class for :class:`wx.Timer`, that calls the given callable
             object once after the given amount of milliseconds, passing any
@@ -342,7 +346,7 @@ def run():
             """,
         items = [
             PyCodeDef('__instances = {}'),
-            PyFunctionDef('__init__', '(self, millis, callableObj, *args, **kwargs)',
+            PyFunctionDef('__init__', '(self, millis, callableObj: Callable[_P, _T], *args: _P.args, **kwargs: _P.kwargs) -> None',
                 doc="""\
                     Constructs a new :class:`wx.CallLater` object.
 
@@ -366,7 +370,7 @@ def run():
 
             PyFunctionDef('__del__', '(self)', 'self.Stop()'),
 
-            PyFunctionDef('Start', '(self, millis=None, *args, **kwargs)',
+            PyFunctionDef('Start', '(self, millis: int | None=None, *args: _P.args, **kwargs: _P.kwargs) -> None',
                 doc="""\
                     (Re)start the timer
 
@@ -388,7 +392,7 @@ def run():
                     self.running = True"""),
             PyCodeDef('Restart = Start'),
 
-            PyFunctionDef('Stop', '(self)',
+            PyFunctionDef('Stop', '(self) -> None',
                 doc="Stop and destroy the timer.",
                 body="""\
                     if self in CallLater.__instances:
@@ -397,16 +401,16 @@ def run():
                         self.timer.Stop()
                         self.timer = None"""),
 
-            PyFunctionDef('GetInterval', '(self)', """\
+            PyFunctionDef('GetInterval', '(self) -> int', """\
                 if self.timer is not None:
                     return self.timer.GetInterval()
                 else:
                     return 0"""),
 
-            PyFunctionDef('IsRunning', '(self)',
+            PyFunctionDef('IsRunning', '(self) -> bool',
                 """return self.timer is not None and self.timer.IsRunning()"""),
 
-            PyFunctionDef('SetArgs', '(self, *args, **kwargs)',
+            PyFunctionDef('SetArgs', '(self, *args: _P.args, **kwargs: _P.kwargs) -> None',
                 doc="""\
                     (Re)set the args passed to the callable object.  This is
                     useful in conjunction with :meth:`Start` if
@@ -421,7 +425,7 @@ def run():
                     self.args = args
                     self.kwargs = kwargs"""),
 
-            PyFunctionDef('HasRun', '(self)', 'return self.hasRun',
+            PyFunctionDef('HasRun', '(self) -> bool', 'return self.hasRun',
                 doc="""\
                     Returns whether or not the callable has run.
 
@@ -429,7 +433,7 @@ def run():
 
                     """),
 
-            PyFunctionDef('GetResult', '(self)', 'return self.result',
+            PyFunctionDef('GetResult', '(self) -> _T', 'return self.result',
                 doc="""\
                     Returns the value of the callable.
 
@@ -437,7 +441,7 @@ def run():
                     :return: result from callable
                     """),
 
-            PyFunctionDef('Notify', '(self)',
+            PyFunctionDef('Notify', '(self) -> None',
                 doc="The timer has expired so call the callable.",
                 body="""\
                     if self.callable and getattr(self.callable, 'im_self', True):
@@ -456,7 +460,7 @@ def run():
     module.addPyCode("FutureCall = deprecated(CallLater, 'Use CallLater instead.')")
 
     module.addPyCode("""\
-        def GetDefaultPyEncoding():
+        def GetDefaultPyEncoding() -> str:
             return "utf-8"
         GetDefaultPyEncoding = deprecated(GetDefaultPyEncoding, msg="wxPython now always uses utf-8")
         """)

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -466,17 +466,10 @@ class FunctionDef(BaseDef, FixWxPrefix):
         TODO: Maybe (optionally) use this syntax to document arg types?
               http://www.python.org/dev/peps/pep-3107/
         """
-        def _cleanName(name):
-            for txt in ['const', '*', '&', ' ']:
-                name = name.replace(txt, '')
-            name = name.replace('::', '.')
-            name = self.fixWxPrefix(name, True)
-            return name
-
         params = list()
         returns = list()
         if self.type and self.type != 'void':
-            returns.append(_cleanName(self.type))
+            returns.append(self.cleanName(self.type))
 
         defValueMap = { 'true':  'True',
                         'false': 'False',
@@ -523,8 +516,8 @@ class FunctionDef(BaseDef, FixWxPrefix):
                         default = param.default
                         if default in defValueMap:
                             default = defValueMap.get(default)
-
-                        s += '=' + '|'.join([_cleanName(x) for x in default.split('|')])
+                        default = '|'.join([self.cleanName(x, True) for x in default.split('|')])
+                        s = f'{s}={default}'
                     params.append(s)
 
         self.pyArgsString = '(' + ', '.join(params) + ')'

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -498,7 +498,7 @@ class FunctionDef(BaseDef, FixWxPrefix):
                 arg, arg_type = self.parseNameAndType(arg, arg_type)
                 if arg_type:
                     if default == 'None':
-                        arg = f'{arg}: {arg_type} | None'
+                        arg = f'{arg}: Optional[{arg_type}]'
                     else:
                         arg = f'{arg}: {arg_type}'
                 if default:
@@ -519,16 +519,19 @@ class FunctionDef(BaseDef, FixWxPrefix):
                     if param.inOut:
                         if param_type:
                             returns.append(param_type)
-                    if param_type:
-                        s = f'{s}: {param_type}'
                     if param.default:
                         default = param.default
                         if default in defValueMap:
                             default = defValueMap.get(default)
-                        if param_type and default == 'None':
-                            s = f'{s} | None'
+                        if param_type:
+                            if default == 'None':
+                                s = f'{s}: Optional[{param_type}]'
+                            else:
+                                s = f'{s}: {param_type}'
                         default = '|'.join([self.cleanName(x, True) for x in default.split('|')])
                         s = f'{s}={default}'
+                    elif param_type:
+                        s = f'{s} : {param_type}'
                     params.append(s)
 
         self.pyArgsString = f"({', '.join(params)})"

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -466,7 +466,7 @@ class FunctionDef(BaseDef, FixWxPrefix):
         params = list()
         returns = list()
         if self.type and self.type != 'void':
-            returns.append(self.cleanName(self.type))
+            returns.append(self.cleanType(self.type))
 
         defValueMap = { 'true':  'True',
                         'false': 'False',

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -540,7 +540,7 @@ class FunctionDef(BaseDef, FixWxPrefix):
         elif len(returns) == 1:
             self.pyArgsString = f'{self.pyArgsString} -> {returns[0]}'
         elif len(returns) > 1:
-            self.pyArgsString = f"{self.pyArgsString} -> tuple[{', '.join(returns)}]"
+            self.pyArgsString = f"{self.pyArgsString} -> Tuple[{', '.join(returns)}]"
 
 
     def collectPySignatures(self):

--- a/etgtools/generators.py
+++ b/etgtools/generators.py
@@ -81,12 +81,15 @@ def nci(text, numSpaces=0, stripLeading=True):
     return newText
 
 
-def wrapText(text):
+def wrapText(text, dontWrap: str = ''):
     import textwrap
     lines = []
     tw = textwrap.TextWrapper(width=70, break_long_words=False)
     for line in text.split('\n'):
-        lines.append(tw.fill(line))
+        if dontWrap and line.lstrip().startswith(dontWrap):
+            lines.append(line)
+        else:
+            lines.append(tw.fill(line))
     return '\n'.join(lines)
 
 

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -236,22 +236,16 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
         if globalVar.ignored or piIgnored(globalVar):
             return
         name = globalVar.pyName or globalVar.name
+        valTyp = 'Any'
         if guessTypeInt(globalVar):
-            valTyp = '0'
+            valTyp = 'int'
         elif guessTypeFloat(globalVar):
-            valTyp = '0.0'
+            valTyp = 'float'
         elif guessTypeStr(globalVar):
-            valTyp = '""'
-        else:
-            valTyp = globalVar.type
-            valTyp = valTyp.replace('const ', '')
-            valTyp = valTyp.replace('*', '')
-            valTyp = valTyp.replace('&', '')
-            valTyp = valTyp.replace(' ', '')
-            valTyp = self.fixWxPrefix(valTyp)
-            valTyp += '()'
-
-        stream.write('%s = %s\n' % (name, valTyp))
+            valTyp = 'str'
+        elif globalVar.type:
+            valTyp = self.cleanType(globalVar.type) or valTyp
+        stream.write(f'{name}: {valTyp}\n')
 
     #-----------------------------------------------------------------------
     def generateDefine(self, define, stream):
@@ -259,10 +253,11 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
         if define.ignored or piIgnored(define):
             return
         # we're assuming that all #defines that are not ignored are integer or string values
+        name = define.pyName or define.name
         if '"' in define.value:
-            stream.write('%s = ""\n' % (define.pyName or define.name))
+            stream.write(f'{name}: str\n')
         else:
-            stream.write('%s = 0\n' % (define.pyName or define.name))
+            stream.write(f'{name}: int\n')
 
     #-----------------------------------------------------------------------
     def generateTypedef(self, typedef, stream, indent=''):

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -81,7 +81,7 @@ header_pyi = """\
 typing_imports = """\
 from __future__ import annotations
 from enum import IntEnum, IntFlag, auto
-from typing import (Any, overload, TypeAlias, TypeVar, ParamSpec, Generic,
+from typing import (Any, overload, TypeAlias, Generic,
     Union, Optional, List, Tuple, Callable
 )
 try:

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -84,6 +84,10 @@ from enum import IntEnum, IntFlag, auto
 from typing import (Any, overload, TypeAlias, TypeVar, ParamSpec, Generic,
     Union, Optional, List, Tuple, Callable
 )
+try:
+    from typing import ParamSpec
+except ImportError:
+    from typing_extensions import ParamSpec
 
 """
 

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -79,8 +79,9 @@ header_pyi = """\
 
 typing_imports = """\
 from __future__ import annotations
+from collections.abc import Callable
 from enum import IntEnum, IntFlag, auto
-from typing import Any, overload, TypeAlias
+from typing import Any, overload, TypeAlias, TypeVar, ParamSpec, Generic
 
 """
 
@@ -371,7 +372,7 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
         if pc.bases:
             stream.write('(%s):\n' % ', '.join(pc.bases))
         else:
-            stream.write('(object):\n')
+            stream.write(':\n')
         indent2 = indent + ' '*4
         if pc.briefDoc:
             stream.write('%s"""\n' % indent2)
@@ -465,8 +466,6 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
             bases = [self.fixWxPrefix(b, True) for b in bases]
             stream.write(', '.join(bases))
             stream.write(')')
-        else:
-            stream.write('(object)')
         stream.write(':\n')
         indent2 = indent + ' '*4
 

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -504,7 +504,12 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
         assert isinstance(memberVar, extractors.MemberVarDef)
         if memberVar.ignored or piIgnored(memberVar):
             return
-        stream.write('%s%s = property(None, None)\n' % (indent, memberVar.name))
+        member_type = memberVar.type
+        if member_type:
+            member_type = self.cleanType(member_type)
+        if not member_type: # Unknown type for the member variable
+            member_type = 'Any'
+        stream.write(f'{indent}{memberVar.name}: {member_type}\n')
 
 
     def generateProperty(self, prop, stream, indent):

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -82,7 +82,7 @@ typing_imports = """\
 from __future__ import annotations
 from collections.abc import Callable
 from enum import IntEnum, IntFlag, auto
-from typing import Any, overload, TypeAlias, TypeVar, ParamSpec, Generic, Union, Optional
+from typing import Any, overload, TypeAlias, TypeVar, ParamSpec, Generic, Union, Optional, List
 
 """
 

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -82,7 +82,7 @@ typing_imports = """\
 from __future__ import annotations
 from collections.abc import Callable
 from enum import IntEnum, IntFlag, auto
-from typing import Any, overload, TypeAlias, TypeVar, ParamSpec, Generic, Union, Optional, List
+from typing import Any, overload, TypeAlias, TypeVar, ParamSpec, Generic, Union, Optional, List, Tuple
 
 """
 

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -80,9 +80,10 @@ header_pyi = """\
 
 typing_imports = """\
 from __future__ import annotations
-from collections.abc import Callable
 from enum import IntEnum, IntFlag, auto
-from typing import Any, overload, TypeAlias, TypeVar, ParamSpec, Generic, Union, Optional, List, Tuple
+from typing import (Any, overload, TypeAlias, TypeVar, ParamSpec, Generic,
+    Union, Optional, List, Tuple, Callable
+)
 
 """
 

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -22,6 +22,7 @@ want to add some type info to that version of the file eventually...
 """
 
 import sys, os, re
+from typing import Union
 import etgtools.extractors as extractors
 import etgtools.generators as generators
 from etgtools.generators import nci, Utf8EncodingStream, textfile_open
@@ -81,7 +82,7 @@ typing_imports = """\
 from __future__ import annotations
 from collections.abc import Callable
 from enum import IntEnum, IntFlag, auto
-from typing import Any, overload, TypeAlias, TypeVar, ParamSpec, Generic
+from typing import Any, overload, TypeAlias, TypeVar, ParamSpec, Generic, Union, Optional
 
 """
 
@@ -250,7 +251,7 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
             stream.write(f'{indent}    {name} = auto()\n')
         # Create the alias if needed
         if alias:
-            stream.write(f'{indent}{alias}: TypeAlias = {enum_name} | int\n')
+            stream.write(f'{indent}{alias}: TypeAlias = Union[{enum_name}, int]\n')
         # And bring the enum members into global scope.  We can't use
         # enum.global_enum for this because:
         #  1. It's only available on Python 3.11+
@@ -547,7 +548,7 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
         assert isinstance(prop, extractors.PyPropertyDef)
         self._generateProperty(prop, stream, indent)
 
-    def _generateProperty(self, prop: extractors.PyPropertyDef | extractors.PropertyDef, stream, indent: str):
+    def _generateProperty(self, prop: Union[extractors.PyPropertyDef, extractors.PropertyDef], stream, indent: str):
         if prop.ignored or piIgnored(prop):
             return
         if prop.setter and prop.getter:

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -509,16 +509,22 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
 
     def generateProperty(self, prop, stream, indent):
         assert isinstance(prop, extractors.PropertyDef)
-        if prop.ignored or piIgnored(prop):
-            return
-        stream.write('%s%s = property(None, None)\n' % (indent, prop.name))
+        self._generateProperty(prop, stream, indent)
 
 
     def generatePyProperty(self, prop, stream, indent):
         assert isinstance(prop, extractors.PyPropertyDef)
+        self._generateProperty(prop, stream, indent)
+
+    def _generateProperty(self, prop: extractors.PyPropertyDef | extractors.PropertyDef, stream, indent: str):
         if prop.ignored or piIgnored(prop):
             return
-        stream.write('%s%s = property(None, None)\n' % (indent, prop.name))
+        if prop.setter and prop.getter:
+            stream.write(f'{indent}{prop.name} = property({prop.getter}, {prop.setter})\n')
+        elif prop.getter:
+            stream.write(f'{indent}{prop.name} = property({prop.getter})\n')
+        elif prop.setter:
+            stream.write(f'{indent}{prop.name} = property(fset={prop.setter})\n') 
 
 
     def generateMethod(self, method, stream, indent, name=None, docstring=None, is_overload=False):

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -380,9 +380,6 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
         argsString = function.pyArgsString
         if not argsString:
             argsString = '()'
-        if '->' in argsString:
-            pos = argsString.find(')')
-            argsString = argsString[:pos+1]
         if '(' != argsString[0]:
             pos = argsString.find('(')
             argsString = argsString[pos:]
@@ -552,9 +549,6 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
         argsString = method.pyArgsString
         if not argsString:
             argsString = '()'
-        if '->' in argsString:
-            pos = argsString.find(') ->')
-            argsString = argsString[:pos+1]
         if '(' != argsString[0]:
             pos = argsString.find('(')
             argsString = argsString[pos:]

--- a/etgtools/sip_generator.py
+++ b/etgtools/sip_generator.py
@@ -610,7 +610,7 @@ from .%s import *
 
         # get the docstring text
         text = nci(extractors.flattenNode(item.briefDoc, False))
-        text = wrapText(text)
+        text = wrapText(text, item.pyName or item.name)
 
 
         #if isinstance(item, extractors.ClassDef):

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -122,6 +122,9 @@ class FixWxPrefix(object):
                 names.append(item.name)
             elif isinstance(item, ast.FunctionDef):
                 names.append(item.name)
+            elif isinstance(item, ast.AnnAssign):
+                if isinstance(item.target, ast.Name):
+                    names.append(item.target.id)
 
         names = list()
         filename = 'wx/core.pyi'

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -19,6 +19,7 @@ import re
 import sys, os
 import copy
 import textwrap
+from typing import Union
 
 
 PY3 = sys.version_info[0] == 3
@@ -221,7 +222,7 @@ class FixWxPrefix(object):
                 return 'list'
         return type_map.get(type_name, type_name)
     
-    def parseNameAndType(self, name_string: str, type_string: str | None) -> tuple[str, str | None]:
+    def parseNameAndType(self, name_string: str, type_string: Union[str, None]) -> tuple[str, str | None]:
         """Given an identifier name and an optional type annotation, process
         these per cleanName and cleanType. Further performs transforms on the
         identifier name that may be required due to the type annotation.

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -19,7 +19,7 @@ import re
 import sys, os
 import copy
 import textwrap
-from typing import Union, Tuple
+from typing import Optional, Tuple
 
 
 PY3 = sys.version_info[0] == 3
@@ -222,7 +222,7 @@ class FixWxPrefix(object):
                 return 'list'
         return type_map.get(type_name, type_name)
     
-    def parseNameAndType(self, name_string: str, type_string: Union[str, None]) -> Tuple[str, str | None]:
+    def parseNameAndType(self, name_string: str, type_string: Optional[str]) -> Tuple[str, Optional[str]]:
         """Given an identifier name and an optional type annotation, process
         these per cleanName and cleanType. Further performs transforms on the
         identifier name that may be required due to the type annotation.

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -19,7 +19,7 @@ import re
 import sys, os
 import copy
 import textwrap
-from typing import Union
+from typing import Union, Tuple
 
 
 PY3 = sys.version_info[0] == 3
@@ -222,7 +222,7 @@ class FixWxPrefix(object):
                 return 'list'
         return type_map.get(type_name, type_name)
     
-    def parseNameAndType(self, name_string: str, type_string: Union[str, None]) -> tuple[str, str | None]:
+    def parseNameAndType(self, name_string: str, type_string: Union[str, None]) -> Tuple[str, str | None]:
         """Given an identifier name and an optional type annotation, process
         these per cleanName and cleanType. Further performs transforms on the
         identifier name that may be required due to the type annotation.

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -200,7 +200,7 @@ class FixWxPrefix(object):
             # --Others
             'PyObject': 'Any',
             'WindowID': 'int', # defined in wx/defs.h
-            # A few instances, for example in LogInfo:
+            'Coord': 'int', # defined in wx/types.h
         }
         type_name = self.cleanName(type_name)
         # Special handling of Vector<type> types -

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -141,7 +141,7 @@ class FixWxPrefix(object):
 
         FixWxPrefix._coreTopLevelNames = names
 
-    def cleanName(self, name: str, is_expression: bool = False) -> str:
+    def cleanName(self, name: str, is_expression: bool = False, fix_wx: bool = True) -> str:
         """Process a C++ name for use in Python code. In all cases, this means
         handling name collisions with Python keywords. For names that will be
         used for an identifier (ex: class, method, constant) - `is_expression`
@@ -161,7 +161,10 @@ class FixWxPrefix(object):
         if not (is_expression and name in ['True', 'False', 'None']) and keyword.iskeyword(name):
             name = f'_{name}' # Python keyword name collision
         name = name.strip()
-        return self.fixWxPrefix(name, True)
+        if fix_wx:
+            return self.fixWxPrefix(name, True)
+        else:
+            return removeWxPrefix(name)
 
     def cleanType(self, type_name: str) -> str:
         """Process a C++ type name for use as a type annotation in Python code.
@@ -225,7 +228,7 @@ class FixWxPrefix(object):
         Ex. The transformation "any_identifier : ..." -> "*args" requires
         modifying both the identifier name and the annotation.
         """
-        name_string = self.cleanName(name_string)
+        name_string = self.cleanName(name_string, fix_wx=False)
         if type_string:
             type_string = self.cleanType(type_string)
             if type_string == '...':

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -100,6 +100,7 @@ class FixWxPrefix(object):
         testName = name
         if '(' in name:
             testName = name[:name.find('(')]
+        testName = testName.split('.')[0]
 
         if testName in FixWxPrefix._coreTopLevelNames:
             return 'wx.'+name

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -199,6 +199,7 @@ class FixWxPrefix(object):
             'double': double_type,
             'Double': double_type,
             # --Others
+            'void': 'Any',
             'PyObject': 'Any',
             'WindowID': 'int', # defined in wx/defs.h
             'Coord': 'int', # defined in wx/types.h

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -14,6 +14,8 @@ stage of the ETG scripts.
 
 import etgtools as extractors
 from .generators import textfile_open
+import keyword
+import re
 import sys, os
 import copy
 import textwrap
@@ -135,7 +137,79 @@ class FixWxPrefix(object):
 
         FixWxPrefix._coreTopLevelNames = names
 
+    def cleanName(self, name: str, is_expression: bool = False) -> str:
+        """Process a C++ name for use in Python code. In all cases, this means
+        handling name collisions with Python keywords. For names that will be
+        used for an identifier (ex: class, method, constant) - `is_expression`
+        is False - this also includes the reserved constant names 'False',
+        'True', and 'None'.  When `is_expression` is True, name are allowed to
+        include special characters and the reserved constant names - this is
+        intended for cleaning up type-hint expressions ans default value
+        expressions.
 
+        Finally, the 'wx.' prefix is added if needed.
+        """
+        for txt in ['const', '*', '&', ' ']:
+            name = name.replace(txt, '')
+        name = name.replace('::', '.')
+        if not is_expression:
+            name = re.sub(r'[^a-zA-Z0-9_\.]', '', name)
+        if not (is_expression and name in ['True', 'False', 'None']) and keyword.iskeyword(name):
+            name = f'_{name}' # Python keyword name collision
+        name = name.strip()
+        return self.fixWxPrefix(name, True)
+
+    def cleanType(self, type_name: str) -> str:
+        """Process a C++ type name for use as a type annotation in Python code.
+        Handles translation of common C++ types to Python types, as well as a
+        few specific wx types to Python types.
+        """
+        double_type = 'float' if PY3 else 'double'
+        long_type = 'int' if PY3 else 'long'
+        type_map = {
+            # Some types are guesses, marked with TODO to verify automatic
+            # conversion actually happens.  Also, these are the type-names
+            # after processing by cleanName (so spaces are removed)
+            # --String types
+            'String': 'str',
+            'Char': 'str',
+            'char':' str',
+            'FileName': 'str', # TODO: check conversion
+            # --Int types
+            'byte': 'int',
+            'short': 'int',
+            'Int': 'int',
+            'unsigned': 'int',
+            'unsignedchar': 'int',
+            'unsignedshort': 'int',
+            'unsignedint': 'int',
+            'time_t': 'int',
+            'size_t': 'int',
+            'Int32': 'int',
+            'long': long_type,
+            'unsignedlong': long_type,
+            'ulong': long_type,
+            'LongLong': long_type,
+            # --Float types
+            'double': double_type,
+            'Double': double_type,
+            # --Others
+            'PyObject': 'Any',
+            'WindowID': 'int', # defined in wx/defs.h
+        }
+        type_name = self.cleanName(type_name)
+        # Special handling of Vector<type> types -
+        if type_name.startswith('Vector<') and type_name.endswith('>'):
+            # Special handling for 'Vector<type>' types
+            type_name = self.cleanName(type_name[7:-1])
+            return f'list[{type_name}]'
+        if type_name.startswith('Array'):
+            type_name = self.cleanName(type_name[5:])
+            if type_name:
+                return f'list[{type_name}]'
+            else:
+                return 'list'
+        return type_map.get(type_name, type_name)
 
 
 def ignoreAssignmentOperators(node):

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -213,11 +213,11 @@ class FixWxPrefix(object):
         if type_name.startswith('Vector<') and type_name.endswith('>'):
             # Special handling for 'Vector<type>' types
             type_name = self.cleanType(type_name[7:-1])
-            return f'list[{type_name}]'
+            return f'List[{type_name}]'
         if type_name.startswith('Array'):
             type_name = self.cleanType(type_name[5:])
             if type_name:
-                return f'list[{type_name}]'
+                return f'List[{type_name}]'
             else:
                 return 'list'
         return type_map.get(type_name, type_name)

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -22,3 +22,4 @@ markupsafe==1.1.1
 doc2dash==2.3.0
 beautifulsoup4
 attrdict3 ; sys_platform == 'win32'
+typing-extensions; python_version < '3.10'

--- a/requirements/install.txt
+++ b/requirements/install.txt
@@ -3,3 +3,4 @@ numpy < 1.17 ; python_version <= '2.7'
 numpy ; python_version >= '3.0' and python_version < '3.12'
 # pillow < 3.0
 six
+typing-extensions; python_version < '3.10'


### PR DESCRIPTION
The wxPython type-stubs are nice in that they expose what classes, methods, etc are available, but there is no type information in them (there's even a comment in `makePyArgsString` referencing implementing this).  This is my 90% of the way there implementation of exposing this type information to the type-stubs.

I also didn't find any open issues regarding type-stubs, so I haven't linked an issue.

For the most part, all of the type-information was already there in the doxygen files, it just had to be pulled into the args strings. There are a few exceptions, mostly revolving around types that are C++ typedefs (ex: WindowID and Coord).

By using `from __future__ import annotations`, all of the type-hints are stringized, so even in the cases where the name referenced is undefined (ex: richtext's TextAttrDimensionFlags), the type-stub files are still valid.  The hints in those cases will just provide no information.

I do have a few discussion points to probably resolve before this is truly ready though:
- From what I can tell by the buildbot output, we build as low as Python 3.6. So I'm assuming any new code doesn't need to be compatible with earlier versions, is this a good assumption?
- How to handle `typing.ParamSpec`: related to the above, ParamSpec was added in Python 3.10. Currently it's only used to type-hint `CallAfter` and `CallLater`, how would you like this import handled:
  - If you're OK with a new dependency [typing-extensions](https://pypi.org/project/typing-extensions/) could be added for Python versions < 3.10, then import from there.
  - I can skip out on typing CallAfter and CallLater, although if other methods come up in the future that would benifit from this sort of typing, we run into the issue again.
- Code style - I tried to keep with the same code style in surrouding areas but I probably named a few variables differently at some point. I also used f-strings since those are in Python 3.6+.  I can go back and use Python 2 style formatting strings if that's what's wanted however.
- There are still some typedef types that aren't covered.  I could dig through and find every instance in the PYI files where a type is referenced that's undefined, but that may end up with a lot of hard-coded conversions (usually to int) in the type-name fixup code. Let me know of any changes there I need to make.
- I have no knowledge of PI files (WingIDE files according to the header), do these changes break those?
- My choice of how to handle C++ `enum`s. I went the route of using the stdlib's `enum.IntEnum` and `enum.IntFlag` here.  My reasoning is - they're still typed as `int`s this way (so compatible), and I define the enums with a prefixed `_` so the type-stubs don't expose them as some sort of real type that is actually accessible in actual wxPython code. I then make a TypeAlias for the name that includes the enum values or an int, so type-checkers won't complain to users that pass raw ints into methods typed with these enums.  The enum then basically serves the purpose of grouping various values together and signaling the the callers which of the named values are expected at the call sites.  I can go back to having enums just being typed as plain old `int`, but I feel we lose the information of "what enum value or flags *should* you be using here".

I also just realized while writing this that subscripting `list` and unions with `|` weren't added until Python 3.9 and 3.10, respectively, so some for me:
- [x] Replace `list[...]` with `List[...]` and import `List` from `typing`.
- [x] Replace `X | Y` with `Union[X, Y]` and import `Union` from `typing`.
- [x] Replace `tuple[...]` with `Tuple[...]` and import `Tuple` from `typing`.
- [x] Replace `from collections.abc import Callable` with `from typing import Callable` - subscripting was introduced in Python 3.10