### PR TITLE
Bugfix. Explicitly convert float to int when calling to wx.Size in pdfviewer

### DIFF
--- a/wx/lib/pdfviewer/viewer.py
+++ b/wx/lib/pdfviewer/viewer.py
@@ -1077,7 +1077,7 @@ class pdfPrintout(wx.Printout):
         pageno = page - 1       # zero based
         width = self.view.pagewidth
         height = self.view.pageheight
-        self.FitThisSizeToPage(wx.Size(width*sfac, height*sfac))
+        self.FitThisSizeToPage(wx.Size(int(width*sfac), int(height*sfac)))
         dc = self.GetDC()
         gc = wx.GraphicsContext.Create(dc)
         if not mupdf:


### PR DESCRIPTION
From Python 3.10 onwards implicit conversion with loss from a float to an int does not happen. (https://bugs.python.org/issue37999)

This means these conversions have to be made explicit in Python code. In particular the constructor to `wx.Size` requires ints. This has introduced a regression:

```
2023-10-27 18:25:54 ERROR [wx.lib.pdfviewer.viewer]: An unexpected error occurred in wx.lib.pdfviewer.viewer. 
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/wx/lib/pdfviewer/viewer.py", line 1080, in OnPrintPage
    self.FitThisSizeToPage(wx.Size(width*sfac, height*sfac))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Size(): arguments did not match any overloaded call:
  overload 1: too many arguments
  overload 2: argument 1 has unexpected type 'float'
  overload 3: argument 1 has unexpected type 'float'
```

This PR fixes the problem by explicitly converting the arguments to `int`.
