### PR TITLE
Fix bundled wxWidgets build on OpenSUSE

### DIFF
--- a/buildtools/build_wxwidgets.py
+++ b/buildtools/build_wxwidgets.py
@@ -370,13 +370,19 @@ def main(wxDir, args):
                 if os.path.exists(frameworkRootDir):
                     shutil.rmtree(frameworkRootDir)
 
+        # Workaround OpenSUSE libdir issue by unsetting CONFIG_SITE envvar
+        env = None
+        if "CONFIG_SITE" in os.environ:
+            env = dict(os.environ)
+            del env["CONFIG_SITE"]
+
         print("Configure options: " + repr(configure_opts))
         wxBuilder = builder.AutoconfBuilder()
         if not options.no_config and not options.clean:
             olddir = os.getcwd()
             if buildDir:
                 os.chdir(buildDir)
-            exitIfError(wxBuilder.configure(dir=wxRootDir, options=configure_opts),
+            exitIfError(wxBuilder.configure(dir=wxRootDir, options=configure_opts, env=env),
                         "Error running configure")
             os.chdir(olddir)
 

--- a/buildtools/builder.py
+++ b/buildtools/builder.py
@@ -165,7 +165,7 @@ class AutoconfBuilder(GNUMakeBuilder):
     def __init__(self, formatName="autoconf"):
         GNUMakeBuilder.__init__(self, formatName=formatName)
 
-    def configure(self, dir=None, options=None):
+    def configure(self, dir=None, options=None, env=None):
         #olddir = os.getcwd()
         #os.chdir(dir)
 
@@ -193,9 +193,9 @@ class AutoconfBuilder(GNUMakeBuilder):
         optionsStr = " ".join(options) if options else ""
         command = "%s %s" % (configure_cmd, optionsStr)
         print(command)
-        result = os.system(command)
+        result = subprocess.run(command, shell=True, env=env)
         #os.chdir(olddir)
-        return result
+        return result.returncode
 
 
 class MSVCBuilder(Builder):


### PR DESCRIPTION
OpenSUSE has defined its libdir to be 'lib64', which is mismatched with wxWidgets' in-place wx-config, which expects 'lib.'  Work around this by unsetting the CONFIG_SITE envvar (which enables the OpenSUSE customizations) when configuring wxWidgets.

Fixes: https://github.com/wxWidgets/Phoenix/issues/558
Fixes: https://github.com/wxWidgets/Phoenix/issues/1067
Fixes: https://github.com/wxWidgets/Phoenix/issues/2422
Fixes: https://github.com/wxWidgets/Phoenix/issues/2532

