### PR TITLE
Bugfix in pure python aui: Early return from method if underlying C++ object has been destroyed

### DIFF
--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -2457,7 +2457,8 @@ class AuiTabCtrl(wx.Control, AuiTabContainer):
 
         :rtype: :class:`wx.Window`.
         """
-
+        if not self:
+            return None # The AuiTabCtrl has already been destroyed
         screen_pt = wx.GetMousePosition()
         client_pt = self.ScreenToClient(screen_pt)
         return self.TabHitTest(client_pt.x, client_pt.y)


### PR DESCRIPTION
When the application is in the process of changing the aui layout programmatically (e.g. by loading a perspective) it is possible to click on a notebook pane that is in the process of being destroyed. This results in the error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/dist-packages/wx/core.py", line 2346, in Notify
    self.notify()
  File "/usr/local/lib/python3.11/dist-packages/wx/core.py", line 3552, in Notify
    self.result = self.callable(*self.args, **self.kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/wx/lib/agw/aui/auibook.py", line 2504, in ShowTooltip
    wnd = self.GetPointedToTab()
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/wx/lib/agw/aui/auibook.py", line 2462, in GetPointedToTab
    client_pt = self.ScreenToClient(screen_pt)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
RuntimeError: wrapped C/C++ object of type AuiTabCtrl has been deleted
```

This PR fixes the bug in the conventional way: By testing for `self` _truthiness_. and returning early without invoking any member methods if it is `False`.