### PR TITLE
Use Python 3.13 to build sdist during CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -53,10 +53,10 @@ jobs:
           submodules: 'recursive'
           fetch-depth: 0
 
-      - name: Set up Python 3.10
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: '3.13'
           cache: 'pip'
 
       - name: Install dependencies


### PR DESCRIPTION
Fixes: https://github.com/wxWidgets/Phoenix/issues/2670


