### PR TITLE
Add Wayland support for Window.GetHandle

### DIFF
--- a/etg/window.py
+++ b/etg/window.py
@@ -136,6 +136,16 @@ def run():
     m1.find('externalLeading').out = True
 
     c.find('GetHandle').type = 'wxUIntPtr*'
+    c.find('GetHandle').detailedDoc = [
+        """The returned value differs from the C++ version of GetHandle when \
+        running on the GTK port. When running on Wayland with GTK, this \
+        function returns a `wl_surface` pointer for the native OS window \
+        containing the widget. On X11 with GTK, this returns the X window \
+        ID for the containing window. On any other backend with GTK, this \
+        function returns 0.\n\n"""
+
+        """On some platforms this may return 0 if the window has not yet been shown."""
+    ]
     c.find('GetHandle').setCppCode("return new wxUIntPtr(wxPyGetWinHandle(self));")
 
     c.addCppMethod('void*', 'GetGtkWidget', '()', """\

--- a/src/window_ex.cpp
+++ b/src/window_ex.cpp
@@ -1,32 +1,15 @@
-
-#ifdef __WXMSW__
-#include <wx/msw/private.h>
-#endif
-
 #ifdef __WXGTK__
-#include <gdk/gdkx.h>
+#include <gdk/gdk.h>
 #include <gtk/gtk.h>
-#ifdef __WXGTK3__
-// Unlike GDK_WINDOW_XWINDOW, GDK_WINDOW_XID can't handle a NULL, so check 1st
-static XID GetXWindow(const wxWindow* wxwin) {
-    if ((wxwin)->m_wxwindow) {
-        if (gtk_widget_get_window((wxwin)->m_wxwindow))
-            return GDK_WINDOW_XID(gtk_widget_get_window((wxwin)->m_wxwindow));
-        return 0;
-    }
-    else {
-        if (gtk_widget_get_window((wxwin)->m_widget))
-            return GDK_WINDOW_XID(gtk_widget_get_window((wxwin)->m_widget));
-        return 0;
-    }
-}
-#else
-#define GetXWindow(wxwin) (wxwin)->m_wxwindow ? \
-                          GDK_WINDOW_XWINDOW((wxwin)->m_wxwindow->window) : \
-                          GDK_WINDOW_XWINDOW((wxwin)->m_widget->window)
+
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
 #endif
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
 #endif
 
+#endif // ifdef __WXGTK__
 
 
 
@@ -36,11 +19,40 @@ wxUIntPtr wxPyGetWinHandle(const wxWindow* win)
 #ifdef __WXMSW__
     return (wxUIntPtr)win->GetHandle();
 #endif
-#if defined(__WXGTK__) || defined(__WXX11__)
-    return (wxUIntPtr)GetXWindow(win);
+
+#ifdef __WXX11__
+    return (wxUIntPtr)win->GetHandle();
 #endif
+
 #ifdef __WXMAC__
     return (wxUIntPtr)win->GetHandle();
 #endif
+
+#ifdef __WXGTK__
+    GtkWidget *gtk_widget = win->GetHandle();
+    if (!gtk_widget) {
+        return 0;
+    };
+    // gtk_widget_get_window disappears in GTK4; then it will be via
+    // gtk_widget_get_native() -> gtk_native_get_surface().
+    GdkWindow *window = gtk_widget_get_window(gtk_widget);
+    if (!window) {
+        return 0;
+    }
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_WINDOW(window)) {
+        return (wxUIntPtr)gdk_x11_window_get_xid(window);
+    }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_WINDOW(window)) {
+        return (wxUIntPtr)gdk_wayland_window_get_wl_surface(window);
+    }
+#endif
+    // Returning 0 on any other backend using GTK.
+    // This is less confusing than returning something else that might
+    // mismatch C++ GetHandle.
+#endif
+
     return 0;
 }


### PR DESCRIPTION
Fixes #1217

This PR adds support for getting a `wl_surface` from Window.GetHandle when running on GTK+Wayland. This patch was originally more complicated by trying to support all the GTK windowing backends. Now, any GTK backend besides X11 or Wayland will return 0. This is less confusing than trying to figure out and match the return type of C++ GetHandle on Windows/Mac/etc in the unlikely case someone uses the GTK port on those platforms. This maintains backwards compatibility because up to now, GetHandle failed and returned 0 on any non-X11 GTK backend.

I tested on Wayland and X11 on current Arch with Python 3.12. Both work (at least, return a nonzero number) as long as you call `frame.Show()` before calling `frame.GetHandle()`. Also confirmed ARM Mac without GTK hasn't broken. I was not able to test Windows.

Suggestions welcome!