### PR TITLE
Add new Window.GetHandleType method

### DIFF
--- a/etg/window.py
+++ b/etg/window.py
@@ -148,6 +148,12 @@ def run():
     ]
     c.find('GetHandle').setCppCode("return new wxUIntPtr(wxPyGetWinHandle(self));")
 
+    c.addCppMethod('wxString', 'GetHandleType', '()',
+        doc="Returns a string identifying the type of OS window returned by :meth:`GetHandle`.\n\n"
+            "The value will be one of 'Windows', 'Mac', 'X11', or 'Wayland', "
+            "or an empty string if the backend is unknown.",
+        body="return new wxString(wxPyGetWinHandleType(self), wxConvUTF8);")
+
     c.addCppMethod('void*', 'GetGtkWidget', '()', """\
     #ifdef __WXGTK__
         return (void*)self->GetHandle();
@@ -342,6 +348,7 @@ def run():
     c.addProperty('GrandParent GetGrandParent')
     c.addProperty('TopLevelParent GetTopLevelParent')
     c.addProperty('Handle GetHandle')
+    c.addProperty('HandleType GetHandleType')
     c.addProperty('HelpText GetHelpText SetHelpText')
     c.addProperty('Id GetId SetId')
     c.addProperty('Label GetLabel SetLabel')

--- a/etg/window.py
+++ b/etg/window.py
@@ -136,6 +136,16 @@ def run():
     m1.find('externalLeading').out = True
 
     c.find('GetHandle').type = 'wxUIntPtr*'
+    c.find('GetHandle').detailedDoc = [
+        """The returned value is the platform-defined handle for the native \
+        window containing the widget. On Windows this is an HWND, on X11 it \
+        is the X window ID, on Wayland it is a wl_surface, etc.\n\n"""
+
+        """Note this differs from the C++ version of GetHandle which \
+        returns a GtkWidget if the GTK backend is in use.\n\n"""
+
+        """On some platforms this may return 0 if the window has not yet been shown."""
+    ]
     c.find('GetHandle').setCppCode("return new wxUIntPtr(wxPyGetWinHandle(self));")
 
     c.addCppMethod('void*', 'GetGtkWidget', '()', """\

--- a/src/window_ex.cpp
+++ b/src/window_ex.cpp
@@ -70,3 +70,75 @@ wxUIntPtr wxPyGetWinHandle(const wxWindow* win)
 
     return 0;
 }
+
+enum HandleType {
+    HANDLE_TYPE_UNKNOWN = 0,
+    HANDLE_TYPE_MSW,
+    HANDLE_TYPE_MAC,
+    HANDLE_TYPE_X11,
+    HANDLE_TYPE_WAYLAND,
+};
+
+static HandleType GetHandleType(const wxWindow *win) {
+#ifdef __WXMSW__
+    return HANDLE_TYPE_MSW;
+#endif
+
+#ifdef __WXX11__
+    return HANDLE_TYPE_X11;
+#endif
+
+#ifdef __WXMAC__
+    return HANDLE_TYPE_MAC;
+#endif
+
+#ifdef __WXGTK__
+    GtkWidget *gtk_widget = win->GetHandle();
+    if (!gtk_widget) {
+        return HANDLE_TYPE_UNKNWON;
+    };
+    // gtk_widget_get_window disappears in GTK4; then it will be via
+    // gtk_widget_get_native() -> gtk_native_get_surface().
+    GdkWindow *window = gtk_widget_get_window(gtk_widget);
+    if (!window) {
+        return HANDLE_TYPE_UNKNWON;
+    }
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_WINDOW(window)) {
+        return HANDLE_TYPE_X11;
+    }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_WINDOW(window)) {
+        return HANDLE_TYPE_WAYLAND;
+    }
+#endif
+#ifdef GDK_WINDOWING_WIN32
+    if (GDK_IS_WIN32_WINDOW(window)) {
+        return HANDLE_TYPE_MSW;
+    }
+#endif
+#ifdef GDK_WINDOWING_QUARTZ
+    if (GDK_IS_QUARTZ_WINDOW(window)) {
+        return HANDLE_TYPE_MAC;
+    }
+#endif
+#endif
+
+    return HANDLE_TYPE_UNKNOWN;
+}
+
+const char * wxPyGetWinHandleType(const wxWindow* win) {
+    switch (GetHandleType(win)) {
+        case HANDLE_TYPE_MSW:
+            return "Windows";
+        case HANDLE_TYPE_MAC:
+            return "Mac";
+        case HANDLE_TYPE_X11:
+            return "X11";
+        case HANDLE_TYPE_WAYLAND:
+            return "Wayland";
+        default:
+            return "";
+    }
+}

