### PR TITLE
speedmeter.py lost background color

### DIFF
--- a/wx/lib/agw/speedmeter.py
+++ b/wx/lib/agw/speedmeter.py
@@ -840,7 +840,7 @@ class SpeedMeter(BufferedWindow):
             interface = 0
 
             for ind in range(numsteps+1):
-                currCol = (r1 + int(rf), g1 +int(gf), b1 +int(bf))
+                currCol = (int(r1 + rf), int(g1 + gf), int(b1 + bf))
                 dc.SetBrush(wx.Brush(currCol))
 
                 gradradius = flrect - radiusteps*ind

--- a/wx/lib/agw/speedmeter.py
+++ b/wx/lib/agw/speedmeter.py
@@ -840,7 +840,7 @@ class SpeedMeter(BufferedWindow):
             interface = 0
 
             for ind in range(numsteps+1):
-                currCol = (r1 + rf, g1 + gf, b1 + bf)
+                currCol = (r1 + int(rf), g1 +int(gf), b1 +int(bf))
                 dc.SetBrush(wx.Brush(currCol))
 
                 gradradius = flrect - radiusteps*ind


### PR DESCRIPTION
Missing typcasts make the background of the speedmeter white
This problem seems to appear since python 3.10 on windows, linux, raspian ... After  this change it works. please look in the other instruments for similar mistakes, please. 
