### PR TITLE
add CreateAccessible and GetOrCreateAccessible

### DIFF
--- a/etg/window.py
+++ b/etg/window.py
@@ -259,6 +259,21 @@ def run():
             wxPyRaiseNotImplemented();
         #endif
         """)
+    c.find('CreateAccessible').setCppCode("""\
+        #if wxUSE_ACCESSIBILITY
+            //wxAccessible* acc = self->CreateAccessible();
+            return self->CreateAccessible();
+        #else
+            wxPyRaiseNotImplemented();
+        #endif
+        """)
+    c.find('GetOrCreateAccessible').setCppCode("""\
+        #if wxUSE_ACCESSIBILITY
+            return self->GetOrCreateAccessible();
+        #else
+            wxPyRaiseNotImplemented();
+        #endif
+        """)
 
     # Make some of the protected methods visible and overridable from Python
     c.find('SendDestroyEvent').ignore(False)

--- a/etg/window.py
+++ b/etg/window.py
@@ -259,9 +259,9 @@ def run():
             wxPyRaiseNotImplemented();
         #endif
         """)
+    c.find('CreateAccessible').factory = True
     c.find('CreateAccessible').setCppCode("""\
         #if wxUSE_ACCESSIBILITY
-            //wxAccessible* acc = self->CreateAccessible();
             return self->CreateAccessible();
         #else
             wxPyRaiseNotImplemented();

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -479,6 +479,7 @@ def addWindowVirtuals(klass):
         ('SetValidator',             'void SetValidator( const wxValidator &validator )'),
         ('GetValidator',             'wxValidator* GetValidator()'),
         ('EnableVisibleFocus',       'void EnableVisibleFocus(bool enabled)'),
+        ('CreateAccessible',         'wxAccessible* CreateAccessible()'),
 
         ## What about these?
         #bool HasMultiplePages() const


### PR DESCRIPTION
This PR improves accessibility support on Windows, once `ext/wxwidgets` is updated to a version after January 11.
( after commit https://github.com/wxWidgets/wxWidgets/commit/bd899c667129a13e265335638a9ddd81e3f8b75e "Add missing documentation of wxWindow accessibility functions" )

This PR adds support for `CreateAccessible`, allowing on-demand creation of custom accessibility support.
(At the moment, if a widget needs customized support, a `wx.Accessible` instance needs to be assigned in advance to a widget using `SetAccessible`.)


The PR is not complete yet.
I'm posting it already, because I need help.
The remaining problem is that `CreateAccessible` in a derived class needs to keep a reference to its return value.

E.g. this code will fail with an address exception if `self._acc = ret = MyAcc(self)` is replaced with `ret = MyAcc(self)`
```
class MyAcc(wx.Accessible): # you must be on Windows to test this
    def GetName(self, childid):
        return (wx.ACC_OK, 'My Name')
    def GetDescription(self, childid):
        return (wx.ACC_OK, 'My Description')
    def GetValue(self, childid):
        return (wx.ACC_OK, 'My Value')

class MyAccessibleTextCtrl(wx.TextCtrl):
    def CreateAccessible(self):
        # which each window can override to create a new wxAccessible-derived object.
        self._acc = ret = MyAcc(self)  # reference needs to be kept
        return ret
```

I tried adding a SIP annotation `/KeepReference/` manually to `sip/gen/window.sip`:
```
    wxAccessible * CreateAccessible() /KeepReference/ ;
```
This did not help, though. The code that actually keeps the reference is not called.