### PR TITLE
Fix test with Python 3.13.1

### DIFF
--- a/unittests/test_cmdproc.py
+++ b/unittests/test_cmdproc.py
@@ -41,19 +41,19 @@ class cmdproc_Tests(wtc.WidgetTestCase):
 
         cmds = cmdproc.GetCommands()
         self.assertEqual(len(cmds), 5)
-        self.assertEqual([x.value for x in cmds], [True]*5)
+        self.assertEqual([x.value for x in list(cmds)], [True]*5)
 
         self.assertTrue(cmdproc.CanUndo())
         self.assertFalse(cmdproc.CanRedo())
 
         cmdproc.Undo()
         cmdproc.Undo()
-        self.assertEqual([x.value for x in cmds], [True]*3 + [False]*2)
+        self.assertEqual([x.value for x in list(cmds)], [True]*3 + [False]*2)
 
         self.assertTrue(cmdproc.CanRedo())
         cmdproc.Redo()
         cmdproc.Redo()
-        self.assertEqual([x.value for x in cmds], [True]*5)
+        self.assertEqual([x.value for x in list(cmds)], [True]*5)
 
         cmdproc.Undo()
         cmdproc.Undo()


### PR DESCRIPTION
Tests stopped working with recent Python 3.13, see https://github.com/python/cpython/pull/125846. This change fixes them.