### PR TITLE
Type stub improvements

### DIFF
--- a/etg/bmpbndl.py
+++ b/etg/bmpbndl.py
@@ -10,7 +10,6 @@
 import etgtools
 import etgtools.tweaker_tools as tools
 from etgtools import MethodDef
-import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -44,7 +43,7 @@ def run():
 
     # Allow on-the-fly creation of a wx.BitmapBundle from a wx.Bitmap, wx.Icon
     # or a wx.Image
-    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+    c.convertFromPyObject = tools.AutoConversionInfo(
         ('wx.Bitmap', 'wx.Icon', ),
         """\
         // Check for type compatibility

--- a/etg/bmpbndl.py
+++ b/etg/bmpbndl.py
@@ -10,6 +10,7 @@
 import etgtools
 import etgtools.tweaker_tools as tools
 from etgtools import MethodDef
+import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -43,7 +44,9 @@ def run():
 
     # Allow on-the-fly creation of a wx.BitmapBundle from a wx.Bitmap, wx.Icon
     # or a wx.Image
-    c.convertFromPyObject = """\
+    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+        ('wx.Bitmap', 'wx.Icon', ),
+        """\
         // Check for type compatibility
         if (!sipIsErr) {
             if (sipCanConvertToType(sipPy, sipType_wxBitmap, SIP_NO_CONVERTORS))
@@ -86,7 +89,7 @@ def run():
         *sipCppPtr = reinterpret_cast<wxBitmapBundle*>(
             sipConvertToType(sipPy, sipType_wxBitmapBundle, sipTransferObj, SIP_NO_CONVERTORS, 0, sipIsErr));
         return 0; // not a new instance
-        """
+        """)
 
 
     c = module.find('wxBitmapBundleImpl')

--- a/etg/colour.py
+++ b/etg/colour.py
@@ -9,6 +9,7 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
+import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -192,7 +193,9 @@ def run():
     #     String with color name or #RRGGBB or #RRGGBBAA format
     #     None  (converts to wxNullColour)
     c.allowNone = True
-    c.convertFromPyObject = """\
+    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+        ('wx.Colour', '_ThreeInts', '_FourInts', 'str', 'None'),
+        """\
         // is it just a typecheck?
         if (!sipIsErr) {
             if (sipPy == Py_None)
@@ -273,7 +276,7 @@ def run():
         *sipCppPtr = reinterpret_cast<wxColour*>(sipConvertToType(
             sipPy, sipType_wxColour, sipTransferObj, SIP_NO_CONVERTORS, 0, sipIsErr));
         return 0; // not a new instance
-    """
+    """)
 
     module.addPyCode('NamedColour = wx.deprecated(Colour, "Use Colour instead.")')
 

--- a/etg/colour.py
+++ b/etg/colour.py
@@ -9,7 +9,6 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
-import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -193,7 +192,7 @@ def run():
     #     String with color name or #RRGGBB or #RRGGBBAA format
     #     None  (converts to wxNullColour)
     c.allowNone = True
-    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+    c.convertFromPyObject = tools.AutoConversionInfo(
         ('wx.Colour', '_ThreeInts', '_FourInts', 'str', 'None'),
         """\
         // is it just a typecheck?

--- a/etg/propgridiface.py
+++ b/etg/propgridiface.py
@@ -9,7 +9,6 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
-import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_propgrid"
@@ -71,7 +70,7 @@ def run():
 
     c.find('GetPtr').overloads[0].ignore()
 
-    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+    c.convertFromPyObject = tools.AutoConversionInfo(
         ('str', 'None', ),
         """\
         // Code to test a PyObject for compatibility with wxPGPropArgCls

--- a/etg/propgridiface.py
+++ b/etg/propgridiface.py
@@ -9,6 +9,7 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
+import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_propgrid"
@@ -70,7 +71,9 @@ def run():
 
     c.find('GetPtr').overloads[0].ignore()
 
-    c.convertFromPyObject = """\
+    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+        ('str', 'None', ),
+        """\
         // Code to test a PyObject for compatibility with wxPGPropArgCls
         if (!sipIsErr) {
             if (sipCanConvertToType(sipPy, sipType_wxPGPropArgCls, SIP_NO_CONVERTORS))
@@ -109,7 +112,7 @@ def run():
                 SIP_NO_CONVERTORS, 0, sipIsErr));
             return 0; // not a new instance
         }
-        """
+        """)
 
 
     #----------------------------------------------------------

--- a/etg/stream.py
+++ b/etg/stream.py
@@ -9,7 +9,6 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
-import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -77,7 +76,7 @@ def run():
     c.includeCppCode('src/stream_input.cpp')
 
     # Use that class for the convert code
-    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+    c.convertFromPyObject = tools.AutoConversionInfo(
         (), # TODO: Track down what python types actually can be wrapped
         """\
         // is it just a typecheck?
@@ -239,7 +238,7 @@ def run():
     c.includeCppCode('src/stream_output.cpp')
 
     # Use that class for the convert code
-    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+    c.convertFromPyObject = tools.AutoConversionInfo(
         (), # TODO: Track down what python types can actually be converted
         """\
         // is it just a typecheck?

--- a/etg/stream.py
+++ b/etg/stream.py
@@ -9,6 +9,7 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
+import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -76,7 +77,9 @@ def run():
     c.includeCppCode('src/stream_input.cpp')
 
     # Use that class for the convert code
-    c.convertFromPyObject = """\
+    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+        (), # TODO: Track down what python types actually can be wrapped
+        """\
         // is it just a typecheck?
         if (!sipIsErr) {
             if (wxPyInputStream::Check(sipPy))
@@ -86,7 +89,7 @@ def run():
         // otherwise do the conversion
         *sipCppPtr = new wxPyInputStream(sipPy);
         return 0; //sipGetState(sipTransferObj);
-        """
+        """)
 
     # Add Python file-like methods so a wx.InputStream can be used as if it
     # was any other Python file object.
@@ -236,7 +239,9 @@ def run():
     c.includeCppCode('src/stream_output.cpp')
 
     # Use that class for the convert code
-    c.convertFromPyObject = """\
+    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+        (), # TODO: Track down what python types can actually be converted
+        """\
         // is it just a typecheck?
         if (!sipIsErr) {
             if (wxPyOutputStream::Check(sipPy))
@@ -246,7 +251,7 @@ def run():
         // otherwise do the conversion
         *sipCppPtr = new wxPyOutputStream(sipPy);
         return sipGetState(sipTransferObj);
-        """
+        """)
 
 
     # Add Python file-like methods so a wx.OutputStream can be used as if it

--- a/etg/wxdatetime.py
+++ b/etg/wxdatetime.py
@@ -9,7 +9,6 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
-import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -312,7 +311,7 @@ def run():
 
     # Add some code (like MappedTypes) to automatically convert from a Python
     # datetime.date or a datetime.datetime object
-    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+    c.convertFromPyObject = tools.AutoConversionInfo(
         ('datetime', 'date', ),
         """\
         // Code to test a PyObject for compatibility with wxDateTime

--- a/etg/wxdatetime.py
+++ b/etg/wxdatetime.py
@@ -9,6 +9,7 @@
 
 import etgtools
 import etgtools.tweaker_tools as tools
+import etgtools.tweaker_tools
 
 PACKAGE   = "wx"
 MODULE    = "_core"
@@ -311,7 +312,9 @@ def run():
 
     # Add some code (like MappedTypes) to automatically convert from a Python
     # datetime.date or a datetime.datetime object
-    c.convertFromPyObject = """\
+    c.convertFromPyObject = etgtools.tweaker_tools.AutoConversionInfo(
+        ('datetime', 'date', ),
+        """\
         // Code to test a PyObject for compatibility with wxDateTime
         if (!sipIsErr) {
             if (sipCanConvertToType(sipPy, sipType_wxDateTime, SIP_NO_CONVERTORS))
@@ -335,7 +338,7 @@ def run():
                 sipPy, sipType_wxDateTime, sipTransferObj, SIP_NO_CONVERTORS, 0, sipIsErr));
 
         return 0;  // Not a new instance
-        """
+        """)
 
 
     #---------------------------------------------

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -542,6 +542,10 @@ class FunctionDef(BaseDef, FixWxPrefix):
                     params.append(s)
 
         self.pyArgsString = f"({', '.join(params)})"
+        # __bool__ and __nonzero__ need to be defined as returning int for SIP, but for Python
+        # __bool__ is required to return a bool:
+        if (self.name or self.pyName) in ('__bool__', '__nonzero__'):
+            returns = ['bool']
         if not returns:
             self.pyArgsString = f'{self.pyArgsString} -> None'
         elif len(returns) == 1:

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -15,12 +15,13 @@ wxWidgets API info which we need from them.
 import sys
 import os
 import pprint
-import xml.etree.ElementTree as ET
+from typing import Optional
+import xml.etree.ElementTree as et
 import copy
 
-from .tweaker_tools import FixWxPrefix, magicMethods, \
+from .tweaker_tools import FixWxPrefix, MethodType, magicMethods, \
                            guessTypeInt, guessTypeFloat, guessTypeStr, \
-                           textfile_open
+                           textfile_open, Signature
 from sphinxtools.utilities import findDescendants
 
 if sys.version_info >= (3, 11):
@@ -285,6 +286,7 @@ class FunctionDef(BaseDef, FixWxPrefix):
         self.type = None
         self.definition = ''
         self.argsString = ''
+        self.signature: Optional[Signature] = None
         self.pyArgsString = ''
         self.isOverloaded = False
         self.overloads = []
@@ -406,7 +408,10 @@ class FunctionDef(BaseDef, FixWxPrefix):
         else:
             parent = self.klass
         item = self.findOverload(matchText)
+        assert item is not None
         item.pyName = newName
+        if item.signature:
+            item.signature.method_name = newName
         item.__dict__.update(kw)
 
         if item is self and not self.hasOverloads():
@@ -470,8 +475,8 @@ class FunctionDef(BaseDef, FixWxPrefix):
         Create a pythonized version of the argsString in function and method
         items that can be used as part of the docstring.
         """
-        params = list()
-        returns = list()
+        params: list[Signature.Parameter] = []
+        returns: list[str] = []
         if self.type and self.type != 'void':
             returns.append(self.cleanType(self.type))
 
@@ -483,6 +488,7 @@ class FunctionDef(BaseDef, FixWxPrefix):
                         'wxArrayInt()' : '[]',
                         'wxEmptyString':  "''", # Makes signatures much shorter
                         }
+        P = Signature.Parameter
         if isinstance(self, CppMethodDef):
             # rip apart the argsString instead of using the (empty) list of parameters
             lastP = self.argsString.rfind(')')
@@ -495,22 +501,15 @@ class FunctionDef(BaseDef, FixWxPrefix):
                 if '=' in arg:
                     default = arg.split('=')[1].strip()
                     arg = arg.split('=')[0].strip()
-                    if default in defValueMap:
-                        default = defValueMap.get(default)
-                    else:
-                        default = self.fixWxPrefix(default, True)
+                    default = defValueMap.get(default, default)
+                    default = self.fixWxPrefix(default, True)
                 # now grab just the last word, it should be the variable name
                 # The rest will be the type information
                 arg_type, arg = arg.rsplit(None, 1)
                 arg, arg_type = self.parseNameAndType(arg, arg_type)
-                if arg_type:
-                    if default == 'None':
-                        arg = f'{arg}: Optional[{arg_type}]'
-                    else:
-                        arg = f'{arg}: {arg_type}'
-                if default:
-                    arg += '=' + default
-                params.append(arg)
+                params.append(P(arg, arg_type, default))
+                if default == 'None':
+                    params[-1].make_optional()
         else:
             for param in self.items:
                 assert isinstance(param, ParamDef)
@@ -523,35 +522,35 @@ class FunctionDef(BaseDef, FixWxPrefix):
                     if param_type:
                         returns.append(param_type)
                 else:
+                    default = ''
                     if param.inOut:
                         if param_type:
                             returns.append(param_type)
                     if param.default:
                         default = param.default
-                        if default in defValueMap:
-                            default = defValueMap.get(default)
-                        if param_type:
-                            if default == 'None':
-                                s = f'{s}: Optional[{param_type}]'
-                            else:
-                                s = f'{s}: {param_type}'
+                        default = defValueMap.get(default, default)
                         default = '|'.join([self.cleanName(x, True) for x in default.split('|')])
-                        s = f'{s}={default}'
-                    elif param_type:
-                        s = f'{s}: {param_type}'
-                    params.append(s)
-
-        self.pyArgsString = f"({', '.join(params)})"
+                    params.append(P(s, param_type, default))
+                    if default == 'None':
+                        params[-1].make_optional()
+        if getattr(self, 'isCtor', False):
+            name = '__init__'
+        else:
+            name = self.name or self.pyName
+            name = self.fixWxPrefix(name)
         # __bool__ and __nonzero__ need to be defined as returning int for SIP, but for Python
         # __bool__ is required to return a bool:
-        if (self.name or self.pyName) in ('__bool__', '__nonzero__'):
-            returns = ['bool']
-        if not returns:
-            self.pyArgsString = f'{self.pyArgsString} -> None'
+        if name in ('__bool__', '__nonzero__'):
+            return_type = 'bool'
+        elif not returns:
+            return_type = 'None'
         elif len(returns) == 1:
-            self.pyArgsString = f'{self.pyArgsString} -> {returns[0]}'
-        elif len(returns) > 1:
-            self.pyArgsString = f"{self.pyArgsString} -> Tuple[{', '.join(returns)}]"
+            return_type = returns[0]
+        else:
+            return_type = f"Tuple[{', '.join(returns)}]"
+        kind = MethodType.STATIC_METHOD if getattr(self, 'isStatic', False) else MethodType.METHOD
+        self.signature = Signature(name, *params, return_type=return_type, method_type=kind)
+        self.pyArgsString = self.signature.args_string(False)
 
 
     def collectPySignatures(self):
@@ -1283,7 +1282,7 @@ class CppMethodDef(MethodDef):
     NOTE: This one is not automatically extracted, but can be added to
           classes in the tweaker stage
     """
-    def __init__(self, type, name, argsString, body, doc=None, isConst=False,
+    def __init__(self, type, name, argsString: str, body, doc=None, isConst=False,
                  cppSignature=None, virtualCatcherCode=None, **kw):
         super(CppMethodDef, self).__init__()
         self.type = type

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -16,7 +16,7 @@ import sys
 import os
 import pprint
 from typing import Optional
-import xml.etree.ElementTree as et
+import xml.etree.ElementTree as ET
 import copy
 
 from .tweaker_tools import AutoConversionInfo, FixWxPrefix, MethodType, magicMethods, \

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -538,8 +538,10 @@ class FunctionDef(BaseDef, FixWxPrefix):
         if getattr(self, 'isCtor', False):
             name = '__init__'
         else:
-            name = self.name or self.pyName
+            name = self.pyName or self.name
             name = self.fixWxPrefix(name)
+            if 'Destroy' in (name, self.name, self.pyName):
+                print(f'Generating signature for: {name}, {self.name}, {self.pyName}')
         # __bool__ and __nonzero__ need to be defined as returning int for SIP, but for Python
         # __bool__ is required to return a bool:
         if name in ('__bool__', '__nonzero__'):
@@ -727,7 +729,7 @@ class ClassDef(BaseDef):
     @convertFromPyObject.setter
     def convertFromPyObject(self, value: AutoConversionInfo) -> None:
         self._convertFromPyObject = value.code
-        name = self.name or self.pyName
+        name = self.pyName or self.name
         name = removeWxPrefix(name)
         FixWxPrefix.register_autoconversion(name, value.convertables)
 

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -538,7 +538,7 @@ class FunctionDef(BaseDef, FixWxPrefix):
                         default = '|'.join([self.cleanName(x, True) for x in default.split('|')])
                         s = f'{s}={default}'
                     elif param_type:
-                        s = f'{s} : {param_type}'
+                        s = f'{s}: {param_type}'
                     params.append(s)
 
         self.pyArgsString = f"({', '.join(params)})"

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -540,8 +540,6 @@ class FunctionDef(BaseDef, FixWxPrefix):
         else:
             name = self.pyName or self.name
             name = self.fixWxPrefix(name)
-            if 'Destroy' in (name, self.name, self.pyName):
-                print(f'Generating signature for: {name}, {self.name}, {self.pyName}')
         # __bool__ and __nonzero__ need to be defined as returning int for SIP, but for Python
         # __bool__ is required to return a bool:
         if name in ('__bool__', '__nonzero__'):

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -717,6 +717,15 @@ class ClassDef(BaseDef):
         if element is not None:
             self.extract(element)
 
+    def is_top_level(self) -> bool:
+        """Check if this class is a subclass of wx.TopLevelWindow"""
+        if not self.nodeBases:
+            return False
+        all_classes, specials = self.nodeBases
+        if 'wxTopLevelWindow' in specials:
+            return True
+        return 'wxTopLevelWindow' in all_classes
+
 
     def renameClass(self, newName):
         self.pyName = newName

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -281,6 +281,8 @@ class FunctionDef(BaseDef, FixWxPrefix):
     """
     Information about a standalone function.
     """
+    _default_method_type = MethodType.FUNCTION
+
     def __init__(self, element=None, **kw):
         super(FunctionDef, self).__init__()
         self.type = None
@@ -548,7 +550,7 @@ class FunctionDef(BaseDef, FixWxPrefix):
             return_type = returns[0]
         else:
             return_type = f"Tuple[{', '.join(returns)}]"
-        kind = MethodType.STATIC_METHOD if getattr(self, 'isStatic', False) else MethodType.METHOD
+        kind = MethodType.STATIC_METHOD if getattr(self, 'isStatic', False) else type(self)._default_method_type
         self.signature = Signature(name, *params, return_type=return_type, method_type=kind)
         self.pyArgsString = self.signature.args_string(False)
 
@@ -587,6 +589,8 @@ class MethodDef(FunctionDef):
     """
     Represents a class method, ctor or dtor declaration.
     """
+    _default_method_type = MethodType.METHOD
+
     def __init__(self, element=None, className=None, **kw):
         super(MethodDef, self).__init__()
         self.className = className
@@ -725,7 +729,6 @@ class ClassDef(BaseDef):
         self._convertFromPyObject = value.code
         name = self.name or self.pyName
         name = removeWxPrefix(name)
-        print('Registering:', name, value.convertables)
         FixWxPrefix.register_autoconversion(name, value.convertables)
 
     def is_top_level(self) -> bool:

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -80,6 +80,7 @@ header_pyi = """\
 
 typing_imports = """\
 from __future__ import annotations
+from datetime import datetime, date
 from enum import IntEnum, IntFlag, auto
 from typing import (Any, overload, TypeAlias, Generic,
     Union, Optional, List, Tuple, Callable
@@ -88,6 +89,12 @@ try:
     from typing import ParamSpec
 except ImportError:
     from typing_extensions import ParamSpec
+
+_TwoInts: TypeAlias = Tuple[int, int]
+_ThreeInts: TypeAlias = Tuple[int, int, int]
+_FourInts: TypeAlias = Tuple[int, int, int, int]
+_TwoFloats: TypeAlias = Tuple[float, float]
+_FourFloats: TypeAlias = Tuple[float, float, float, float]
 
 """
 

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -295,6 +295,8 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
         name = define.pyName or define.name
         if '"' in define.value:
             stream.write(f'{name}: str\n')
+        elif define.value in ('true', 'false'):
+            stream.write(f'{name}: bool\n')
         else:
             stream.write(f'{name}: int\n')
 

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -322,7 +322,8 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
             t = typedef.type.replace('>', '')
             t = t.replace(' ', '')
             bases = t.split('<')
-            bases = [self.fixWxPrefix(b, True) for b in bases]
+            bases = (self.fixWxPrefix(b, True) for b in bases)
+            bases = [b.replace('*', '') for b in bases] # fix for RichTextLine*
             name = self.fixWxPrefix(typedef.name)
 
         # Now write the Python equivalent class for the typedef

--- a/etgtools/sphinx_generator.py
+++ b/etgtools/sphinx_generator.py
@@ -622,7 +622,9 @@ class ParameterList(Node):
         theargs = []
 
         for arg in arguments:
-
+            arg = arg.split(':')[0].strip() # Remove the typehint
+            if arg in ('_from', '_def', '_is'): # Reserved Python keywords we've had to rename
+                arg = arg[1:]
             myarg = arg.split('=')[0].strip()
             if myarg:
                 theargs.append(myarg)

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -12,6 +12,7 @@ Some helpers and utility functions that can assist with the tweaker
 stage of the ETG scripts.
 """
 
+import enum
 import etgtools as extractors
 from .generators import textfile_open
 import keyword
@@ -19,7 +20,7 @@ import re
 import sys, os
 import copy
 import textwrap
-from typing import Optional, Tuple
+from typing import NamedTuple, Optional, Tuple, Union
 
 
 isWindows = sys.platform.startswith('win')
@@ -38,6 +39,174 @@ magicMethods = {
     'operator bool' : '__int__',  # Why not __nonzero__?
     # TODO: add more
 }
+
+
+class AutoConversionInfo(NamedTuple):
+    convertables: tuple[str, ...] # String type-hints for each of the types that can be automatically converted to this class
+    code: str                     # Code that will be added to SIP for this conversion
+
+
+class ParameterType(enum.Enum):
+    VAR_ARGS = enum.auto()
+    KWARGS = enum.auto()
+    POSITIONAL_ONLY = enum.auto()
+    DEFAULT = enum.auto()
+
+
+class MethodType(enum.Enum):
+    STATIC_METHOD = enum.auto()  # Class @staticmethod method
+    CLASS_METHOD = enum.auto()   # Class @classmethod method
+    METHOD = enum.auto()         # Class regular method
+    FUNCTION = enum.auto()       # non-class function
+
+
+class Signature:
+    """Like inspect.Signature, but a bit simpler because we need it only for a few purposes:
+    - Creation from a C++ args string
+    - We *don't* want stringized (ie: all of them) type-hints to be evaluated, since we're
+      processing them in a context where most of them will be unresolvable.
+    """
+
+    class Parameter:
+        __slots__ = ('name', 'type_hint', 'default', 'position_type', )
+        name: str
+        type_hint: Optional[str]
+        default: Optional[str]
+        position_type: ParameterType
+
+        def __init__(self, name: str, type_hint: Optional[str] = None, default: Optional[str] = None, position_type: ParameterType = ParameterType.DEFAULT) -> None:
+            if name.startswith('**'):
+                name = name[2:]
+                position_type = ParameterType.KWARGS
+            elif name.startswith('*'):
+                name = name[1:]
+                position_type = ParameterType.VAR_ARGS
+            type_hint = type_hint.replace('::', '.') if type_hint else None
+            default = default.replace('::', '.') if default else None
+            self.name = name
+            self.type_hint = type_hint
+            self.default = default
+            self.position_type = position_type
+
+        @property
+        def _position_marking(self) -> str:
+            if self.position_type is ParameterType.KWARGS:
+                return '**'
+            elif self.position_type is ParameterType.VAR_ARGS:
+                return '*'
+            return ''
+
+        def untyped(self) -> str:
+            if self.default is None:
+                return f'{self._position_marking}{self.name}'
+            else:
+                return f'{self._position_marking}{self.name}={self.default}'
+
+        def __str__(self) -> str:
+            if self.type_hint is None and self.default is None:
+                return f'{self._position_marking}{self.name}'
+            elif self.type_hint is None:
+                return f'{self._position_marking}{self.name}={self.default}'
+            elif self.default is None:
+                return f'{self._position_marking}{self.name}: {self.type_hint}'
+            else:
+                return f'{self._position_marking}{self.name}: {self.type_hint}={self.default}'
+            
+        def make_optional(self) -> None:
+            if self.type_hint is not None and not self.type_hint.startswith('Optional['):
+                self.type_hint = f'Optional[{self.type_hint}]'
+
+    __slots__ = ('_method_name', 'return_type', '_parameters', '_method_type', )
+    _method_name: str
+    return_type: Optional[str]
+    _parameters: dict[str, Parameter]
+    _method_type: MethodType    
+
+    def __init__(self, method_name: str, *parameters: Parameter, return_type: Optional[str] = None, method_type: MethodType = MethodType.METHOD) -> None:
+        self._parameters = {
+            p.name: p
+            for p in parameters
+        }
+        self.return_type = return_type.replace('::', '.') if return_type else None
+        self._method_type = method_type
+        self.method_name = method_name
+
+    @property
+    def method_name(self) -> str:
+        return self._method_name
+    
+    @method_name.setter
+    def method_name(self, value: str, /) -> None:
+        self._method_name = magicMethods.get(value, value)
+
+    def __getitem__(self, key: Union[str, int]) -> Parameter:
+        """Get parameter by name or by index. Indexing is into the paramters skips 'cls' and 'self' for
+        classmethods and methods.
+        """
+        if isinstance(key, int):
+            key = list(self._parameters)[key]
+        if isinstance(key, str):
+            return self._parameters[key]
+        else:
+            raise TypeError(f'Indexing must be via parameter name or index, got {key}')
+        
+    def __iter__(self):
+        return iter(self._parameters.values())
+        
+    def __contains__(self, parameter_name: str) -> bool:
+        return parameter_name in self._parameters
+
+    def args_string(self, typed: bool = True, include_selfcls: bool = False) -> str:
+        """Get a string of just the parameters needed for the method signature, 
+        optionally with 'self' or 'cls' where applicable, and type-hints
+        """
+        if include_selfcls and self.is_classmethod:
+            parameters = (type(self).Parameter('cls'), *self._parameters.values())
+        elif include_selfcls and self.is_method:
+            parameters = (type(self).Parameter('self'), *self._parameters.values())
+        else:
+            parameters = self._parameters.values()
+        stringizer = str if typed else type(self).Parameter.untyped
+        return_type = f' -> {self.return_type}' if self.return_type else ''
+        return f'({', '.join(map(stringizer, parameters))}){return_type}'
+    
+    def signature(self, typed: bool = True) -> str:
+        """Get the full signature for the function/method, including method and
+        all required python syntax, optionally including all type-hints.
+        """
+        return f'def {self.method_name}{self.args_string(typed, True)}:'
+    
+    def __str__(self) -> str:
+        return self.signature()
+
+    def definition_lines(self, typed: bool = True) -> list[str]:
+        """return the lines required to write the full method definition,
+        including decorators
+        """
+        if self.is_staticmethod:
+            lines = ['@staticmethod']
+        elif self.is_classmethod:
+            lines = ['@classmethod']
+        else:
+            lines = []
+        lines.append(self.signature(typed))
+        return lines
+
+    @property
+    def is_staticmethod(self) -> bool:
+        return self._method_type is MethodType.STATIC_METHOD
+    
+    @property
+    def is_classmethod(self) -> bool:
+        return self._method_type is MethodType.CLASS_METHOD
+    
+    @property
+    def is_method(self) -> bool:
+        return self._method_type is MethodType.METHOD
+    
+    @property
+    def is_function(self) -> bool:
+        return self._method_type is MethodType.FUNCTION
 
 
 def removeWxPrefixes(node):
@@ -151,7 +320,10 @@ class FixWxPrefix(object):
         Finally, the 'wx.' prefix is added if needed.
         """
         name = re.sub(r'(const(?![\w\d]))', '', name) # remove 'const', but not 'const'raints
-        for txt in ['*', '&', ' ']:
+        replacements = [' ', '*']
+        if not is_expression:
+            replacements.extend(['&'])
+        for txt in replacements:
             name = name.replace(txt, '')
         name = name.replace('::', '.')
         if not is_expression:

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -42,7 +42,7 @@ magicMethods = {
 
 
 class AutoConversionInfo(NamedTuple):
-    convertables: tuple[str, ...] # String type-hints for each of the types that can be automatically converted to this class
+    convertables: Tuple[str, ...] # String type-hints for each of the types that can be automatically converted to this class
     code: str                     # Code that will be added to SIP for this conversion
 
 
@@ -254,10 +254,10 @@ class FixWxPrefix(object):
     """
 
     _coreTopLevelNames = None
-    _auto_conversions: dict[str, tuple[str, ...]] = {}
+    _auto_conversions: dict[str, Tuple[str, ...]] = {}
 
     @classmethod
-    def register_autoconversion(cls, class_name: str, convertables: tuple[str, ...]) -> None:
+    def register_autoconversion(cls, class_name: str, convertables: Tuple[str, ...]) -> None:
         cls._auto_conversions[class_name] = convertables
 
     def fixWxPrefix(self, name, checkIsCore=False):

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -162,7 +162,7 @@ class FixWxPrefix(object):
         if fix_wx:
             return self.fixWxPrefix(name, True)
         else:
-            return removeWxPrefix(name)
+            return name
 
     def cleanType(self, type_name: str) -> str:
         """Process a C++ type name for use as a type annotation in Python code.

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -150,7 +150,8 @@ class FixWxPrefix(object):
 
         Finally, the 'wx.' prefix is added if needed.
         """
-        for txt in ['const', '*', '&', ' ']:
+        name = re.sub(r'(const(?![\w\d]))', '', name) # remove 'const', but not 'const'raints
+        for txt in ['*', '&', ' ']:
             name = name.replace(txt, '')
         name = name.replace('::', '.')
         if not is_expression:


### PR DESCRIPTION
Follow up to #2468 , addressing issues brought up in #2665 and #2666 . (I finally figured out my problem with running `etg` without `--nodoc`, so now I can finally test the doc building warnings).

Issues addressed:
 - [x] sphinx generator "SEVERE" warnings during signature validation:
   - Over-aggressive C++ syntax removal (ex: `constraint` -> `raint`) no longer happens.
   - Special case handle parameters named `_from`, `_is`, and `_def` (Python reserved keywords)
   - Most other warnings are handled by correctly factoring in (and removing) that the type-hints are present in the args string.
 - [x] `__bool__` returning `int`: Special case handling done in the writing of the method.  I'm not sure why we can't just change the definition in the sip file, but sip complains that it must return an `int`.
 - [x] `None` allowed for `parent` argument on `TopLevelWindow` subclasses.
 - [x] Marks values coming from `#define` directives which are boolean as `bool`.
 - [x] Properties declared using the `variable = property(<getter>, <setter>)` syntax not being seen as the applicable type.  This is a `typeshed` issue (and not one easily solve).  Addressed by using decorator syntax when a getter and type-hints are present on the getter and/or setter (setter-only properties still have to use the `variable = property(fset=<setter>)` syntax.
 - [x] sphinx generator warning for `SetAssertMode`.  The clean-name code was inappropriately removing applying the "remove wx prefix" code to argument names:
  ````
  ==> Function/Method signature from `extractors`: SetAssertMode(AppAssertMode : AppAssertMode)
  ==> Parameter list from wxWidgets XML items:     ['wxAppAssertMode']
  ````
- [ ] `wx.DateTime` accepts `datetime.datetime` and `datetime.date` objects in its constructor.  Similarly, `wx.Point`, `wx.Size`, and other similar automated conversions are handled.

Things I'd like extra eyes on:
- [x] `None` for `parent` argument: Are any of the changed type-stubs incorrect in allowing `None` there? Are there any missing?
- [x] Help with potentially addressing the `wx.DateTime` typing.

Closes #2665 
Closes #2666