### PR TITLE
Unpin setuptools on Windows

### DIFF
--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -1,8 +1,7 @@
 # Python packages needed for building and testing wxPython Phoenix
 -r install.txt
 appdirs
-setuptools < 74 ; sys.platform == 'win32'
-setuptools ; sys.platform != 'win32'
+setuptools
 sip == 6.8.5
 
 wheel


### PR DESCRIPTION
setuptools.msvc has been reinstated in setuptools 74.1.0

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #2590 

