### PR TITLE
Extract some static metadata from setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,9 +43,22 @@ dynamic = [
     "dependencies",
     "license",
     "readme",
-    "scripts",
     "version",
 ]
+
+[project.scripts]
+helpviewer = "wx.tools.helpviewer:main"
+img2png = "wx.tools.img2png:main"
+img2py = "wx.tools.img2py:main"
+img2xpm = "wx.tools.img2xpm:main"
+pycrust = "wx.py.PyCrust:main"
+pyshell = "wx.py.PyShell:main"
+pyslices = "wx.py.PySlices:main"
+pyslicesshell = "wx.py.PySlicesShell:main"
+pywxrc = "wx.tools.pywxrc:main"
+wxdemo = "wx.tools.wxget_docs_demo:demo_main" # Get/Launch Demo
+wxdocs = "wx.tools.wxget_docs_demo:docs_main" # Get/Launch Docs
+wxget = "wx.tools.wxget:main"                 # New wx wget
 
 [project.urls]
 Documentation = "https://docs.wxpython.org/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,17 +1,60 @@
 [project]
 name = "wxPython"
+description = "Cross platform GUI toolkit for Python, \"Phoenix\" version"
+requires-python = ">= 3.9"
+authors = [
+    { name = "Robin Dunn", email = "robin@alldunn.com" },
+    { name = "Scott Talbert", email = "swt@techie.net" },
+]
+keywords = [
+    "GUI",
+    "awesome",
+    "cross-platform",
+    "user-interface",
+    "wx",
+    "wxWidgets",
+    "wxWindows",
+]
+classifiers = [
+    "Development Status :: 6 - Mature",
+    "Environment :: MacOS X :: Cocoa",
+    "Environment :: Win32 (MS Windows)",
+    "Environment :: X11 Applications :: GTK",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved",
+    "Operating System :: MacOS",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: Microsoft :: Windows :: Windows 7",
+    "Operating System :: Microsoft :: Windows :: Windows 10",
+    "Operating System :: Microsoft :: Windows :: Windows 11",
+    "Operating System :: POSIX",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: Software Development :: User Interfaces",
+]
 dynamic = [
-    "authors",
-    "classifiers",
     "dependencies",
-    "description",
-    "keywords",
     "license",
     "readme",
     "scripts",
-    "urls",
     "version",
 ]
