### PR TITLE
Remove attrdict3 build dependency and use plain dict

### DIFF
--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -977,7 +977,7 @@ def getVisCVersion():
         raise RuntimeError('getMSVCInfo has not been called yet.')
     # Convert a float like 14.28 to 140, for historical reasons
     # TODO: decide on switching to 142, 143, etc.??
-    ver = str(int(MSVCinfo.vc_ver)) + '0'
+    ver = str(int(MSVCinfo["vc_ver"])) + '0'
     return ver
 
 
@@ -990,7 +990,7 @@ def getExpectedVisCVersion():
     """
     if MSVCinfo is None:
         raise RuntimeError('getMSVCInfo has not been called yet.')
-    py_ver = MSVCinfo.py_ver
+    py_ver = MSVCinfo["py_ver"]
     if py_ver in ((3, 5), (3, 6), (3, 7), (3, 8)):
         min_ver = 14.0
     elif py_ver in ((3, 9), (3, 10)):
@@ -1009,8 +1009,6 @@ def getMSVCInfo(PYTHON, arch, set_env=False):
     if MSVCinfo is not None:
         return MSVCinfo
 
-    from attrdict import AttrDict
-
     # Note that it starts with a monkey-patch in setuptools.msvc to
     # workaround this issue: pypa/setuptools#1902
     cmd = \
@@ -1025,13 +1023,13 @@ def getMSVCInfo(PYTHON, arch, set_env=False):
         "print(env)"
     cmd = cmd.format(arch)
     env = eval(runcmd('"%s" -c "%s"' % (PYTHON, cmd), getOutput=True, echoCmd=False))
-    info = AttrDict(env)
+    info = dict(env)
 
     if set_env:
-        os.environ['PATH'] =    info.path
-        os.environ['INCLUDE'] = info.include
-        os.environ['LIB'] =     info.lib
-        os.environ['LIBPATH'] = info.libpath
+        os.environ['PATH'] =    info["path"]
+        os.environ['INCLUDE'] = info["include"]
+        os.environ['LIB'] =     info["lib"]
+        os.environ['LIBPATH'] = info["libpath"]
 
         # We already have everything we need, tell distutils to not go hunting
         # for it all again if it happens to be called.

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -27,5 +27,4 @@ Jinja2==2.10
 markupsafe==1.1.1
 doc2dash==2.3.0
 beautifulsoup4
-attrdict3 ; sys_platform == 'win32'
 typing-extensions; python_version < '3.10'

--- a/wscript
+++ b/wscript
@@ -75,7 +75,7 @@ def configure(conf):
         # WAF uses the VisualStudio version to select the compiler, rather than
         # the compiler version like we see elsewhere. Luckily we've got that
         # value in the MSVC info.
-        msvc_version = f"msvc {info.vs_ver}"
+        msvc_version = f'msvc {info["vs_ver"]}'
 
         conf.env['MSVC_VERSIONS'] = [msvc_version]
         conf.env['MSVC_TARGETS'] = [conf.options.msvc_arch]


### PR DESCRIPTION
While converting the project to pyproject.toml, I stumbled upon a missing dependency (that I was able to add as a build dependency). But when investigating it further, there was only one function using that import, and it doesn't do very much. There are multiple packages on PyPI with similar code, published under different names. But we don't really need it, there's only three places where it is used, so simply replacing it with a dictionary access is way enough.

Here's how I verified the equivalence between the two ways:
In buildtools/config.py, I renamed the info variable to info2, and populated info with a dict. I used pprint (prettyprint) to show the output, as it was too long otherwise.
```python
MSVCinfo = None
def getMSVCInfo(PYTHON, arch, set_env=False):
    """
    Fetch info from the system about MSVC, such as versions, paths, etc.
    """
    global MSVCinfo
    if MSVCinfo is not None:
        return MSVCinfo
    from attrdict import AttrDict
    # Note that it starts with a monkey-patch in setuptools.msvc to
    # workaround this issue: pypa/setuptools#1902
    cmd = \
        "import os, sys, setuptools.msvc; " \
        "setuptools.msvc.isfile = lambda path: path is not None and os.path.isfile(path); " \
        "ei = setuptools.msvc.EnvironmentInfo('{}', vc_min_ver=14.0); " \
        "env = ei.return_env(); " \
        "env['vc_ver'] = ei.vc_ver; " \
        "env['vs_ver'] = ei.vs_ver; " \
        "env['arch'] = ei.pi.arch; " \
        "env['py_ver'] = sys.version_info[:2]; " \
        "print(env)"
    cmd = cmd.format(arch)
    env = eval(runcmd('"%s" -c "%s"' % (PYTHON, cmd), getOutput=True, echoCmd=False))
    print("getMSVCInfo env variable is: ")
    print(env)
    info = dict(env)
    info2 = AttrDict(env)
    from pprint import pprint
    print("getMSVCInfo info2 is (pprint): ")
    pprint(info2)
    # print("getMSVCInfo info2 is (print): ")
    # print(info2)
    print("getMSVCInfo is: ")
    pprint(info)
    # print(info)
   
    if set_env:
        os.environ['PATH'] =    info["path"]
        os.environ['INCLUDE'] = info["include"]
        os.environ['LIB'] =     info["lib"]
        os.environ['LIBPATH'] = info["libpath"]

        # We already have everything we need, tell distutils to not go hunting
        # for it all again if it happens to be called.
        os.environ['DISTUTILS_USE_SDK'] = "1"
        os.environ['MSSdk'] = "1"
    MSVCinfo = info
    return info
```

During the CI builds on Windows machines, I noted the two outputs. They are exacly the same, except for my print that has the label:

<details><summary>Details: with dict</summary>
<p>

```
getMSVCInfo is: 
{'arch': 'amd64',
 'include': 'C:\\Program Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\Include;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\Include;C:\\Program '
            'Files (x86)\\Windows '
            'Kits\\NETFXSDK\\4.7.2\\include\\um;C:\\Program Files\\Microsoft '
            'Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\include;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\include;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Auxiliary\\VS\\include;C:\\Program '
            'Files (x86)\\Windows '
            'Kits\\10\\include\\10.0.26100.0\\ucrt;C:\\Program Files '
            '(x86)\\Windows '
            'Kits\\10\\\\include\\10.0.26100.0\\\\um;C:\\Program Files '
            '(x86)\\Windows '
            'Kits\\10\\\\include\\10.0.26100.0\\\\shared;C:\\Program Files '
            '(x86)\\Windows '
            'Kits\\10\\\\include\\10.0.26100.0\\\\winrt;C:\\Program Files '
            '(x86)\\Windows '
            'Kits\\10\\\\include\\10.0.26100.0\\\\cppwinrt;C:\\Program Files '
            '(x86)\\Windows Kits\\NETFXSDK\\4.8\\include\\um',
 'lib': 'C:\\Program Files\\Microsoft Visual '
        'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\Lib\\x64;C:\\Program '
        'Files\\Microsoft Visual '
        'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\Lib\\x64;C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319;C:\\Program '
        'Files (x86)\\Windows Kits\\NETFXSDK\\4.7.2\\lib\\um\\x64;C:\\Program '
        'Files\\Microsoft Visual '
        'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\lib\\x64;C:\\Program '
        'Files\\Microsoft Visual '
        'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\lib\\x64;C:\\Program '
        'Files (x86)\\Windows Kits\\NETFXSDK\\4.8\\lib\\um\\x64;C:\\Program '
        'Files (x86)\\Windows '
        'Kits\\10\\lib\\10.0.26100.0\\ucrt\\x64;C:\\Program Files '
        '(x86)\\Windows Kits\\10\\\\lib\\10.0.26100.0\\\\um\\x64',
 'libpath': 'C:\\Program Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\Lib\\x64;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\Lib\\x64;C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319;C:\\Program '
            'Files (x86)\\Windows Kits\\10\\References;C:\\Program Files '
            '(x86)\\Windows Kits\\10\\UnionMetadata;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\lib\\x64;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\lib\\x64;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\lib\\x86\\store\\references;C:\\Program '
            'Files (x86)\\Windows '
            'Kits\\10\\UnionMetadata\\10.0.26100.0;C:\\Program Files '
            '(x86)\\Windows Kits\\10\\References\\10.0.26100.0',
 'path': 'C:\\Program Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\bin\\HostX64\\x64;C:\\Program '
         'Files (x86)\\Windows Kits\\10\\Bin\\x64;C:\\Program Files '
         '(x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.7.2 '
         'Tools\\x64\\;C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319;C:\\Program '
         'Files (x86)\\HTML Help Workshop;C:\\Program '
         'Files\\Git\\mingw64\\bin;C:\\Program '
         'Files\\Git\\usr\\bin;C:\\hostedtoolcache\\windows\\Python\\3.9.13\\x64\\Scripts;C:\\hostedtoolcache\\windows\\Python\\3.9.13\\x64;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\VC\\VCPackages;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team '
         'Explorer;C:\\Program Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\MSBuild\\Current\\bin\\Roslyn;C:\\Program '
         'Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 '
         'Tools\\x64\\;C:\\Program Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\FSharp\\Tools;C:\\Program '
         'Files\\Microsoft Visual Studio\\2022\\Enterprise\\Team '
         'Tools\\DiagnosticsHub\\Collector;C:\\Program Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\Extensions\\Microsoft\\CodeCoverage.Console;C:\\Program '
         'Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\\\x64;C:\\Program '
         'Files (x86)\\Windows Kits\\10\\bin\\\\x64;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\\\MSBuild\\Current\\Bin\\amd64;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\Tools\\;C:\\Program '
         'Files\\MongoDB\\Server\\5.0\\bin;C:\\aliyun-cli;C:\\vcpkg;C:\\Program '
         'Files (x86)\\NSIS\\;C:\\tools\\zstd;C:\\Program '
         'Files\\Mercurial\\;C:\\hostedtoolcache\\windows\\stack\\3.3.1\\x64;C:\\\\ghcup\\bin;C:\\mingw64\\bin;C:\\Program '
         'Files\\dotnet;C:\\Program Files\\MySQL\\MySQL Server '
         '8.0\\bin;C:\\Program '
         'Files\\R\\R-4.4.2\\bin\\x64;C:\\SeleniumWebDrivers\\GeckoDriver;C:\\SeleniumWebDrivers\\EdgeDriver\\;C:\\SeleniumWebDrivers\\ChromeDriver;C:\\Program '
         'Files (x86)\\sbt\\bin;C:\\Program Files\\Git\\bin;C:\\Program Files '
         '(x86)\\pipx_bin;C:\\npm\\prefix;C:\\hostedtoolcache\\windows\\go\\1.21.13\\x64\\bin;C:\\hostedtoolcache\\windows\\Ruby\\3.0.7\\x64\\bin;C:\\Program '
         'Files\\OpenSSL\\bin;C:\\tools\\kotlinc\\bin;C:\\hostedtoolcache\\windows\\Java_Temurin-Hotspot_jdk\\8.0.432-6\\x64\\bin;C:\\Program '
         'Files\\ImageMagick-7.1.1-Q16-HDRI;C:\\Program Files\\Microsoft '
         'SDKs\\Azure\\CLI2\\wbin;C:\\ProgramData\\kind;C:\\ProgramData\\Chocolatey\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program '
         'Files\\dotnet\\;C:\\Program Files\\PowerShell\\7\\;C:\\Program '
         'Files\\Microsoft\\Web Platform Installer\\;C:\\Program '
         'Files\\TortoiseSVN\\bin;C:\\Program Files\\Microsoft SQL '
         'Server\\Client SDK\\ODBC\\170\\Tools\\Binn\\;C:\\Program '
         'Files\\Microsoft SQL Server\\150\\Tools\\Binn\\;C:\\Program Files '
         '(x86)\\Windows Kits\\10\\Windows Performance Toolkit\\;C:\\Program '
         'Files (x86)\\WiX Toolset v3.14\\bin;C:\\Program Files\\Microsoft SQL '
         'Server\\130\\DTS\\Binn\\;C:\\Strawberry\\c\\bin;C:\\Strawberry\\perl\\site\\bin;C:\\Strawberry\\perl\\bin;C:\\ProgramData\\chocolatey\\lib\\pulumi\\tools\\Pulumi\\bin;C:\\Program '
         'Files\\CMake\\bin;C:\\ProgramData\\chocolatey\\lib\\maven\\apache-maven-3.9.9\\bin;C:\\Program '
         'Files\\Microsoft Service '
         'Fabric\\bin\\Fabric\\Fabric.Code;C:\\Program Files\\Microsoft '
         'SDKs\\Service '
         'Fabric\\Tools\\ServiceFabricLocalClusterManager;C:\\Program '
         'Files\\nodejs\\;C:\\Program Files\\Git\\cmd;C:\\Program '
         'Files\\GitHub CLI\\;c:\\tools\\php;C:\\Program '
         'Files\\Amazon\\AWSCLIV2\\;C:\\Program '
         'Files\\Amazon\\SessionManagerPlugin\\bin\\;C:\\Program '
         'Files\\Amazon\\AWSSAMCLI\\bin\\;C:\\Program Files\\Microsoft SQL '
         'Server\\130\\Tools\\Binn\\;C:\\Program '
         'Files\\LLVM\\bin;C:\\Users\\runneradmin\\.dotnet\\tools;C:\\Users\\runneradmin\\.cargo\\bin;C:\\Users\\runneradmin\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program '
         'Files (x86)\\Microsoft Visual Studio\\Installer;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\VC\\Tools\\Llvm\\x64\\bin;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\CMake\\bin;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\Ninja;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\VC\\Linux\\bin\\ConnectionManagerExe;C:\\Program '
         'Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\vcpkg',
 'py_ver': (3, 9),
 'vc_ver': 14.42,
 'vs_ver': 17.12}
``` 

</p>
</details> 


<details><summary>Details</summary>
<p>

```
getMSVCInfo info2 is (pprint): 
{'arch': 'amd64',
 'include': 'C:\\Program Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\Include;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\Include;C:\\Program '
            'Files (x86)\\Windows '
            'Kits\\NETFXSDK\\4.7.2\\include\\um;C:\\Program Files\\Microsoft '
            'Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\include;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\include;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Auxiliary\\VS\\include;C:\\Program '
            'Files (x86)\\Windows '
            'Kits\\10\\include\\10.0.26100.0\\ucrt;C:\\Program Files '
            '(x86)\\Windows '
            'Kits\\10\\\\include\\10.0.26100.0\\\\um;C:\\Program Files '
            '(x86)\\Windows '
            'Kits\\10\\\\include\\10.0.26100.0\\\\shared;C:\\Program Files '
            '(x86)\\Windows '
            'Kits\\10\\\\include\\10.0.26100.0\\\\winrt;C:\\Program Files '
            '(x86)\\Windows '
            'Kits\\10\\\\include\\10.0.26100.0\\\\cppwinrt;C:\\Program Files '
            '(x86)\\Windows Kits\\NETFXSDK\\4.8\\include\\um',
 'lib': 'C:\\Program Files\\Microsoft Visual '
        'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\Lib\\x64;C:\\Program '
        'Files\\Microsoft Visual '
        'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\Lib\\x64;C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319;C:\\Program '
        'Files (x86)\\Windows Kits\\NETFXSDK\\4.7.2\\lib\\um\\x64;C:\\Program '
        'Files\\Microsoft Visual '
        'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\lib\\x64;C:\\Program '
        'Files\\Microsoft Visual '
        'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\lib\\x64;C:\\Program '
        'Files (x86)\\Windows Kits\\NETFXSDK\\4.8\\lib\\um\\x64;C:\\Program '
        'Files (x86)\\Windows '
        'Kits\\10\\lib\\10.0.26100.0\\ucrt\\x64;C:\\Program Files '
        '(x86)\\Windows Kits\\10\\\\lib\\10.0.26100.0\\\\um\\x64',
 'libpath': 'C:\\Program Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\Lib\\x64;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\Lib\\x64;C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319;C:\\Program '
            'Files (x86)\\Windows Kits\\10\\References;C:\\Program Files '
            '(x86)\\Windows Kits\\10\\UnionMetadata;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\ATLMFC\\lib\\x64;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\lib\\x64;C:\\Program '
            'Files\\Microsoft Visual '
            'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\lib\\x86\\store\\references;C:\\Program '
            'Files (x86)\\Windows '
            'Kits\\10\\UnionMetadata\\10.0.26100.0;C:\\Program Files '
            '(x86)\\Windows Kits\\10\\References\\10.0.26100.0',
 'path': 'C:\\Program Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\VC\\Tools\\MSVC\\14.42.34433\\bin\\HostX64\\x64;C:\\Program '
         'Files (x86)\\Windows Kits\\10\\Bin\\x64;C:\\Program Files '
         '(x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.7.2 '
         'Tools\\x64\\;C:\\Windows\\Microsoft.NET\\Framework64\\v4.0.30319;C:\\Program '
         'Files (x86)\\HTML Help Workshop;C:\\Program '
         'Files\\Git\\mingw64\\bin;C:\\Program '
         'Files\\Git\\usr\\bin;C:\\hostedtoolcache\\windows\\Python\\3.9.13\\x64\\Scripts;C:\\hostedtoolcache\\windows\\Python\\3.9.13\\x64;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\VC\\VCPackages;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TestWindow;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\TeamFoundation\\Team '
         'Explorer;C:\\Program Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\MSBuild\\Current\\bin\\Roslyn;C:\\Program '
         'Files (x86)\\Microsoft SDKs\\Windows\\v10.0A\\bin\\NETFX 4.8 '
         'Tools\\x64\\;C:\\Program Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\FSharp\\Tools;C:\\Program '
         'Files\\Microsoft Visual Studio\\2022\\Enterprise\\Team '
         'Tools\\DiagnosticsHub\\Collector;C:\\Program Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\Extensions\\Microsoft\\CodeCoverage.Console;C:\\Program '
         'Files (x86)\\Windows Kits\\10\\bin\\10.0.26100.0\\\\x64;C:\\Program '
         'Files (x86)\\Windows Kits\\10\\bin\\\\x64;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\\\MSBuild\\Current\\Bin\\amd64;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\Tools\\;C:\\Program '
         'Files\\MongoDB\\Server\\5.0\\bin;C:\\aliyun-cli;C:\\vcpkg;C:\\Program '
         'Files (x86)\\NSIS\\;C:\\tools\\zstd;C:\\Program '
         'Files\\Mercurial\\;C:\\hostedtoolcache\\windows\\stack\\3.3.1\\x64;C:\\\\ghcup\\bin;C:\\mingw64\\bin;C:\\Program '
         'Files\\dotnet;C:\\Program Files\\MySQL\\MySQL Server '
         '8.0\\bin;C:\\Program '
         'Files\\R\\R-4.4.2\\bin\\x64;C:\\SeleniumWebDrivers\\GeckoDriver;C:\\SeleniumWebDrivers\\EdgeDriver\\;C:\\SeleniumWebDrivers\\ChromeDriver;C:\\Program '
         'Files (x86)\\sbt\\bin;C:\\Program Files\\Git\\bin;C:\\Program Files '
         '(x86)\\pipx_bin;C:\\npm\\prefix;C:\\hostedtoolcache\\windows\\go\\1.21.13\\x64\\bin;C:\\hostedtoolcache\\windows\\Ruby\\3.0.7\\x64\\bin;C:\\Program '
         'Files\\OpenSSL\\bin;C:\\tools\\kotlinc\\bin;C:\\hostedtoolcache\\windows\\Java_Temurin-Hotspot_jdk\\8.0.432-6\\x64\\bin;C:\\Program '
         'Files\\ImageMagick-7.1.1-Q16-HDRI;C:\\Program Files\\Microsoft '
         'SDKs\\Azure\\CLI2\\wbin;C:\\ProgramData\\kind;C:\\ProgramData\\Chocolatey\\bin;C:\\Windows\\system32;C:\\Windows;C:\\Windows\\System32\\Wbem;C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\;C:\\Windows\\System32\\OpenSSH\\;C:\\Program '
         'Files\\dotnet\\;C:\\Program Files\\PowerShell\\7\\;C:\\Program '
         'Files\\Microsoft\\Web Platform Installer\\;C:\\Program '
         'Files\\TortoiseSVN\\bin;C:\\Program Files\\Microsoft SQL '
         'Server\\Client SDK\\ODBC\\170\\Tools\\Binn\\;C:\\Program '
         'Files\\Microsoft SQL Server\\150\\Tools\\Binn\\;C:\\Program Files '
         '(x86)\\Windows Kits\\10\\Windows Performance Toolkit\\;C:\\Program '
         'Files (x86)\\WiX Toolset v3.14\\bin;C:\\Program Files\\Microsoft SQL '
         'Server\\130\\DTS\\Binn\\;C:\\Strawberry\\c\\bin;C:\\Strawberry\\perl\\site\\bin;C:\\Strawberry\\perl\\bin;C:\\ProgramData\\chocolatey\\lib\\pulumi\\tools\\Pulumi\\bin;C:\\Program '
         'Files\\CMake\\bin;C:\\ProgramData\\chocolatey\\lib\\maven\\apache-maven-3.9.9\\bin;C:\\Program '
         'Files\\Microsoft Service '
         'Fabric\\bin\\Fabric\\Fabric.Code;C:\\Program Files\\Microsoft '
         'SDKs\\Service '
         'Fabric\\Tools\\ServiceFabricLocalClusterManager;C:\\Program '
         'Files\\nodejs\\;C:\\Program Files\\Git\\cmd;C:\\Program '
         'Files\\GitHub CLI\\;c:\\tools\\php;C:\\Program '
         'Files\\Amazon\\AWSCLIV2\\;C:\\Program '
         'Files\\Amazon\\SessionManagerPlugin\\bin\\;C:\\Program '
         'Files\\Amazon\\AWSSAMCLI\\bin\\;C:\\Program Files\\Microsoft SQL '
         'Server\\130\\Tools\\Binn\\;C:\\Program '
         'Files\\LLVM\\bin;C:\\Users\\runneradmin\\.dotnet\\tools;C:\\Users\\runneradmin\\.cargo\\bin;C:\\Users\\runneradmin\\AppData\\Local\\Microsoft\\WindowsApps;C:\\Program '
         'Files (x86)\\Microsoft Visual Studio\\Installer;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\VC\\Tools\\Llvm\\x64\\bin;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\CMake\\bin;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\CommonExtensions\\Microsoft\\CMake\\Ninja;C:\\Program '
         'Files\\Microsoft Visual '
         'Studio\\2022\\Enterprise\\Common7\\IDE\\VC\\Linux\\bin\\ConnectionManagerExe;C:\\Program '
         'Files\\Microsoft Visual Studio\\2022\\Enterprise\\VC\\vcpkg',
 'py_ver': (3, 9),
 'vc_ver': 14.42,
 'vs_ver': 17.12}
``` 

</p>
</details> 


Only the title is different ("getMSVCInfo is: " vs "getMSVCInfo info2 is (pprint): "), so it is equivalent. Before having all usages found (at first I missed the places where the global variable was used instead of the function), CI on my fork failed (documentation at first), but then passed.
So, it is safe to do that replacement, and not depend on a not widely used package.