### PR TITLE
Fix additional SyntaxWarnings with Python 3.12

### DIFF
--- a/wx/lib/docview.py
+++ b/wx/lib/docview.py
@@ -1023,7 +1023,7 @@ class DocTemplate(wx.Object):
 
 
     def __init__(self, manager, description, filter, dir, ext, docTypeName, viewTypeName, docType, viewType, flags=DEFAULT_TEMPLATE_FLAGS, icon=None):
-        """
+        r"""
         Constructor. Create instances dynamically near the start of your
         application after creating a wxDocManager instance, and before doing
         any document or view operations.

--- a/wx/lib/layoutf.py
+++ b/wx/lib/layoutf.py
@@ -132,8 +132,8 @@ class Layoutf(wx.LayoutConstraints):
              'r': 'wx.Right', 'h': 'wx.Height', 'w': 'wx.Width',
              'x': 'wx.CentreX', 'y': 'wx.CentreY' }
 
-    rexp1 = re.compile('^\s*([tlrbhwxy])\s*([!\?\*])\s*(\d*)\s*$')
-    rexp2 = re.compile('^\s*([tlrbhwxy])\s*([=%<>^_])\s*([tlrbhwxy]?)\s*(\d*)\s*#(\d+)\s*$')
+    rexp1 = re.compile(r'^\s*([tlrbhwxy])\s*([!\?\*])\s*(\d*)\s*$')
+    rexp2 = re.compile(r'^\s*([tlrbhwxy])\s*([=%<>^_])\s*([tlrbhwxy]?)\s*(\d*)\s*#(\d+)\s*$')
 
     def __init__(self,pstr=None,winlist=None):
         wx.LayoutConstraints.__init__(self)

--- a/wx/lib/wxpTag.py
+++ b/wx/lib/wxpTag.py
@@ -14,7 +14,7 @@
 # o Updated for V2.5 compatibility
 #
 
-'''
+r'''
 wx.lib.wxpTag
 
 This module contains a wxHtmlTagHandler that knows how to build

--- a/wx/tools/pywxrc.py
+++ b/wx/tools/pywxrc.py
@@ -521,7 +521,7 @@ class XmlResourceCompiler:
         # Generate subclasses
         for subclass in subclasses:
             windowClass = bases[subclass]
-            subclass = re.sub("^\S+\.", "", subclass)
+            subclass = re.sub(r"^\S+\.", "", subclass)
             windowClass = re.sub("^wx", "", windowClass)
             outputList.append(self.templates.SUBCLASS_HEADER % locals())
             outputList.append('\n')
@@ -760,7 +760,7 @@ class XmlResourceCompiler:
     #-------------------------------------------------------------------
 
     def ConvertText(self, st):
-        """
+        r"""
         Encode special characters as escaped C/Python string characters.
 
             \n => \\n


### PR DESCRIPTION
It seems that Python 3.12 has started emitting additional SyntaxWarnings in cases where there are backslashes used in strings, so change these strings to raw strings to avoid the warnings.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #NNNN