--- a/src/window_ex.cpp
+++ b/src/window_ex.cpp
@@ -95,13 +95,13 @@ static HandleType GetHandleType(const wxWindow *win) {
 #ifdef __WXGTK__
     GtkWidget *gtk_widget = win->GetHandle();
     if (!gtk_widget) {
-        return HANDLE_TYPE_UNKNWON;
+        return HANDLE_TYPE_UNKNOWN;
     };
     // gtk_widget_get_window disappears in GTK4; then it will be via
     // gtk_widget_get_native() -> gtk_native_get_surface().
     GdkWindow *window = gtk_widget_get_window(gtk_widget);
     if (!window) {
-        return HANDLE_TYPE_UNKNWON;
+        return HANDLE_TYPE_UNKNOWN;
     }
 #ifdef GDK_WINDOWING_X11
     if (GDK_IS_X11_WINDOW(window)) {

--- a/src/window_ex.cpp
+++ b/src/window_ex.cpp
@@ -1,32 +1,22 @@
-
-#ifdef __WXMSW__
-#include <wx/msw/private.h>
-#endif
-
 #ifdef __WXGTK__
-#include <gdk/gdkx.h>
+#include <gdk/gdk.h>
 #include <gtk/gtk.h>
-#ifdef __WXGTK3__
-// Unlike GDK_WINDOW_XWINDOW, GDK_WINDOW_XID can't handle a NULL, so check 1st
-static XID GetXWindow(const wxWindow* wxwin) {
-    if ((wxwin)->m_wxwindow) {
-        if (gtk_widget_get_window((wxwin)->m_wxwindow))
-            return GDK_WINDOW_XID(gtk_widget_get_window((wxwin)->m_wxwindow));
-        return 0;
-    }
-    else {
-        if (gtk_widget_get_window((wxwin)->m_widget))
-            return GDK_WINDOW_XID(gtk_widget_get_window((wxwin)->m_widget));
-        return 0;
-    }
-}
-#else
-#define GetXWindow(wxwin) (wxwin)->m_wxwindow ? \
-                          GDK_WINDOW_XWINDOW((wxwin)->m_wxwindow->window) : \
-                          GDK_WINDOW_XWINDOW((wxwin)->m_widget->window)
+
+// GDK3 gdkconfig.h lists the possible window backend #defines.
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
 #endif
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
+#ifdef GDK_WINDOWING_WIN32
+#include <gdk/gdkwin32.h>
+#endif
+#ifdef GDK_WINDOWING_QUARTZ
+#include <gdk/gdkquartz.h>
 #endif
 
+#endif // ifdef __WXGTK__
 
 
 
@@ -36,11 +26,47 @@ wxUIntPtr wxPyGetWinHandle(const wxWindow* win)
 #ifdef __WXMSW__
     return (wxUIntPtr)win->GetHandle();
 #endif
-#if defined(__WXGTK__) || defined(__WXX11__)
-    return (wxUIntPtr)GetXWindow(win);
+
+#ifdef __WXX11__
+    return (wxUIntPtr)win->GetHandle();
 #endif
+
 #ifdef __WXMAC__
     return (wxUIntPtr)win->GetHandle();
 #endif
+
+#ifdef __WXGTK__
+    GtkWidget *gtk_widget = win->GetHandle();
+    if (!gtk_widget) {
+        return 0;
+    };
+    // gtk_widget_get_window disappears in GTK4; then it will be via
+    // gtk_widget_get_native() -> gtk_native_get_surface().
+    GdkWindow *window = gtk_widget_get_window(gtk_widget);
+    if (!window) {
+        return 0;
+    }
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_WINDOW(window)) {
+        return (wxUIntPtr)gdk_x11_window_get_xid(window);
+    }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_WINDOW(window)) {
+        return (wxUIntPtr)gdk_wayland_window_get_wl_surface(window);
+    }
+#endif
+#ifdef GDK_WINDOWING_WIN32
+    if (GDK_IS_WIN32_WINDOW(window)) {
+        return (wxUIntPtr)gdk_win32_window_get_handle(window);
+    }
+#endif
+#ifdef GDK_WINDOWING_QUARTZ
+    if (GDK_IS_QUARTZ_WINDOW(window)) {
+        return (wxUIntPtr)gdk_quartz_window_get_nswindow(window);
+    }
+#endif
+#endif
+
     return 0;
 }


### PR DESCRIPTION
This adds a new `GetHandleType` method that returns one of the strings "Windows", "Mac", "X11", or "Wayland" that tells the user what the return type of `GetHandle` will be. On a non-GTK build you can get this info from `PlatformInfo.PortId`, but on GTK `GetHandle` will "dereference" the `GtkWidget` into an `HWND` etc. So, without some extra help from native code, it's impossible for a user to safely use the pointer returned from `GetHandle` (unless they write their own backend-guessing code).

Issues:
* This PR also has the commits from #2561. I will not take this out of draft until that has been resolved, but still would appreciate feedback now on if this has a chance of being accepted. I don't think there's a cleaner way to make this PR in GitHub...
* The return type/values is definitely up for debate.