### PR TITLE
Replace use of numpy.sometrue with numpy.any for numpy v2 compatibility (#2498)

### DIFF
--- a/wx/lib/floatcanvas/FloatCanvas.py
+++ b/wx/lib/floatcanvas/FloatCanvas.py
@@ -601,7 +601,7 @@ class FloatCanvas(wx.Panel):
 
         """
 
-        if N.sometrue(self.PanelSize <= 2 ):
+        if N.any(self.PanelSize <= 2):
             # it's possible for this to get called before being properly initialized.
             return
         if self.Debug: start = clock()

--- a/wx/lib/plot/plotcanvas.py
+++ b/wx/lib/plot/plotcanvas.py
@@ -2044,8 +2044,7 @@ class PlotCanvas(wx.Panel):
         """
         if self.last_PointLabel is not None:
             # compare pointXY
-            if np.sometrue(
-                    mDataDict["pointXY"] != self.last_PointLabel["pointXY"]):
+            if np.any(mDataDict["pointXY"] != self.last_PointLabel["pointXY"]):
                 # closest changed
                 self._drawPointLabel(self.last_PointLabel)  # erase old
                 self._drawPointLabel(mDataDict)  # plot new


### PR DESCRIPTION
Numpy v2 has removed the `numpy.sometrue` function (it was deprecated in numpy 1.25.0). numpy.any has been around for a very long time so there should be no backwards compatibility issue.

This fixes/closes issues #2498 and #2574.
