### PR TITLE
Introduce basic pyproject.toml, supporting existing build methods only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,4 +25,5 @@ requires = [
 build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.setuptools.packages.find]
+exclude = ["src", "buildtools*", "etgtools", "sphinxtools", "src", "unittests"]
 namespaces = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,13 @@ dynamic = [
     "urls",
     "version",
 ]
+
+[build-system]
+requires = [
+    "setuptools>=61",
+    "cython == 3.0.10",
+    "sip == 6.9.1",
+]
+# Using "setuptools.build_meta:__legacy__" instead of "setuptools.build_meta" for now.
+# Allows to have access to the folder on the search path when building, like before.
+build-backend = "setuptools.build_meta:__legacy__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[project]
+name = "wxPython"
+dynamic = [
+    "authors",
+    "classifiers",
+    "dependencies",
+    "description",
+    "keywords",
+    "license",
+    "readme",
+    "scripts",
+    "urls",
+    "version",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,3 +23,6 @@ requires = [
 # Using "setuptools.build_meta:__legacy__" instead of "setuptools.build_meta" for now.
 # Allows to have access to the folder on the search path when building, like before.
 build-backend = "setuptools.build_meta:__legacy__"
+
+[tool.setuptools.packages.find]
+namespaces = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dynamic = [
 
 [build-system]
 requires = [
-    "setuptools>=61",
+    "setuptools>=70.1",
     "cython == 3.0.10",
     "sip == 6.9.1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dynamic = [
 requires = [
     "setuptools>=70.1",
     "cython == 3.0.10",
+    "requests >= 2.26.0",
     "sip == 6.9.1",
 ]
 # Using "setuptools.build_meta:__legacy__" instead of "setuptools.build_meta" for now.

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -6,8 +6,7 @@ sip == 6.9.1
 
 wheel
 twine
-requests
-requests[security]
+requests >= 2.26.0
 cython==3.0.10
 pytest
 pytest-xdist

--- a/setup-wxsvg.py
+++ b/setup-wxsvg.py
@@ -31,6 +31,28 @@ URL              = "http://wxPython.org/"
 DOWNLOAD_URL     = "https://pypi.org/project/wxPython"
 LICENSE          = "wxWindows Library License (https://opensource.org/licenses/wxwindows.php)"
 PLATFORMS        = "WIN32,WIN64,OSX,POSIX"
+KEYWORDS         = "GUI,wx,wxWindows,wxWidgets,cross-platform,user-interface,awesome"
+
+CLASSIFIERS      = """\
+Development Status :: 6 - Mature
+Environment :: MacOS X :: Cocoa
+Environment :: Win32 (MS Windows)
+Environment :: X11 Applications :: GTK
+Intended Audience :: Developers
+License :: OSI Approved
+Operating System :: MacOS :: MacOS X
+Operating System :: Microsoft :: Windows :: Windows 7
+Operating System :: Microsoft :: Windows :: Windows 10
+Operating System :: POSIX
+Programming Language :: Python :: 3.7
+Programming Language :: Python :: 3.8
+Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
+Programming Language :: Python :: 3.11
+Programming Language :: Python :: 3.12
+Programming Language :: Python :: Implementation :: CPython
+Topic :: Software Development :: User Interfaces
+"""
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 PACKAGE = 'wx.svg'
@@ -68,7 +90,10 @@ setup(name             = 'wx.svg',
       url              = URL,
       download_url     = DOWNLOAD_URL,
       license          = LICENSE,
+      classifiers      = [c for c in CLASSIFIERS.split("\n") if c],
+      keywords         = KEYWORDS,
       #packages         = [PACKAGE],
       ext_modules      = modules,
       options          = { 'build' : BUILD_OPTIONS,  },
+      scripts          = [],
 )

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,12 @@ from distutils.command.build        import build as orig_build
 from setuptools.command.install     import install as orig_install
 from setuptools.command.bdist_egg   import bdist_egg as orig_bdist_egg
 from setuptools.command.sdist       import sdist as orig_sdist
-try:
-    from wheel.bdist_wheel import bdist_wheel as orig_bdist_wheel
-    haveWheel = True
-except ImportError:
-    haveWheel = False
+from setuptools.command.bdist_wheel import bdist_wheel as orig_bdist_wheel
 
 from buildtools.config import Config, msg, opj, runcmd, canGetSOName, getSOName
 import buildtools.version as version
 
+haveWheel = True
 
 # Create a buildtools.config.Configuration object
 cfg = Config(noWxConfig=True)


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Related issues/PRs: https://github.com/wxWidgets/Phoenix/issues/2651, https://github.com/wxWidgets/Phoenix/pull/1253, https://github.com/wxWidgets/Phoenix/issues/2104
Does not close any of them, except maybe https://github.com/wxWidgets/Phoenix/pull/1253, as it only allows existing builds to continue working as before.


This PR adds a basic pyproject.toml file to the project. I limited the scope here to only have the existing build infrastructure, in GitHub actions and `python build.py bdist_wheel` locally (after having the other build steps done). It doesn't magically transform the builds that would make latest-and-greatest build methods now work that didn't work before. But it allows us to now build upon that and gradually reduce customizations when possible, and safely add configuration for tools into the pyproject.toml that can help us improve the global quality of the project.

Why do so little? I tried many many different ways, and even 80+ commits later, some things still didn't work everywhere, and the behaviour was different in many ways, which was hard to know if something could be a breaking change or not. Here, I kept it simple, only what was needed to get the same artifact with our existing commands.


So, the changes:
- Add a pyproject.toml. Adding a pyproject.toml triggers new defaults for various packaging related behaviors, so this "breaks" the current build. Let's fix this below.
- Add the name of the project in the `[project]` table.
- Declare metadata that is supplied to setuptools through the setup.py as dynamic. These could be ported to static metadata later on.
- Add a `[build-system]` table with the build-backend (set to the same fallback value as if it wasn't there). The `__legacy__` in `setuptools.build_meta:__legacy__` instead of `setuptools.build_meta` that should be used is because we currently rely on the old behaviour of having that root folder on the python search path, that isn't the case when a pyproject.toml file is present. (opts-in to some new modern defaults).
- Defines some build-time dependencies. This is what build frontends like pip will install in the clean, isolated, envs when building. This means that technically, `requirements/devel.txt` isn't useful anymore, in regard to what is needed when building. Not having "requests" listed there, for example, even if installed in CI, means it will not be available in the isolated env that would be used when building. Nothing else is present in that env. `requirements/devel.txt` is still kept for now, in order to have a state to revert to/compare to later on.
- Lower bound `requests` to remove `requests[security]` that is a no-op since years. It solves a package resolution problem where pip was trying all the combinations of older dependencies to satisfy this.
- Fix a deprecation warning that will be enforced in October 2025 with the `wheels` package. Simply use setuptools as suggested, and lower-bound the version of setuptools that includes that change. October 2025 is really near, and possibly the existing builds, even without this PR, wouldn't work anymore.
- Make the second setup.py for wx.svg (setup-wxsvg.py) work again, by adding dynamic metadata to the `setup()` call, as it fails the builds in the wheel stage as it expects a value, since these were declared as dynamic in the pyproject.toml. The values were copied from the main `setup.py`, and are not useful as such. They can be removed when the dynamic fields in question are ported to the pyproject.toml file later on. This means that I didn't have to mess around with changing the build mechanism of that cython module, which retarded this PR by 3-4 weeks when trying to make the builds fork with that extension module inside the main setup.py to avoid the dynamic metadata failure described above.

Apart from the changes seen in this PR, and the version numbers from vcs, the sdist is the same between main and this PR.
For Win x64 Python 3.13 wheels, same thing, except the LICENSE.txt of the .dist-info is utf8 with unix line endings (expected), and the usual variations in the compiled extensions.
Windows x86 python 3.9 wheels has the same kinds of changes as win x64 python 3.13 wheels.
macOS 3.13 wheel has only the version number related differences and the extension module differences (that impact checksums).



I would like this PR to be squashed-merged as a single commit. It is not intended to be bisected anyways, and my development wasn't oriented to be clean when debugging CI. (I know I cleaned a bit when rebasing, but still)
