### PR TITLE
TST: Integer division for randint() in makeRandomRectangles()

### DIFF
--- a/unittests/test_dcDrawLists.py
+++ b/unittests/test_dcDrawLists.py
@@ -63,8 +63,8 @@ def makeRandomRectangles():
     rects = []
 
     for i in range(num):
-        W = random.randint(10, w/2)
-        H = random.randint(10, h/2)
+        W = random.randint(10, w//2)
+        H = random.randint(10, h//2)
         x = random.randint(0, w - W)
         y = random.randint(0, h - H)
         rects.append( (x, y, W, H) )


### PR DESCRIPTION
Python 3.12 does not accept floats for random.randint() anymore. Use integer division instead.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #2507

