### PR TITLE
Use unwrap before isbuiltin check

### DIFF
--- a/wx/py/introspect.py
+++ b/wx/py/introspect.py
@@ -171,6 +171,7 @@ def getCallTip(command='', locals=None):
         pass
     tip1 = ''
     argspec = ''
+    obj = inspect.unwrap(obj)
     if inspect.isbuiltin(obj):
         # Builtin functions don't have an argspec that we can get.
         pass


### PR DESCRIPTION
`inspect.isbuiltin` does not unwrap obj, but `inspect.signature` does, which can result in a ValueError.
So, added `inspect.unwrap` just before `inspect.isbuiltin`.

Fixes #2484 

