### PR TITLE
Remove references to Python 2.7 defaults from build.py

### DIFF
--- a/build.py
+++ b/build.py
@@ -48,8 +48,8 @@ import buildtools.version as version
 
 
 # defaults
-PYVER = '2.7'
-PYSHORTVER = '27'
+PYVER = '3.9'
+PYSHORTVER = '39'
 PYTHON = None  # it will be set later
 PYTHON_ARCH = 'UNKNOWN'
 
@@ -106,7 +106,7 @@ Usage: ./build.py [command(s)] [options]
 
   Commands:
       N.N NN        Major.Minor version number of the Python to use to run
-                    the other commands.  Default is 2.7.  Or you can use
+                    the other commands.  Default is 3.9.  Or you can use
                     --python to specify the actual Python executable to use.
 
       dox           Run Doxygen to produce the XML file used by ETG scripts


### PR DESCRIPTION
The build.py script is already impossible to run with Python 2.7, so there is no reason left to still set it as a default and help output.

There also line 1637 that has a list of python versions, that is possibly not maintained. As I didn't fully understand the implications, I didn't do anything. (Is it copying DLLs only for older versions? or all supported versions must be kept in that list?)
https://github.com/wxWidgets/Phoenix/blob/45f9e89f5daf964188d1a20fea59e5205373cad6/build.py#L1637

Other script files that I couldn't reason about their usages, are
https://github.com/wxWidgets/Phoenix/blob/45f9e89f5daf964188d1a20fea59e5205373cad6/bin/build-sip-msw
and 
https://github.com/wxWidgets/Phoenix/blob/45f9e89f5daf964188d1a20fea59e5205373cad6/bin/build-sip-posix

Probably both are nonfunctioning now.