### PR TITLE
Fix InspectionTool crashes due to bad perspective string errros

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -5178,7 +5178,7 @@ class AuiManager(wx.EvtHandler):
             elif val_name == "transparent":
                 pane.transparent = int(value)
             else:
-                raise Exception("Bad perspective string")
+                raise Exception("Bad perspective string", val_name)
 
         # replace escaped characters so we can
         # split up the string easily

--- a/wx/lib/inspection.py
+++ b/wx/lib/inspection.py
@@ -405,11 +405,11 @@ class InspectionFrame(wx.Frame):
         rect = utils.AdjustRectToScreen(self.GetRect())
         self.SetRect(rect)
 
-        perspective = config.Read('perspective', '')
+        perspective = config.Read('perspective1', '')
         if perspective:
             try:
                 self.mgr.LoadPerspective(perspective)
-            except wx.PyAssertionError:
+            except Exception:
                 # ignore bad perspective string errors
                 pass
         self.includeSizers = config.ReadBool('includeSizers', False)
@@ -430,7 +430,7 @@ class InspectionFrame(wx.Frame):
 
         if hasattr(self, "mgr"):
             perspective = self.mgr.SavePerspective()
-            config.Write('perspective', perspective)
+            config.Write('perspective1', perspective)
             config.WriteBool('includeSizers', self.includeSizers)
 
 #---------------------------------------------------------------------------


### PR DESCRIPTION
To ensure backward compatibility from version 4.2.3* to 4.2.2, use the config key 'perspective1' for version 4.2.3 and later.

Fixes #2626

