### PR TITLE
wx.agw.aui: Make behavior in all platforms more equal

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -6141,11 +6141,8 @@ class AuiManager(wx.EvtHandler):
         return self._dock_constraint_x, self._dock_constraint_y
 
     def Update(self):
-        if '__WXGTK__' in wx.PlatformInfo:
-            wx.CallAfter(self.DoUpdate)
-        else:
-            self.DoUpdate()
-
+        wx.CallAfter(self.DoUpdate)
+        
     def DoUpdateEvt(self, evt):
         self.Unbind(wx.EVT_WINDOW_CREATE)
         wx.CallAfter(self.DoUpdate)


### PR DESCRIPTION
This is a very small PR. It removes an unnecessary `if '__WXGTK__' in wx.PlatformInfo:` Removing it makes the code base two lines smaller, as well as make the behavior in different platforms more equal in some corner cases.

Remark that the change is to _defer_ the actual update (DoUpdate) in all platforms, as it is currently done in GTK. This makes sense as `Update` is called internally by various functions inside framemanager and not all resizing of components may have taken place when it is called.

The following images show one such corner case when this deferral makes the different between incorrect and correct layout. In particular when aui panes have callbacks that impact dock sizes when they are added programmatically to a notebook so that the dock becomes taller to make room for the tabs in the notebook. (The patient data shows is *not* from an actual patient.)

### GTK (same, correct, behavior before and after the proposed change)
![image](https://github.com/wxWidgets/Phoenix/assets/23492126/8724866f-ca19-48b6-bf89-79e0a279e9b8)

### MSW (incorrect behavior before the change. Notice how the patient data is cut because the dock tabs take space)
![image](https://github.com/wxWidgets/Phoenix/assets/23492126/0ff070cb-28a9-47f5-b26e-7f9a4b49c519)

### MSW (correct behavior after the change)
![image](https://github.com/wxWidgets/Phoenix/assets/23492126/0bcf7e81-ce84-429a-925a-0fc4d0374525)


