### PR TITLE
float -> int

### DIFF
--- a/wx/lib/ogl/basic.py
+++ b/wx/lib/ogl/basic.py
@@ -2756,9 +2756,9 @@ class RectangleShape(Shape):
             dc.SetPen(TransparentPen)
 
             if self._cornerRadius:
-                dc.DrawRoundedRectangle(x1 + self._shadowOffsetX, y1 + self._shadowOffsetY, self._width, self._height, self._cornerRadius)
+                dc.DrawRoundedRectangle(int(x1 + self._shadowOffsetX), int(y1 + self._shadowOffsetY), int(self._width), int(self._height), self._cornerRadius)
             else:
-                dc.DrawRectangle(x1 + self._shadowOffsetX, y1 + self._shadowOffsetY, self._width, self._height)
+                dc.DrawRectangle(int(x1 + self._shadowOffsetX), int(y1 + self._shadowOffsetY), int(self._width), int(self._height))
 
         if self._pen:
             if self._pen.GetWidth() == 0:
@@ -2769,9 +2769,9 @@ class RectangleShape(Shape):
             dc.SetBrush(self._brush)
 
         if self._cornerRadius:
-            dc.DrawRoundedRectangle(int(x1), int(y1), self._width, self._height, self._cornerRadius)
+            dc.DrawRoundedRectangle(int(x1), int(y1), int(self._width), int(self._height), self._cornerRadius)
         else:
-            dc.DrawRectangle(int(x1), int(y1), self._width, self._height)
+            dc.DrawRectangle(int(x1), int(y1), int(self._width), int(self._height))
 
     def GetBoundingBoxMin(self):
         """Get the bounding box minimum."""


### PR DESCRIPTION
DrawRectangle and DrawRoundedRectangle requires ints instead of floats for height and width. Fixed in basics.py 
*Relative to issue:* https://github.com/wxWidgets/Phoenix/issues/2648

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes:
Added int() around height and width parameters passed when calling DrawRectangle and DrawRoundedRectangle, as it was already being done for x and y.
