### PR TITLE
Avoid calling FlatMenu Destroy() in a finally block

### DIFF
--- a/wx/lib/agw/flatmenu.py
+++ b/wx/lib/agw/flatmenu.py
@@ -5358,10 +5358,8 @@ class FlatMenu(FlatMenuBase):
 
 
     def Destroy(self, *args, **kwargs):
-        try:
-            self.Clear()
-        finally:
-            return super().Destroy(*args, **kwargs)
+        self.Clear()
+        return super().Destroy(*args, **kwargs)
 
 
     def SetMenuBar(self, mb):


### PR DESCRIPTION
Fixes https://github.com/wxWidgets/Phoenix/issues/2630

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->


