### PR TITLE
Bugfixes in pure python aui where rapid layout changes may trigger calls to destroyed C++ objets.

### DIFF
--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -2457,7 +2457,8 @@ class AuiTabCtrl(wx.Control, AuiTabContainer):
 
         :rtype: :class:`wx.Window`.
         """
-
+        if not self:
+            return None # The AuiTabCtrl has already been destroyed
         screen_pt = wx.GetMousePosition()
         client_pt = self.ScreenToClient(screen_pt)
         return self.TabHitTest(client_pt.x, client_pt.y)

--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -8435,6 +8435,10 @@ class AuiManager(wx.EvtHandler):
                                     not part.sizer_item.IsShown()):
                 continue
 
+            # don't draw items that have a pane whose window has been deleted
+            if part.pane and not part.pane.window:
+                continue
+
             ptype = part.type
 
             if ptype in [AuiDockUIPart.typeDockSizer, AuiDockUIPart.typePaneSizer]:


### PR DESCRIPTION
This PR addresses two cases in pure-python aui where rapid layout changes may cause errors by trying to use C++ objects that have been destroyed. 

The details of the errors are given at https://github.com/wxWidgets/Phoenix/pull/2473

This is an improved version of that older PR  that I retracted because testing showed it was not sufficient to to resolve the problem. I and others have been testing this current PR as part of the wxPython-Meticy release. The issue appears to be fully resolved. This PR is safe to apply since it simply tests that the underlying C++ objects exist and are valid before they are used.

