### PR TITLE
Fixes DeleteButton function

### DIFF
--- a/wx/lib/agw/ribbon/buttonbar.py
+++ b/wx/lib/agw/ribbon/buttonbar.py
@@ -608,10 +608,10 @@ class RibbonButtonBar(RibbonControl):
         :see: :meth:`~RibbonButtonBar.ClearButtons`
         """
 
-        for button in self._buttons:
+        for i, button in enumerate(self._buttons):
             if button.id == button_id:
                 self._layouts_valid = False
-                self._buttons.pop(button)
+                self._buttons.pop(i)
                 self.Realize()
                 self.Refresh()
                 return True


### PR DESCRIPTION
Fixes the error when calling the DeleteButton of a RibbonButtonBar

```
File "..../python3.9/site-packages/wx/lib/agw/ribbon/buttonbar.py", line 614, in DeleteButton
    self._buttons.pop(button)
TypeError: 'RibbonButtonBarButtonBase' object cannot be interpreted as an integer
```


Fixes #2511

