### PR TITLE
Implement __iter__ for wxList iterator classes

### DIFF
--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -1055,6 +1055,11 @@ public:
         if (PyErr_Occurred())
             return NULL;
     %End
+
+    PyObject* __iter__();
+    %MethodCode
+        return PyObject_SelfIter(sipSelf);
+    %End
 }};
 
 class {ListClass}


### PR DESCRIPTION
This fixes being able to use these classes in for loops, for example. Specifically it fixes the cmdproc tests with Python 3.13.1.
