### PR TITLE
Update typo in persist_handlers.py

### DIFF
--- a/wx/lib/agw/persist/persist_handlers.py
+++ b/wx/lib/agw/persist/persist_handlers.py
@@ -1335,7 +1335,7 @@ class TreeCtrlHandler(AbstractHandler):
         if not root:
             return []
         if self._window.HasFlag(wx.TR_HIDE_ROOT):
-            return self.GeSelectionStateOfChildren(root)
+            return self.GetSelectionStateOfChildren(root)
         else:
             return self.GetSelectionStateOfItem(root)
 


### PR DESCRIPTION
This should fix a typo in the return statement.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #2376 

