### PR TITLE
Add Window methods GetNativeWindowHandle and GetNativeWindowHandleType

### DIFF
--- a/etg/window.py
+++ b/etg/window.py
@@ -240,8 +240,8 @@ def run():
             return pix
             """)
 
-    c.addCppMethod('void*', 'GetNativeWindowHandle', '()',
-           'return wxPyNativeWindowHandle(self);',
+    c.addCppMethod('size_t', 'GetNativeWindowHandle', '()',
+           'return (size_t)wxPyNativeWindowHandle(self);',
            doc="""Returns a platform-specific handle to the OS window containing this widget.
 
                 The :meth:`GetNativeWindowHandleType` method provides the concrete type of the handle.

--- a/etg/window.py
+++ b/etg/window.py
@@ -240,6 +240,23 @@ def run():
             return pix
             """)
 
+    c.addCppMethod('void*', 'GetNativeWindowHandle', '()',
+           'return wxPyNativeWindowHandle(self);',
+           doc="""Returns a platform-specific handle to the OS window containing this widget.
+
+                The :meth:`GetNativeWindowHandleType` method provides the concrete type of the handle.
+
+                On some platforms this may return 0 until you have called :meth:`Show` on the window.""")
+
+    c.addCppMethod('wxString', 'GetNativeWindowHandleType', '()',
+           body="""\
+                return new wxString(
+                    wxPyNativeWindowHandleTypeString(self),
+                    wxConvUTF8
+                );""",
+           doc="""Returns a string describing the type of object that will be returned by :meth:`GetNativeWindowHandle`.
+
+               An empty string is returned if the platform is not supported.""")
 
     # wxAccessbile is MSW only. Provide a NotImplemented fallback for the
     # other platforms.
@@ -343,6 +360,8 @@ def run():
     c.addProperty('MinSize GetMinSize SetMinSize')
     c.addProperty('MinWidth GetMinWidth')
     c.addProperty('Name GetName SetName')
+    c.addProperty('NativeWindowHandle GetNativeWindowHandle')
+    c.addProperty('NativeWindowHandleType GetNativeWindowHandleType')
     c.addProperty('Parent GetParent')
     c.addProperty('Position GetPosition SetPosition')
     c.addProperty('ScreenPosition GetScreenPosition')

--- a/src/window_ex.cpp
+++ b/src/window_ex.cpp
@@ -113,11 +113,11 @@ static int get_gtk_handle_type(const wxWindow *win) {
 static void * get_gtk_handle(const wxWindow *win) {
     GdkWindow *gdkwin = get_gdk_window(win);
     if (!gdkwin) {
-        return HANDLE_TYPE_UNKNOWN;
+        return NULL;
     }
 #ifdef GDK_WINDOWING_X11
     if (GDK_IS_X11_WINDOW(gdkwin)) {
-        return gdk_x11_window_get_xid(gdkwin);
+        return (void *)gdk_x11_window_get_xid(gdkwin);
     }
 #endif
 #ifdef GDK_WINDOWING_WAYLAND

--- a/src/window_ex.cpp
+++ b/src/window_ex.cpp
@@ -79,7 +79,16 @@ static GdkWindow * get_gdk_window(const wxWindow *win) {
     if (!gtk) {
         return NULL;
     }
-    return gtk_widget_get_window(gtk);
+    // confusing: on X (and maybe others), every widget is a window, and the
+    // GDK window will be the widget-window instead of the real toplevel
+    // window. solution: passing through gtk_widget_get_toplevel. it
+    // is...weirdly defined. the docs say to check the return value right away
+    // with GTK_IS_WINDOW.
+    GtkWidget *toplevel = gtk_widget_get_toplevel(gtk);
+    if (!GTK_IS_WINDOW(toplevel)) {
+        return NULL;
+    }
+    return gtk_widget_get_window(toplevel);
 }
 
 static int get_gtk_handle_type(const wxWindow *win) {

--- a/src/window_ex.cpp
+++ b/src/window_ex.cpp
@@ -46,24 +46,162 @@ wxUIntPtr wxPyGetWinHandle(const wxWindow* win)
 }
 
 
-void * wxPyNativeWindowHandle(const wxWindow *win)
-{
-    return NULL;
-}
-
 enum NativeHandleType {
     HANDLE_TYPE_UNKNOWN,
+    HANDLE_TYPE_XID,
+    HANDLE_TYPE_WL_SURFACE,
+    HANDLE_TYPE_NSWINDOW,
+    HANDLE_TYPE_HWND,
 };
+
+
+#ifdef __WXGTK__
+// *lots* of preprocessor junk throughout the GTK code, to handle different GTK
+// backends en/disabled at compile-time.
+//
+// gdkconfig.h lists the possible GDK_WINDOWING_FOO #defines. the only one
+// being skipped here is "Broadway" which is HTML/webassembly.
+#ifdef GDK_WINDOWING_X11
+#include <gdk/gdkx.h>
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+#include <gdk/gdkwayland.h>
+#endif
+#ifdef GDK_WINDOWING_WIN32
+#include <gdk/gdkwin32.h>
+#endif
+#ifdef GDK_WINDOWING_QUARTZ
+#include <gdk/gdkquartz.h>
+#endif
+
+static GdkWindow * get_gdk_window(const wxWindow *win) {
+    GtkWidget *gtk = win->GetHandle();
+    if (!gtk) {
+        return NULL;
+    }
+    return gtk_widget_get_window(gtk);
+}
+
+static int get_gtk_handle_type(const wxWindow *win) {
+    GdkWindow *gdkwin = get_gdk_window(win);
+    if (!gdkwin) {
+        return HANDLE_TYPE_UNKNOWN;
+    }
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_WINDOW(gdkwin)) {
+        return HANDLE_TYPE_XID;
+    }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_WINDOW(gdkwin)) {
+        return HANDLE_TYPE_WL_SURFACE;
+    }
+#endif
+#ifdef GDK_WINDOWING_WIN32
+    if (GDK_IS_WIN32_WINDOW(gdkwin)) {
+        return HANDLE_TYPE_HWND;
+    }
+#endif
+#ifdef GDK_WINDOWING_QUARTZ
+    if (GDK_IS_QUARTZ_WINDOW(gdkwin)) {
+        return HANDLE_TYPE_NSWINDOW;
+    }
+#endif
+    return HANDLE_TYPE_UNKNOWN;
+}
+
+static void * get_gtk_handle(const wxWindow *win) {
+    GdkWindow *gdkwin = get_gdk_window(win);
+    if (!gdkwin) {
+        return HANDLE_TYPE_UNKNOWN;
+    }
+#ifdef GDK_WINDOWING_X11
+    if (GDK_IS_X11_WINDOW(gdkwin)) {
+        return gdk_x11_window_get_xid(gdkwin);
+    }
+#endif
+#ifdef GDK_WINDOWING_WAYLAND
+    if (GDK_IS_WAYLAND_WINDOW(gdkwin)) {
+        return gdk_wayland_window_get_wl_surface(gdkwin);
+    }
+#endif
+#ifdef GDK_WINDOWING_WIN32
+    if (GDK_IS_WIN32_WINDOW(gdkwin)) {
+        return gdk_win32_window_get_handle(gdkwin);
+    }
+#endif
+#ifdef GDK_WINDOWING_QUARTZ
+    if (GDK_IS_QUARTZ_WINDOW(gdkwin)) {
+        return gdk_quartz_window_get_nswindow(gdkwin);
+    }
+#endif
+    return NULL;
+}
+#endif // ifdef __WXGTK__
+
+// All the possible __WXFOO__ port #defines are documented at:
+// <https://docs.wxwidgets.org/latest/page_cppconst.html#page_cppconst_guisystem>
 
 int wxPyNativeWindowHandleType(const wxWindow *win)
 {
+#ifdef __WXGTK__
+    return get_gtk_handle_type(win);
+#endif
+#ifdef __WXX11__
+    return HANDLE_TYPE_XID;
+#endif
+#ifdef __WXOSX_COCOA__
+    return HANDLE_TYPE_NSWINDOW;
+#endif
+#ifdef __WXMSW__
+    return HANDLE_TYPE_HWND;
+#endif
     return HANDLE_TYPE_UNKNOWN;
 }
 
 const char * wxPyNativeWindowHandleTypeString(const wxWindow *win)
 {
     switch (wxPyNativeWindowHandleType(win)) {
+        case HANDLE_TYPE_XID:
+            return "XID";
+        case HANDLE_TYPE_WL_SURFACE:
+            return "wl_surface";
+        case HANDLE_TYPE_NSWINDOW:
+            return "NSWindow";
+        case HANDLE_TYPE_HWND:
+            return "HWND";
         default:
             return "";
     }
+}
+
+#ifdef __WXOSX_COCOA__
+#include <objc/objc-runtime.h>
+#endif
+void * wxPyNativeWindowHandle(const wxWindow *win)
+{
+#ifdef __WXGTK__
+    return get_gtk_handle(win);
+#endif
+#if defined(__WXMSW__) || defined(__WXX11__)
+    // TODO possibly wrong. hard to confirm.
+    return win->GetHandle();
+#endif
+#ifdef __WXOSX_COCOA__
+    id nsview = (id) win->GetHandle();
+    // experimentally confirmed it's an NSView via libobjc's
+    // object_getClassName.
+    SEL window_sel = sel_registerName("window");
+    if (!window_sel) {
+        return NULL;
+    }
+    id (*invoke)(id, SEL) = (id (*)(id, SEL)) objc_msgSend;
+    id nswindow = invoke(nsview, window_sel);
+    if (!nswindow) {
+        return NULL;
+    }
+    return nswindow;
+#endif
+
+    return NULL;
 }

--- a/src/window_ex.cpp
+++ b/src/window_ex.cpp
@@ -1,4 +1,4 @@
-
+#include <stddef.h>
 #ifdef __WXMSW__
 #include <wx/msw/private.h>
 #endif
@@ -43,4 +43,27 @@ wxUIntPtr wxPyGetWinHandle(const wxWindow* win)
     return (wxUIntPtr)win->GetHandle();
 #endif
     return 0;
+}
+
+
+void * wxPyNativeWindowHandle(const wxWindow *win)
+{
+    return NULL;
+}
+
+enum NativeHandleType {
+    HANDLE_TYPE_UNKNOWN,
+};
+
+int wxPyNativeWindowHandleType(const wxWindow *win)
+{
+    return HANDLE_TYPE_UNKNOWN;
+}
+
+const char * wxPyNativeWindowHandleTypeString(const wxWindow *win)
+{
+    switch (wxPyNativeWindowHandleType(win)) {
+        default:
+            return "";
+    }
 }

--- a/unittests/test_window.py
+++ b/unittests/test_window.py
@@ -168,14 +168,14 @@ class WindowTests(wtc.WidgetTestCase):
     def test_NativeWindowHandleType(self):
         w = wx.Window(self.frame, -1, (10,10), (50,50))
         self.assertEqual(w.GetNativeWindowHandleType(), w.NativeWindowHandleType)
-        self.assert_(w.NativeWindowHandleType)
+        self.assertTrue(w.NativeWindowHandleType)
 
 
     def test_NativeWindowHandle(self):
         parent = self.frame
         child = wx.Window(self.frame, -1, (10,10), (50,50))
         self.assertEqual(parent.NativeWindowHandle, parent.GetNativeWindowHandle())
-        self.assertNotEqual(parent.NativeWindowHandle, 0)
+        self.assertTrue(parent.NativeWindowHandle)
         # This tries to be a platform-agnostic test by confirming that,
         # regardless of what the window handle type really is, it should be the
         # same value for two normal widgets in the same OS window. In contrast,

--- a/unittests/test_window.py
+++ b/unittests/test_window.py
@@ -60,6 +60,8 @@ class WindowTests(wtc.WidgetTestCase):
         w.MinSize
         w.MinWidth
         w.Name
+        w.NativeWindowHandle
+        w.NativeWindowHandleType
         w.Parent
         w.Position
         w.Rect
@@ -161,6 +163,27 @@ class WindowTests(wtc.WidgetTestCase):
             a.colFg = wx.Colour('blue')
         with self.assertRaises(AttributeError):
             a.font = wx.NORMAL_FONT
+
+
+    def test_NativeWindowHandleType(self):
+        w = wx.Window(self.frame, -1, (10,10), (50,50))
+        self.assertEqual(w.GetNativeWindowHandleType(), w.NativeWindowHandleType)
+        self.assert_(w.NativeWindowHandleType)
+
+
+    def test_NativeWindowHandle(self):
+        parent = self.frame
+        child = wx.Window(self.frame, -1, (10,10), (50,50))
+        self.assertEqual(parent.NativeWindowHandle, parent.GetNativeWindowHandle())
+        self.assertNotEqual(parent.NativeWindowHandle, 0)
+        # This tries to be a platform-agnostic test by confirming that,
+        # regardless of what the window handle type really is, it should be the
+        # same value for two normal widgets in the same OS window. In contrast,
+        # wxWidgets C++ GetHandle on GTK or Cocoa will return a different value
+        # for every widget, implying that whatever the return type is, it's not
+        # the OS window.
+        self.assertEqual(parent.NativeWindowHandle, child.NativeWindowHandle)
+
 
 #---------------------------------------------------------------------------
 


### PR DESCRIPTION
This adds 2 new Window methods that give users access to the platform window handle. C++ `GetHandle` usually returns widget handles. The user can technically get from there to the window handle on their own, but it's very complicated and would require guessing some info that wxWidgets already knows.

My use-case is creating an OS child window in order to embed Vulkan graphics in a wxPython GUI. It also looks like folks use this trick for embedding webviews.

`GetNativeWindowHandle` returns a pointer-as-int, and `GetNativeWindowHandleType` returns a string designating what the real type of `GetNativeWindowHandle()` is. Both these functions especially help GTK users by "dereferencing" down to the actual MSW/Mac/X/Wayland backend that GTK is using.

This includes a new unit test that tries to confirm on any platform that:
* `NativeWindowHandle` is not zero
* For a parent and child widget in the same window, `parent.NativeWindowHandle == child.NativeWindowHandle`.
This seems like a pretty solid check, without any platform knowledge, that whatever is being returned really is a window handle and not a widget handle.

Returning strings from `NativeWindowHandleType` isn't great. I'm not sure what the best way to go is.

Tested on:
- [X] Mac
- [X] Linux GTK X11
- [X] Linux GTK Wayland
- [ ] Windows