### PR TITLE
fix siplib build on Windows

### DIFF
--- a/wscript
+++ b/wscript
@@ -9,6 +9,7 @@
 
 import sys
 import os
+import glob
 import setuptools
 
 try:
@@ -542,19 +543,12 @@ def build(bld):
 
     # Create the build tasks for each of our extension modules.
     addRelwithdebugFlags(bld, 'siplib')
+    module_src = sorted(glob.glob('sip/siplib/*.c'))
+    if isWindows: module_src.append('sip/siplib/bool.cpp')
     siplib = bld(
         features = 'c cxx cshlib cxxshlib pyext',
         target   = makeTargetName(bld, 'siplib'),
-        source   = ['sip/siplib/apiversions.c',
-                    'sip/siplib/descriptors.c',
-                    'sip/siplib/int_convertors.c',
-                    'sip/siplib/objmap.c',
-                    'sip/siplib/qtlib.c',
-                    'sip/siplib/sip_array.c',
-                    'sip/siplib/siplib.c',
-                    'sip/siplib/threads.c',
-                    'sip/siplib/voidptr.c',
-                    ],
+        source   = module_src,
         uselib   = 'siplib WX WXPY',
     )
     makeExtCopyRule(bld, 'siplib')


### PR DESCRIPTION
When trying to build 4.2.2 with Python 3.12 on Windows 64 bit, I got an error when siplib was linked.
The symbol `sipSetBool` was missing.

The generated `sip\siplib\setup.py` has these lines, but the file content is not used when building with waf:
```
if sys.platform == 'win32':
    module_src.append('bool.cpp')
```

This PR adds `bool.cpp` also to `wscript`.