### PR TITLE
Simplify haveWheel condition in setup.py

### DIFF
--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -4,7 +4,6 @@ appdirs
 setuptools
 sip == 6.9.1
 
-wheel
 twine
 requests >= 2.26.0
 cython==3.0.10


### PR DESCRIPTION
Following #2687, where the wheel dependency has been changed to use the setuptools recommended approach, as the old pattern would have been removed in October 2025, this PR removes the `haveWheel` condition from the setup.py. (Unindent code where needed)

In the same depreciation issue handling, the `wheel` dependency (that was installed through pip), was needed before setuptools 70.1 as it provided the `bdist_wheel` implementation. Since we already require that minimum setuptools, drop the `wheel` dependency.

> ### Historical note
> This project used to contain the implementation of the [setuptools](https://pypi.org/project/setuptools/) `bdist_wheel` command, but as of setuptools v70.1, it no longer needs `wheel` installed for that to work. Thus, you should install this only if you intend to use the `wheel` command line tool!

_From https://pypi.org/project/wheel/_

Note that `pip wheel` doesn't require our project to install `wheel` to work as before.