### PR TITLE
Possible fix for #2345

### DIFF
--- a/wx/lib/agw/scrolledthumbnail.py
+++ b/wx/lib/agw/scrolledthumbnail.py
@@ -1534,7 +1534,7 @@ class ScrolledThumbnail(wx.ScrolledWindow):
 
         # scroll view
         xu, yu = self.GetScrollPixelsPerUnit()
-        sy = sy/yu + (sy%yu and [1] or [0])[0] # convert sy to scroll units
+        sy = sy//yu + (sy%yu and [1] or [0])[0] # convert sy to scroll units
         x, y = self.GetViewStart()
 
         self.Scroll(x,sy)


### PR DESCRIPTION
Possible fix for #2345 - Thumbnailctrl SetSelection raises exception if it tries to scroll

Fixes #2345

