### PR TITLE
Fix rubberband overlapping

### DIFF
--- a/wx/lib/mixins/rubberband.py
+++ b/wx/lib/mixins/rubberband.py
@@ -332,8 +332,7 @@ class RubberBand:
         dc.SetBrush(wx.TRANSPARENT_BRUSH)
         dc.SetLogicalFunction(wx.XOR)
         if boxToErase:
-            r = wx.Rect(*boxToErase)
-            dc.DrawRectangle(r)
+            dc.Clear()
 
         r = wx.Rect(*boxToDraw)
         dc.DrawRectangle(r)


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #2627

This fixes the rubberband (lib.mixins.rubberband) overlapping on each draw, resize or move due to the [__drawAndErase()](https://github.com/wxWidgets/Phoenix/blob/82b1c7aa7ea28f9f142efcd3f31942b1011a5d6d/wx/lib/mixins/rubberband.py#L326) method that is not clearing the old box before moving or resizing the bounding box but drawing another box.