+
+[project.urls]
+Documentation = "https://docs.wxpython.org/"
+Download = "https://pypi.org/project/wxPython"
+Homepage = "https://wxPython.org/"
+Source = "https://github.com/wxWidgets/Phoenix"
+Repository = "https://github.com/wxWidgets/Phoenix.git"
+Issues = "https://github.com/wxWidgets/Phoenix/issues"
+Discuss = "https://discuss.wxpython.org/"
 
 [build-system]
 requires = [

--- a/setup-wxsvg.py
+++ b/setup-wxsvg.py
@@ -64,5 +64,4 @@ setup(name             = 'wx.svg',
       #packages         = [PACKAGE],
       ext_modules      = modules,
       options          = { 'build' : BUILD_OPTIONS,  },
-      scripts          = [],
 )

--- a/setup-wxsvg.py
+++ b/setup-wxsvg.py
@@ -25,34 +25,9 @@ cfg = Config(noWxConfig=True)
 
 DESCRIPTION      = 'Wrapper for nanosvg library, plus code for integrating with wxPython'
 LONG_DESCRIPTION = ''
-AUTHOR           = 'Robin Dunn'
-AUTHOR_EMAIL     = 'robin@alldunn.com'
-URL              = "http://wxPython.org/"
-DOWNLOAD_URL     = "https://pypi.org/project/wxPython"
 LICENSE          = "wxWindows Library License (https://opensource.org/licenses/wxwindows.php)"
 PLATFORMS        = "WIN32,WIN64,OSX,POSIX"
-KEYWORDS         = "GUI,wx,wxWindows,wxWidgets,cross-platform,user-interface,awesome"
 
-CLASSIFIERS      = """\
-Development Status :: 6 - Mature
-Environment :: MacOS X :: Cocoa
-Environment :: Win32 (MS Windows)
-Environment :: X11 Applications :: GTK
-Intended Audience :: Developers
-License :: OSI Approved
-Operating System :: MacOS :: MacOS X
-Operating System :: Microsoft :: Windows :: Windows 7
-Operating System :: Microsoft :: Windows :: Windows 10
-Operating System :: POSIX
-Programming Language :: Python :: 3.7
-Programming Language :: Python :: 3.8
-Programming Language :: Python :: 3.9
-Programming Language :: Python :: 3.10
-Programming Language :: Python :: 3.11
-Programming Language :: Python :: 3.12
-Programming Language :: Python :: Implementation :: CPython
-Topic :: Software Development :: User Interfaces
-"""
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 PACKAGE = 'wx.svg'
@@ -85,13 +60,7 @@ setup(name             = 'wx.svg',
       version          = cfg.VERSION,
       description      = DESCRIPTION,
       long_description = LONG_DESCRIPTION,
-      author           = AUTHOR,
-      author_email     = AUTHOR_EMAIL,
-      url              = URL,
-      download_url     = DOWNLOAD_URL,
       license          = LICENSE,
-      classifiers      = [c for c in CLASSIFIERS.split("\n") if c],
-      keywords         = KEYWORDS,
       #packages         = [PACKAGE],
       ext_modules      = modules,
       options          = { 'build' : BUILD_OPTIONS,  },

--- a/setup.py
+++ b/setup.py
@@ -31,19 +31,8 @@ DOCS_BASE='http://docs.wxPython.org'
 
 #----------------------------------------------------------------------
 
-NAME             = version.PROJECT_NAME
-DESCRIPTION      = "Cross platform GUI toolkit for Python, \"Phoenix\" version"
-AUTHOR           = "Robin Dunn"
-AUTHOR_EMAIL     = "robin@alldunn.com"
-URL              = "http://wxPython.org/"
-PROJECT_URLS     = {
-                    "Source": "https://github.com/wxWidgets/Phoenix",
-                    "Documentation": "https://docs.wxpython.org/",
-                   }
-DOWNLOAD_URL     = "https://pypi.org/project/{}".format(NAME)
 LICENSE          = "wxWindows Library License (https://opensource.org/licenses/wxwindows.php)"
 PLATFORMS        = "WIN32,WIN64,OSX,POSIX"
-KEYWORDS         = "GUI,wx,wxWindows,wxWidgets,cross-platform,user-interface,awesome"
 
 LONG_DESCRIPTION = """\
 Welcome to wxPython's Project Phoenix! Phoenix is the improved next-generation
@@ -70,27 +59,6 @@ the respective items. (Documents are launched in the default browser and demo is
 with python).
 """.format(version=cfg.VERSION, docs_base=DOCS_BASE)
 
-
-CLASSIFIERS      = """\
-Development Status :: 6 - Mature
-Environment :: MacOS X :: Cocoa
-Environment :: Win32 (MS Windows)
-Environment :: X11 Applications :: GTK
-Intended Audience :: Developers
-License :: OSI Approved
-Operating System :: MacOS :: MacOS X
-Operating System :: Microsoft :: Windows :: Windows 7
-Operating System :: Microsoft :: Windows :: Windows 10
-Operating System :: POSIX
-Programming Language :: Python :: 3.7
-Programming Language :: Python :: 3.8
-Programming Language :: Python :: 3.9
-Programming Language :: Python :: 3.10
-Programming Language :: Python :: 3.11
-Programming Language :: Python :: 3.12
-Programming Language :: Python :: Implementation :: CPython
-Topic :: Software Development :: User Interfaces
-"""
 
 with open('requirements/install.txt') as fid:
     INSTALL_REQUIRES = [line.strip()
@@ -358,20 +326,11 @@ BUILD_OPTIONS = { } #'build_base' : cfg.BUILD_BASE }
 
 
 if __name__ == '__main__':
-    setup(name             = NAME,
-          version          = cfg.VERSION,
-          description      = DESCRIPTION,
+    setup(version          = cfg.VERSION,
           long_description = LONG_DESCRIPTION,
           long_description_content_type = 'text/x-rst',
-          author           = AUTHOR,
-          author_email     = AUTHOR_EMAIL,
-          url              = URL,
-          project_urls     = PROJECT_URLS,
-          download_url     = DOWNLOAD_URL,
           license          = LICENSE,
           platforms        = PLATFORMS,
-          classifiers      = [c for c in CLASSIFIERS.split("\n") if c],
-          keywords         = KEYWORDS,
           install_requires = INSTALL_REQUIRES,
           zip_safe         = False,
           include_package_data = True,

--- a/setup.py
+++ b/setup.py
@@ -294,28 +294,6 @@ setuptools.command.build_py.make_writable = wx_make_writable
 
 WX_PKGLIST = [cfg.PKGDIR] + [cfg.PKGDIR + '.' + pkg for pkg in find_packages('wx')]
 
-ENTRY_POINTS = {
-    'console_scripts' : [
-        "img2png = wx.tools.img2png:main",
-        "img2py = wx.tools.img2py:main",
-        "img2xpm = wx.tools.img2xpm:main",
-        "pywxrc = wx.tools.pywxrc:main",
-#        ],
-#    'gui_scripts' : [  # TODO: Why was this commented out?
-        "wxget = wx.tools.wxget:main",  # New wx wget
-        "wxdocs = wx.tools.wxget_docs_demo:docs_main",  # Get/Launch Docs
-        "wxdemo = wx.tools.wxget_docs_demo:demo_main",  # Get/Launch Demo
-        "helpviewer = wx.tools.helpviewer:main",
-        "pycrust = wx.py.PyCrust:main",
-        "pyshell = wx.py.PyShell:main",
-        "pyslices = wx.py.PySlices:main",
-        "pyslicesshell = wx.py.PySlicesShell:main",
-        ],
-    }
-
-SCRIPTS = []
-DATA_FILES = []
-
 HEADERS = None
 BUILD_OPTIONS = { } #'build_base' : cfg.BUILD_BASE }
 #if cfg.WXPORT == 'msw':
@@ -340,9 +318,6 @@ if __name__ == '__main__':
 
           options          = { 'build'     : BUILD_OPTIONS },
 
-          scripts          = SCRIPTS,
-          data_files       = DATA_FILES,
           headers          = HEADERS,
           cmdclass         = CMDCLASS,
-          entry_points     = ENTRY_POINTS,
         )


### PR DESCRIPTION
Follows #2687.

This PR is a first simplification of the setup.py scripts.
It ports some metadata and other static info to the pyproject.toml file.

I touched up a bit the classifiers, urls, and authors to match the current situation, so it is not a 1:1 match. (Well, it was when I copied it, but after that I made some edits). For the authors, I looked at the commit info for adding the current maintainer. I invite you to take a look at it and see if it is fine with you (ie, is Windows 7 still relevant? What about missing Windows 8, 8.1 between 7 and 10?)


Differences:
Apart from the files changed in this PR and the version-related changes, this is the difference that is caused:

sdist:
![image](https://github.com/user-attachments/assets/19f93cac-0a33-4e37-8431-66eddb87c045)
![image](https://github.com/user-attachments/assets/6de642a9-43cd-41db-9287-340cd2cad773)
![image](https://github.com/user-attachments/assets/37082678-1a90-47a4-9d94-47973d893bd9)
![image](https://github.com/user-attachments/assets/a2975d38-628c-480e-ac91-8c3ce94c146b)



windows x64 py3.13 wheel:
![image](https://github.com/user-attachments/assets/b0f69a82-fcf3-4b0f-a747-4caff8368c5c)
![image](https://github.com/user-attachments/assets/da2d4dda-90f1-4f98-a1b5-35ce203c08dc)
