### PR TITLE
Add support for ULC_AUTO_CHECK_PARENT

### DIFF
--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -9025,6 +9025,16 @@ class UltimateListMainWindow(wx.ScrolledWindow):
         self.SetItem(item)
         self.RefreshLine(item._itemId)
 
+        if self.HasAGWFlag(ULC_AUTO_CHECK_PARENT) and\
+                item.GetKind() == 1:        # check box like item
+            col = item.GetColumn()
+            info = self.GetColumn(col)
+            if self.GetCheckedItemCount(col) == self.GetItemCount():
+                info.Check(True)
+            else:
+                info.Check(False)
+            self.SetColumn(col, info)
+
         if not sendEvent:
             return
 


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #2516

This PR implements the fix proposed in #2516 to add support for the ULC_AUTO_CHECK_PARENT style of the UltimateListCtrl.

The following code can be used to test the fix:

```
import wx
import wx.lib.agw.ultimatelistctrl as ULC

class MyFrame(wx.Frame):
    def __init__(self, parent):
        wx.Frame.__init__(self, parent)
        agw_style = (wx.LC_REPORT | wx.LC_VRULES | wx.LC_HRULES | wx.LC_SINGLE_SEL |
                     ULC.ULC_AUTO_CHECK_CHILD | ULC.ULC_AUTO_CHECK_PARENT)
        self.ulc = ULC.UltimateListCtrl(self, -1, agwStyle=agw_style, size=(640, 480))
        self.populateList()


    def populateList(self):
        info = ULC.UltimateListItem()
        info._mask = wx.LIST_MASK_TEXT | wx.LIST_MASK_FORMAT | ULC.ULC_MASK_WIDTH | ULC.ULC_MASK_CHECK
        info._format = 0
        info._kind = 1
        info._text = "Column 0"
        info._width = 120
        self.ulc.InsertColumnInfo(0, info)
        info = ULC.UltimateListItem()
        info._mask = wx.LIST_MASK_TEXT | wx.LIST_MASK_FORMAT | ULC.ULC_MASK_WIDTH | ULC.ULC_MASK_CHECK
        info._format = 0
        info._kind = 1
        info._text = "Column 1"
        info._width = 120
        self.ulc.InsertColumnInfo(1, info)
        for r in range(8):
            label = f"Col 0, Item {r}"
            self.ulc.InsertStringItem(r, label, it_kind=1)
            label = f"Col 1, Item {r}"
            self.ulc.SetStringItem(r, 1, label, it_kind=1)


if __name__ == '__main__':
    app = wx.App()
    frame = MyFrame(None)
    frame.Show()
    app.MainLoop()
```

