### PR TITLE
CI: only build the oldest and newest Pythons on PRs

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -113,6 +113,10 @@ jobs:
             architecture: x86
           - os: macos-13
             architecture: x86
+          # Only build oldest and newest Pythons on PRs
+          - python-version: ${{ github.event_name == 'pull_request' && '3.10' }}
+          - python-version: ${{ github.event_name == 'pull_request' && '3.11' }}
+          - python-version: ${{ github.event_name == 'pull_request' && '3.12' }}
 
     env:
       VERSION: ${{ needs.build-source-dist.outputs.VERSION }}


### PR DESCRIPTION
It seems a bit excessive and unnecessary to build for all Pythons on every PR.  Still build for all Pythons on commits.

