### PR TITLE
Possible fix for #2549

### DIFF
--- a/wx/lib/agw/customtreectrl.py
+++ b/wx/lib/agw/customtreectrl.py
@@ -1428,6 +1428,9 @@ class TreeTextCtrl(ExpandoTextCtrl):
             bs = self.GetBestSize()
             self.SetSize((-1, bs.height))
 
+        if self._startValue:
+            self.SelectAll()
+          
         self.Bind(wx.EVT_CHAR, self.OnChar)
         self.Bind(wx.EVT_KEY_UP, self.OnKeyUp)
         self.Bind(wx.EVT_KILL_FOCUS, self.OnKillFocus)


### PR DESCRIPTION
This should fix #2549 - EditLabel on CustomTreeCtrl doesn't automatically select the entire text

Fixes #2549

