### PR TITLE
wx.agw.aui. Do layout as the last step after all pane infos have recomputed their best sizes

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -6218,12 +6218,6 @@ class AuiManager(wx.EvtHandler):
         if not self._masterManager:
             self.UpdateNotebook()
 
-        # delete old sizer first
-        self._frame.SetSizer(None)
-
-        # create a layout for all of the panes
-        sizer = self.LayoutAll(self._panes, self._docks, self._uiparts, False)
-
         # hide or show panes as necessary,
         # and float panes as necessary
 
@@ -6322,6 +6316,12 @@ class AuiManager(wx.EvtHandler):
                 r = p.rect
 
             old_pane_rects.append(r)
+            
+        # delete old sizer first
+        self._frame.SetSizer(None)
+
+        # create a layout for all of the panes
+        sizer = self.LayoutAll(self._panes, self._docks, self._uiparts, False)
 
         # apply the new sizer
         self._frame.SetSizer(sizer)


### PR DESCRIPTION
In python only aui, the layout of the docks and panes should be the last step of the update, after all panes have recomputed their best sizes.
