### PR TITLE
style: Normalise numpy imports with `import numpy as np`

### DIFF
--- a/demo/FloatCanvas.py
+++ b/demo/FloatCanvas.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 try:
-    import numpy as N
+    import numpy as np
     import numpy.random as RandomArray
     haveNumpy = True
     #print("Using numpy, version:", N.__version__)
@@ -720,7 +720,7 @@ def BuildDrawFrame(): # this gets called when needed, rather than on import
 
             x += dx
             color = "SEA GREEN"
-            Points = N.array(( (x, y), (x, y+2.*h/3), (x+w, y+h), (x+w, y+h/2.), (x + 2.*w/3, y+h/2.), (x + 2.*w/3,y) ), N.float64)
+            Points = np.array(( (x, y), (x, y+2.*h/3), (x+w, y+h), (x+w, y+h/2.), (x + 2.*w/3, y+h/2.), (x + 2.*w/3,y) ), np.float64)
             R = Canvas.AddPolygon(Points,  LineWidth = 2, FillColor = color)
             R.Name = color + " Polygon"
             R.Bind(FloatCanvas.EVT_FC_RIGHT_DOWN, self.RectGotHitRight)
@@ -729,7 +729,7 @@ def BuildDrawFrame(): # this gets called when needed, rather than on import
 
             x += dx
             color = "Red"
-            Points = N.array(( (x, y), (x, y+2.*h/3), (x+w, y+h), (x+w, y+h/2.), (x + 2.*w/3, y+h/2.), (x + 2.*w/3,y) ), N.float64)
+            Points = np.array(( (x, y), (x, y+2.*h/3), (x+w, y+h), (x+w, y+h/2.), (x + 2.*w/3, y+h/2.), (x + 2.*w/3,y) ), np.float64)
             R = Canvas.AddPointSet(Points,  Diameter = 4, Color = color)
             R.Name = "PointSet"
             R.Bind(FloatCanvas.EVT_FC_LEFT_DOWN, self.PointSetGotHit)
@@ -1139,7 +1139,7 @@ def BuildDrawFrame(): # this gets called when needed, rather than on import
                                           Family = wx.FONTFAMILY_ROMAN,
                                           Alignment = "right"
                                           )
-            Point = N.array((100, -20), N.float64)
+            Point = np.array((100, -20), np.float64)
             Box = Canvas.AddScaledTextBox("Here is even more auto wrapped text. This time the line spacing is set to 0.8. \n\nThe Padding is set to 0.",
                                           Point,
                                           Size = 3,
@@ -1153,7 +1153,7 @@ def BuildDrawFrame(): # this gets called when needed, rather than on import
                                           )
             Canvas.AddPoint(Point, "Red", 2)
 
-            Point = N.array((0, -40), N.float64)
+            Point = np.array((0, -40), np.float64)
     #        Point = N.array((0, 0), N.float_)
             for Position in ["tl", "bl", "tr", "br"]:
     #        for Position in ["br"]:
@@ -1172,7 +1172,7 @@ def BuildDrawFrame(): # this gets called when needed, rather than on import
                                           )
             Canvas.AddPoint(Point, "Red", 4)
 
-            Point = N.array((-20, 60), N.float64)
+            Point = np.array((-20, 60), np.float64)
             Box = Canvas.AddScaledTextBox("Here is some\ncentered\ntext",
                                           Point,
                                           Size = 4,
@@ -1188,7 +1188,7 @@ def BuildDrawFrame(): # this gets called when needed, rather than on import
                                           LineSpacing = 0.8
                                           )
 
-            Point = N.array((-20, 20), N.float64)
+            Point = np.array((-20, 20), np.float64)
             Box = Canvas.AddScaledTextBox("Here is some\nright aligned\ntext",
                                           Point,
                                           Size = 4,
@@ -1203,7 +1203,7 @@ def BuildDrawFrame(): # this gets called when needed, rather than on import
                                           LineSpacing = 0.8
                                           )
 
-            Point = N.array((100, -60), N.float64)
+            Point = np.array((100, -60), np.float64)
             Box = Canvas.AddScaledTextBox("Here is some auto wrapped text. This time it is centered, rather than right aligned.\n\nThe Padding is set to 2.",
                                           Point,
                                           Size = 3,
@@ -1728,11 +1728,11 @@ def BuildDrawFrame(): # this gets called when needed, rather than on import
             for line in data:
                 if line:
                     if line == "# -b": #New segment beginning
-                        if segment: Shorelines.append(N.array(segment))
+                        if segment: Shorelines.append(np.array(segment))
                         segment = []
                     else:
                         segment.append([float(e) for e in line.split()])
-            if segment: Shorelines.append(N.array(segment))
+            if segment: Shorelines.append(np.array(segment))
 
             if stats:
                 NumSegments = len(Shorelines)

--- a/demo/PyPlot.py
+++ b/demo/PyPlot.py
@@ -3,7 +3,7 @@ import wx
 
 hadImportError = False
 try:
-    import numpy
+    import numpy as np
     import wx.lib.plot
 except ImportError:
     hadImportError = True

--- a/demo/RawBitmapAccess.py
+++ b/demo/RawBitmapAccess.py
@@ -19,9 +19,9 @@ TEST_GC = False
 
 if USE_NUMPY:
     try:
-        import numpy
+        import numpy as np
         def makeByteArray(shape):
-            return numpy.empty(shape, numpy.uint8)
+            return np.empty(shape, np.uint8)
         numtype = 'numpy'
     except ImportError:
         try:

--- a/samples/floatcanvas/BNAEditor.py
+++ b/samples/floatcanvas/BNAEditor.py
@@ -9,7 +9,7 @@ BNA is a simple text format for storing polygons in lat-long coordinates.
 import os, sys
 import sets
 
-import numpy as N
+import numpy as np
 
 #### import local version:
 #sys.path.append("..")
@@ -75,7 +75,7 @@ class BNAData:
                 num_points = int(line)
                 self.Types.append(Type)
                 self.Names.append(Name)
-                polygon = N.zeros((num_points,2),N.float)
+                polygon = np.zeros((num_points,2),np.float)
                 for i in range(num_points):
                     polygon[i,:] = map(float, file_.readline().split(','))
                 self.PointsData.append(polygon)
@@ -208,7 +208,7 @@ class DrawFrame(wx.Frame):
             dc.SetPen(wx.Pen('WHITE', 2, wx.SHORT_DASH))
             dc.SetLogicalFunction(wx.XOR)
             if self.SelectedPointNeighbors is None:
-                self.SelectedPointNeighbors = N.zeros((3,2), N.float)
+                self.SelectedPointNeighbors = np.zeros((3,2), np.float)
                 #fixme: This feels very inelegant!
                 if Index == 0:
                     self.SelectedPointNeighbors[0] = self.SelectedPoly.Points[-1]

--- a/samples/floatcanvas/BarPlot.py
+++ b/samples/floatcanvas/BarPlot.py
@@ -9,7 +9,7 @@ from wx.lib.floatcanvas import NavCanvas, FloatCanvas
 #sys.path.append("../")
 #from floatcanvas import NavCanvas, FloatCanvas
 
-import numpy as N
+import numpy as np
 from numpy import random as random
 
 NumChannels = 200
@@ -27,7 +27,7 @@ def YScaleFun(center):
     """
 
     # center gets ignored in this case
-    return N.array((1, float(NumChannels)/MaxValue), N.float)
+    return np.array((1, float(NumChannels)/MaxValue), np.float)
 
 def ScaleWorldToPixel(self, Lengths):
     """
@@ -41,7 +41,7 @@ def ScaleWorldToPixel(self, Lengths):
         Lengths should be a NX2 array of (x,y) coordinates, or
         a 2-tuple, or sequence of 2-tuples.
     """
-    return  N.ceil(( (N.asarray(Lengths, N.float)*self.TransformVector) )).astype('i')
+    return  np.ceil(( (np.asarray(Lengths, np.float)*self.TransformVector) )).astype('i')
 
 
 class DrawFrame(wx.Frame):
@@ -75,7 +75,7 @@ class DrawFrame(wx.Frame):
         self.BarWidth = 0.75
         # add an X axis
         Canvas.AddLine(((0,0), (NumChannels, 0 )),)
-        for x in N.linspace(1, NumChannels, 11):
+        for x in np.linspace(1, NumChannels, 11):
             Canvas.AddText("%i"%x, (x-1+self.BarWidth/2,0), Position="tc")
 
         for i, Value in enumerate(self.Values):

--- a/samples/floatcanvas/DrawRect.py
+++ b/samples/floatcanvas/DrawRect.py
@@ -20,7 +20,7 @@ import wx
 from wx.lib.floatcanvas import NavCanvas, FloatCanvas, GUIMode
 from wx.lib.floatcanvas.Utilities import GUI
 
-import numpy as N
+import numpy as np
 
 class DrawFrame(wx.Frame):
 

--- a/samples/floatcanvas/Hexagons.py
+++ b/samples/floatcanvas/Hexagons.py
@@ -19,7 +19,7 @@ from wx.lib.floatcanvas import NavCanvas, FloatCanvas
 
 NumHexagons = 1000
 
-import numpy as N
+import numpy as np
 from numpy.random import uniform
 
 import  random
@@ -56,8 +56,8 @@ class DrawFrame(wx.Frame):
         print("Max colors:", len(self.colors))
         Canvas = self.Canvas
         D = 1.0
-        h = D *N.sqrt(3)/2
-        Hex = N.array(((D   , 0),
+        h = D *np.sqrt(3)/2
+        Hex = np.array(((D   , 0),
                      (D/2 , -h),
                      (-D/2, -h),
                      (-D  , 0),

--- a/samples/floatcanvas/MovingElements.py
+++ b/samples/floatcanvas/MovingElements.py
@@ -26,7 +26,7 @@ elif ver == 'local':
     from floatcanvas import FloatCanvas as FC
     from floatcanvas.Utilities import BBox
 
-import numpy as N
+import numpy as np
 
 ## here we create some new mixins:
 
@@ -38,7 +38,7 @@ class MovingObjectMixin:
 
     def GetOutlinePoints(self):
         BB = self.BoundingBox
-        OutlinePoints = N.array( ( (BB[0,0], BB[0,1]),
+        OutlinePoints = np.array( ( (BB[0,0], BB[0,1]),
                                     (BB[0,0], BB[1,1]),
                                     (BB[1,0], BB[1,1]),
                                     (BB[1,0], BB[0,1]),
@@ -119,7 +119,7 @@ class ConnectorLine(FC.LineOnlyMixin, FC.DrawObject,):
 
 
     def _Draw(self, dc , WorldToPixel, ScaleWorldToPixel, HTdc=None):
-        Points = N.array( (self.Object1.GetConnectPoint(),
+        Points = np.array( (self.Object1.GetConnectPoint(),
                            self.Object2.GetConnectPoint()) )
         Points = WorldToPixel(Points)
         dc.SetPen(self.Pen)
@@ -139,7 +139,7 @@ class TriangleShape1(FC.Polygon, MovingObjectMixin):
         L is the length of one side of the Triangle
         """
 
-        XY = N.asarray(XY)
+        XY = np.asarray(XY)
         XY.shape = (2,)
 
         Points = self.CompPoints(XY, L)
@@ -155,12 +155,12 @@ class TriangleShape1(FC.Polygon, MovingObjectMixin):
         return self.Points
 
     def CompPoints(self, XY, L):
-        c = L/ N.sqrt(3)
+        c = L/ np.sqrt(3)
 
-        Points = N.array(((0, c),
+        Points = np.array(((0, c),
                           ( L/2.0, -c/2.0),
                           (-L/2.0, -c/2.0)),
-                          N.float64)
+                          np.float64)
 
         Points += XY
         return Points
@@ -189,10 +189,10 @@ class DrawFrame(wx.Frame):
         Canvas.Bind(FC.EVT_MOTION, self.OnMove )
         Canvas.Bind(FC.EVT_LEFT_UP, self.OnLeftUp )
 
-        Points = N.array(((0,0),
+        Points = np.array(((0,0),
                           (1,0),
                           (0.5, 1)),
-                         N.float)
+                         np.float)
 
         data  = (( (0,0),  1),
                  ( (3,3),  2),

--- a/samples/floatcanvas/MovingPlot.py
+++ b/samples/floatcanvas/MovingPlot.py
@@ -7,7 +7,7 @@ efficient moving line on it.
 """
 
 import wx
-import numpy as N
+import numpy as np
 
 ## import the installed version
 from wx.lib.floatcanvas import NavCanvas, FloatCanvas
@@ -114,19 +114,19 @@ class DrawFrame(wx.Frame):
         # what the options are.
 
         self.Canvas.AddRectangle((0, -1.1),
-                                 (2*N.pi, 2.2),
+                                 (2*np.pi, 2.2),
                                  LineColor = "Black",
                                  LineStyle = "Solid",
                                  LineWidth    = 1,
                                  FillColor    = None,
                                  FillStyle    = "Solid",
                                  InForeground = 0)
-        for tic in N.arange(7):
+        for tic in np.arange(7):
             self.Canvas.AddText("%1.1f"%tic,
                                 (tic,-1.1),
                                 Position = 'tc')
 
-        for tic in N.arange(-1, 1.1, 0.5):
+        for tic in np.arange(-1, 1.1, 0.5):
             self.Canvas.AddText("%1.1f"%tic,
                                 (0,tic),
                                 Position = 'cr')
@@ -145,7 +145,7 @@ class DrawFrame(wx.Frame):
 
     def OnTimer(self,event):
         self.count += .1
-        self.data1[:,1] = N.sin(self.time+self.count) #fake move
+        self.data1[:,1] = np.sin(self.time+self.count) #fake move
 
         self.line.SetPoints(self.data1)
 
@@ -155,11 +155,11 @@ class DrawFrame(wx.Frame):
         self.n  = 100
         self.dT = 0.05
 
-        self.time = 2.0*N.pi*N.arange(100)/100.0
+        self.time = 2.0*np.pi*np.arange(100)/100.0
 
-        self.data1 = 1.0*N.ones((100,2))
+        self.data1 = 1.0*np.ones((100,2))
         self.data1[:,0] = self.time
-        self.data1[:,1] = N.sin(self.time)
+        self.data1[:,1] = np.sin(self.time)
         Canvas = self.Canvas
         self.Canvas.ClearAll()
         self.DrawAxis()

--- a/samples/floatcanvas/MovingTriangle.py
+++ b/samples/floatcanvas/MovingTriangle.py
@@ -21,7 +21,7 @@ elif ver == 'local':
     from floatcanvas import NavCanvas,  Resources
     from floatcanvas import FloatCanvas as FC
 
-import numpy as N
+import numpy as np
 
 ## here we create a new DrawObject:
 ##  code borrowed and adapted from Werner Bruhin
@@ -45,7 +45,7 @@ class TriangleShape1(FC.Polygon, ShapeMixin):
         L is the length of one side of the Triangle
         """
 
-        XY = N.asarray(XY)
+        XY = np.asarray(XY)
         XY.shape = (2,)
 
         Points = self.CompPoints(XY, L)
@@ -59,12 +59,12 @@ class TriangleShape1(FC.Polygon, ShapeMixin):
         ShapeMixin.__init__(self)
 
     def CompPoints(self, XY, L):
-        c = L/ N.sqrt(3)
+        c = L/ np.sqrt(3)
 
-        Points = N.array(((0, c),
+        Points = np.array(((0, c),
                           ( L/2.0, -c/2.0),
                           (-L/2.0, -c/2.0)),
-                          N.float64)
+                          np.float64)
 
         Points += XY
         return Points
@@ -101,10 +101,10 @@ class DrawFrame(wx.Frame):
                             FillColor    = "CYAN",
                             FillStyle    = "Solid")
 
-        Points = N.array(((0,0),
+        Points = np.array(((0,0),
                           (1,0),
                           (0.5, 1)),
-                         N.float64)
+                         np.float64)
 
         data  = (( (0,0),  1),
                  ( (3,3),  2),

--- a/samples/floatcanvas/PieChart.py
+++ b/samples/floatcanvas/PieChart.py
@@ -14,7 +14,7 @@ from wx.lib.floatcanvas.FCObjects import PieChart
 #from floatcanvas.SpecialObjects import PieChart
 
 
-import numpy as N
+import numpy as np
 
 class DrawFrame(wx.Frame):
 
@@ -39,22 +39,22 @@ class DrawFrame(wx.Frame):
 
         Values = (10,10,10)
         Colors = ('Red', 'Blue', 'Green')
-        Pie1 = PieChart(N.array((0, 0)), 10, Values, Colors, Scaled=False)
+        Pie1 = PieChart(np.array((0, 0)), 10, Values, Colors, Scaled=False)
         Canvas.AddObject(Pie1)
 
         Values = (10, 5, 5)
-        Pie2 = PieChart(N.array((40, 0)), 10, Values, Colors)
+        Pie2 = PieChart(np.array((40, 0)), 10, Values, Colors)
         Canvas.AddObject(Pie2)
 
         # test default colors
         Values = (10, 15, 12, 24, 6, 10, 13, 11, 9, 13, 15, 12)
-        Pie3 = PieChart(N.array((20, 20)), 10, Values, LineColor="Black")
+        Pie3 = PieChart(np.array((20, 20)), 10, Values, LineColor="Black")
         Canvas.AddObject(Pie3)
 
         # missng slice!
         Values = (10, 15, 12, 24)
         Colors = ('Red', 'Blue', 'Green', None)
-        Pie4 = PieChart(N.array((0, -15)), 10, Values, Colors, LineColor="Black")
+        Pie4 = PieChart(np.array((0, -15)), 10, Values, Colors, LineColor="Black")
         Canvas.AddObject(Pie4)
 
 
@@ -62,7 +62,7 @@ class DrawFrame(wx.Frame):
         Values = (10, 12, 14)
         Styles = ("Solid", "CrossDiagHatch","CrossHatch")
         Colors = ('Red', 'Blue', 'Green')
-        Pie4 = PieChart(N.array((20, -20)), 10, Values, Colors, Styles)
+        Pie4 = PieChart(np.array((20, -20)), 10, Values, Colors, Styles)
         Canvas.AddObject(Pie2)
 
         Pie1.Bind(FloatCanvas.EVT_FC_LEFT_DOWN, self.Pie1Hit)

--- a/samples/floatcanvas/PolyEditor.py
+++ b/samples/floatcanvas/PolyEditor.py
@@ -5,7 +5,7 @@ PolyEditor: a simple app for editing polygons
 
 Used as a demo for FloatCanvas
 """
-import numpy as N
+import numpy as np
 import random
 import numpy.random as RandomArray
 
@@ -112,7 +112,7 @@ class DrawFrame(wx.Frame):
             dc.SetPen(wx.Pen('WHITE', 2, wx.SHORT_DASH))
             dc.SetLogicalFunction(wx.XOR)
             if self.SelectedPointNeighbors is None:
-                self.SelectedPointNeighbors = N.zeros((3,2), N.float64)
+                self.SelectedPointNeighbors = np.zeros((3,2), np.float64)
                 #fixme: This feels very inelegant!
                 if Index == 0:
                     self.SelectedPointNeighbors[0] = self.SelectedPoly.Points[-1]

--- a/samples/floatcanvas/ProcessDiagram.py
+++ b/samples/floatcanvas/ProcessDiagram.py
@@ -25,7 +25,7 @@ elif ver == 'local':
     from floatcanvas import FloatCanvas as FC
     from floatcanvas.Utilities import BBox
 
-import numpy as N
+import numpy as np
 
 ## here we create some new mixins:
 ## fixme: These really belong in floatcanvas package -- but I kind of want to clean it up some first
@@ -45,7 +45,7 @@ class MovingObjectMixin:
 
         """
         BB = self.BoundingBox
-        OutlinePoints = N.array( ( (BB[0,0], BB[0,1]),
+        OutlinePoints = np.array( ( (BB[0,0], BB[0,1]),
                                    (BB[0,0], BB[1,1]),
                                    (BB[1,0], BB[1,1]),
                                    (BB[1,0], BB[0,1]),
@@ -100,8 +100,8 @@ class NodeObject(FC.Group, MovingObjectMixin, ConnectorObjectMixin):
                  TextColor = "Black",
                  InForeground  = False,
                  IsVisible = True):
-        XY = N.asarray(XY, N.float).reshape(2,)
-        WH = N.asarray(WH, N.float).reshape(2,)
+        XY = np.asarray(XY, np.float).reshape(2,)
+        WH = np.asarray(WH, np.float).reshape(2,)
         Label = FC.ScaledText(Label,
                         XY,
                         Size = WH[1] / 2.0,
@@ -171,7 +171,7 @@ class ConnectorLine(FC.LineOnlyMixin, FC.DrawObject,):
 
 
     def _Draw(self, dc , WorldToPixel, ScaleWorldToPixel, HTdc=None):
-        Points = N.array( (self.Object1.GetConnectPoint(),
+        Points = np.array( (self.Object1.GetConnectPoint(),
                            self.Object2.GetConnectPoint()) )
         Points = WorldToPixel(Points)
         dc.SetPen(self.Pen)
@@ -191,7 +191,7 @@ class TriangleShape1(FC.Polygon, MovingObjectMixin):
         L is the length of one side of the Triangle
         """
 
-        XY = N.asarray(XY)
+        XY = np.asarray(XY)
         XY.shape = (2,)
 
         Points = self.CompPoints(XY, L)
@@ -207,12 +207,12 @@ class TriangleShape1(FC.Polygon, MovingObjectMixin):
         return self.Points
 
     def CompPoints(self, XY, L):
-        c = L/ N.sqrt(3)
+        c = L/ np.sqrt(3)
 
-        Points = N.array(((0, c),
+        Points = np.array(((0, c),
                           ( L/2.0, -c/2.0),
                           (-L/2.0, -c/2.0)),
-                          N.float64)
+                          np.float64)
 
         Points += XY
         return Points

--- a/samples/floatcanvas/ScaleDemo.py
+++ b/samples/floatcanvas/ScaleDemo.py
@@ -22,7 +22,7 @@ from wx.lib.floatcanvas import NavCanvas, FloatCanvas
 #from floatcanvas import NavCanvas, FloatCanvas
 
 
-import numpy as N
+import numpy as np
 
 def YScaleFun(center):
     """
@@ -30,7 +30,7 @@ def YScaleFun(center):
 
     """
     # center gets ignored in this case
-    return N.array((5e7, 1), N.float)
+    return np.array((5e7, 1), np.float)
 
 class DrawFrame(wx.Frame):
 
@@ -54,8 +54,8 @@ class DrawFrame(wx.Frame):
 
         self.Canvas = Canvas
 
-        Point = N.array((50e-6, 0))
-        Size = N.array(( (2000e-6 - 5e-6), 50000))
+        Point = np.array((50e-6, 0))
+        Size = np.array(( (2000e-6 - 5e-6), 50000))
         Box = Canvas.AddRectangle(Point,
                                   Size,
                                   FillColor = "blue"

--- a/samples/floatcanvas/TextBox.py
+++ b/samples/floatcanvas/TextBox.py
@@ -15,7 +15,7 @@ from wx.lib.floatcanvas import NavCanvas, FloatCanvas
 #sys.path.append("..")
 #from floatcanvas import NavCanvas, FloatCanvas
 
-import numpy as N
+import numpy as np
 
 class DrawFrame(wx.Frame):
 
@@ -188,7 +188,7 @@ class DrawFrame(wx.Frame):
                                       Family = wx.ROMAN,
                                       Alignment = "right"
                                       )
-        Point = N.array((100, -20), N.float64)
+        Point = np.array((100, -20), np.float64)
         Box = Canvas.AddScaledTextBox("Here is even more auto wrapped text. This time the line spacing is set to 0.8. \n\nThe Padding is set to 0.",
                                       Point,
                                       Size = 3,
@@ -202,7 +202,7 @@ class DrawFrame(wx.Frame):
                                       )
         Canvas.AddPoint(Point, "Red", 2)
 
-        Point = N.array((0, -40), N.float64)
+        Point = np.array((0, -40), np.float64)
 #        Point = N.array((0, 0), N.float_)
         for Position in ["tl", "bl", "tr", "br"]:
 #        for Position in ["br"]:
@@ -221,7 +221,7 @@ class DrawFrame(wx.Frame):
                                       )
         Canvas.AddPoint(Point, "Red", 4)
 
-        Point = N.array((-20, 60), N.float64)
+        Point = np.array((-20, 60), np.float64)
         Box = Canvas.AddScaledTextBox("Here is some\ncentered\ntext",
                                       Point,
                                       Size = 4,
@@ -237,7 +237,7 @@ class DrawFrame(wx.Frame):
                                       LineSpacing = 0.8
                                       )
 
-        Point = N.array((-20, 20), N.float64)
+        Point = np.array((-20, 20), np.float64)
         Box = Canvas.AddScaledTextBox("Here is some\nright aligned\ntext",
                                       Point,
                                       Size = 4,
@@ -252,7 +252,7 @@ class DrawFrame(wx.Frame):
                                       LineSpacing = 0.8
                                       )
 
-        Point = N.array((100, -60), N.float64)
+        Point = np.array((100, -60), np.float64)
         Box = Canvas.AddScaledTextBox("Here is some auto wrapped text. This time it is centered, rather than right aligned.\n\nThe Padding is set to 2.",
                                       Point,
                                       Size = 3,

--- a/samples/floatcanvas/TextBox2.py
+++ b/samples/floatcanvas/TextBox2.py
@@ -22,7 +22,7 @@ from wx.lib.floatcanvas import NavCanvas, FloatCanvas, Resources
 #from floatcanvas import NavCanvas, FloatCanvas, Resources
 
 
-import numpy as N
+import numpy as np
 
 LongString = (
 """This is a long string. It is a bunch of text. I am using it to test how the nifty wrapping text box works when you want to re-size.
@@ -62,7 +62,7 @@ class DrawFrame(wx.Frame):
         self.Canvas.Bind(FloatCanvas.EVT_LEFT_UP, self.OnLeftUp )
         self.Canvas.Bind(FloatCanvas.EVT_LEFT_DOWN, self.OnLeftDown)
 
-        Point = N.array((0,0), N.float)
+        Point = np.array((0,0), np.float)
 
 
 

--- a/samples/floatcanvas/Tree.py
+++ b/samples/floatcanvas/Tree.py
@@ -25,7 +25,7 @@ elif ver == 'local':
     from floatcanvas import FloatCanvas as FC
     from floatcanvas.Utilities import BBox
 
-import numpy as N
+import numpy as np
 
 ## here we create some new mixins:
 ## fixme: These really belong in floatcanvas package -- but I kind of want to clean it up some first
@@ -45,7 +45,7 @@ class MovingObjectMixin:
 
         """
         BB = self.BoundingBox
-        OutlinePoints = N.array( ( (BB[0,0], BB[0,1]),
+        OutlinePoints = np.array( ( (BB[0,0], BB[0,1]),
                                    (BB[0,0], BB[1,1]),
                                    (BB[1,0], BB[1,1]),
                                    (BB[1,0], BB[0,1]),
@@ -100,8 +100,8 @@ class NodeObject(FC.Group, MovingObjectMixin, ConnectorObjectMixin):
                  TextColor = "Black",
                  InForeground  = False,
                  IsVisible = True):
-        XY = N.asarray(XY, N.float).reshape(2,)
-        WH = N.asarray(WH, N.float).reshape(2,)
+        XY = np.asarray(XY, np.float).reshape(2,)
+        WH = np.asarray(WH, np.float).reshape(2,)
         Label = FC.ScaledText(Label,
                         XY,
                         Size = WH[1] / 2.0,
@@ -163,7 +163,7 @@ class ConnectorLine(FC.LineOnlyMixin, FC.DrawObject,):
 
 
     def _Draw(self, dc , WorldToPixel, ScaleWorldToPixel, HTdc=None):
-        Points = N.array( (self.Object1.GetConnectPoint(),
+        Points = np.array( (self.Object1.GetConnectPoint(),
                            self.Object2.GetConnectPoint()) )
         Points = WorldToPixel(Points)
         dc.SetPen(self.Pen)
@@ -183,7 +183,7 @@ class TriangleShape1(FC.Polygon, MovingObjectMixin):
         L is the length of one side of the Triangle
         """
 
-        XY = N.asarray(XY)
+        XY = np.asarray(XY)
         XY.shape = (2,)
 
         Points = self.CompPoints(XY, L)
@@ -199,12 +199,12 @@ class TriangleShape1(FC.Polygon, MovingObjectMixin):
         return self.Points
 
     def CompPoints(self, XY, L):
-        c = L/ N.sqrt(3)
+        c = L/ np.sqrt(3)
 
-        Points = N.array(((0, c),
+        Points = np.array(((0, c),
                           ( L/2.0, -c/2.0),
                           (-L/2.0, -c/2.0)),
-                          N.float64)
+                          np.float64)
 
         Points += XY
         return Points

--- a/samples/floatcanvas/VectPlot.py
+++ b/samples/floatcanvas/VectPlot.py
@@ -6,7 +6,7 @@ A small test app that uses FloatCanvas to draw a vector plot.
 """
 
 import wx
-import numpy as N
+import numpy as np
 import random
 
 ## import the installed version
@@ -95,19 +95,19 @@ class DrawFrame(wx.Frame):
         # what the options are.
 
         self.Canvas.AddRectangle((0, -1.1),
-                                 (2*N.pi, 2.2),
+                                 (2*np.pi, 2.2),
                                  LineColor = "Black",
                                  LineStyle = "Solid",
                                  LineWidth    = 1,
                                  FillColor    = None,
                                  FillStyle    = "Solid",
                                  InForeground = 0)
-        for tic in N.arange(7):
+        for tic in np.arange(7):
             self.Canvas.AddText("%1.1f"%tic,
                                 (tic, -1.1),
                                 Position = 'tc')
 
-        for tic in N.arange(-1,1.1,0.5):
+        for tic in np.arange(-1,1.1,0.5):
             self.Canvas.AddText("%1.1f"%tic,
                                 (0,tic),
                                 Position = 'cr')
@@ -122,10 +122,10 @@ class DrawFrame(wx.Frame):
         #Canvas.Draw()
 
     def Plot(self, event = None):
-        x = N.arange(0, 2*N.pi, 0.1)
+        x = np.arange(0, 2*np.pi, 0.1)
         x.shape = (-1,1)
-        y = N.sin(x)
-        data = N.concatenate((x, y),1)
+        y = np.sin(x)
+        data = np.concatenate((x, y),1)
 
         Canvas = self.Canvas
         self.Canvas.ClearAll()

--- a/samples/floatcanvas/YDownDemo.py
+++ b/samples/floatcanvas/YDownDemo.py
@@ -23,10 +23,10 @@ from wx.lib.floatcanvas import NavCanvas, FloatCanvas
 #from floatcanvas import NavCanvas, FloatCanvas
 
 
-import numpy as N
+import numpy as np
 
 def YDownProjection(CenterPoint):
-    return N.array((1,-1))
+    return np.array((1,-1))
 
 class DrawFrame(wx.Frame):
 

--- a/samples/rawbmp/rawbmp1.py
+++ b/samples/rawbmp/rawbmp1.py
@@ -20,9 +20,9 @@ TEST_GC = False
 
 if USE_NUMPY:
     try:
-        import numpy
+        import numpy as np
         def makeByteArray(shape):
-            return numpy.empty(shape, numpy.uint8)
+            return np.empty(shape, np.uint8)
         numtype = 'numpy'
     except ImportError:
         USE_NUMPY = False

--- a/unittests/test_colour.py
+++ b/unittests/test_colour.py
@@ -41,8 +41,8 @@ class Colour(wtc.WidgetTestCase):
 
 
     def test_numpy_ctor(self):
-        import numpy
-        a = numpy.array( [1,2,3,4] )
+        import numpy as np
+        a = np.array( [1,2,3,4] )
         c = wx.Colour(a)
         self.assertTrue(c.Get() == (1,2,3,4))
 

--- a/unittests/test_gdicmn.py
+++ b/unittests/test_gdicmn.py
@@ -35,8 +35,8 @@ class TestPoint(unittest.TestCase):
         p = wx.Point( [123,456] )
 
     def test_numpy_ctor(self):
-        import numpy
-        a = numpy.array([123,456])
+        import numpy as np
+        a = np.array([123,456])
         p = wx.Point(a)
 
 
@@ -399,8 +399,8 @@ class TestRect(unittest.TestCase):
         self.assertTrue(r1 == (1,2,3,4))
 
     def test_numpy_ctor(self):
-        import numpy
-        r1 = wx.Rect( numpy.array([1,2,3,4]) )
+        import numpy as np
+        r1 = wx.Rect( np.array([1,2,3,4]) )
         self.assertTrue(r1 == (1,2,3,4))
 
 

--- a/wx/lib/floatcanvas/FCObjects.py
+++ b/wx/lib/floatcanvas/FCObjects.py
@@ -18,7 +18,7 @@ import sys
 
 import wx
 
-import numpy as N
+import numpy as np
 
 from .Utilities import BBox
 from wx.lib.floatcanvas.Utilities import Colors
@@ -559,7 +559,7 @@ class XYObjectMixin:
          array of shape (2, )
 
         """
-        Delta = N.asarray(Delta, float)
+        Delta = np.asarray(Delta, float)
         self.XY += Delta
         self.BoundingBox += Delta
 
@@ -572,7 +572,7 @@ class XYObjectMixin:
         self.BoundingBox = BBox.asBBox((self.XY, self.XY))
 
     def SetPoint(self, xy):
-        xy = N.array(xy, float)
+        xy = np.array(xy, float)
         xy.shape = (2,)
 
         self.XY = xy
@@ -596,7 +596,7 @@ class PointsObjectMixin:
          array of shape (2, )
 
         """
-        Delta = N.asarray(Delta, float)
+        Delta = np.asarray(Delta, float)
         Delta.shape = (2,)
         self.Points += Delta
         self.BoundingBox += Delta
@@ -630,10 +630,10 @@ class PointsObjectMixin:
 
         """
         if copy:
-            self.Points = N.array(Points, float)
+            self.Points = np.array(Points, float)
             self.Points.shape = (-1, 2) # Make sure it is a NX2 array, even if there is only one point
         else:
-            self.Points = N.asarray(Points, float)
+            self.Points = np.asarray(Points, float)
         self.CalcBoundingBox()
 
 
@@ -670,7 +670,7 @@ class Polygon(PointsObjectMixin, LineAndFillMixin, DrawObject):
 
         """
         DrawObject.__init__(self, InForeground)
-        self.Points = N.array(Points ,float) # this DOES need to make a copy
+        self.Points = np.array(Points ,float) # this DOES need to make a copy
         self.CalcBoundingBox()
 
         self.LineColor = LineColor
@@ -721,7 +721,7 @@ class Line(PointsObjectMixin, LineOnlyMixin, DrawObject):
         DrawObject.__init__(self, InForeground)
 
 
-        self.Points = N.array(Points,float)
+        self.Points = np.array(Points,float)
         self.CalcBoundingBox()
 
         self.LineColor = LineColor
@@ -798,7 +798,7 @@ class Arrow(XYObjectMixin, LineOnlyMixin, DrawObject):
 
         DrawObject.__init__(self, InForeground)
 
-        self.XY = N.array(XY, float)
+        self.XY = np.array(XY, float)
         self.XY.shape = (2,) # Make sure it is a length 2 vector
         self.Length = Length
         self.Direction = float(Direction)
@@ -870,16 +870,16 @@ class Arrow(XYObjectMixin, LineOnlyMixin, DrawObject):
         """Calculate the arrow points."""
         L = self.Length
         S = self.ArrowHeadSize
-        phi = self.ArrowHeadAngle * N.pi / 360
-        theta = (270 - self.Direction) * N.pi / 180
-        AP = N.array( ( (0,0),
+        phi = self.ArrowHeadAngle * np.pi / 360
+        theta = (270 - self.Direction) * np.pi / 180
+        AP = np.array( ( (0,0),
                         (0,0),
-                        (N.cos(theta - phi), -N.sin(theta - phi) ),
+                        (np.cos(theta - phi), -np.sin(theta - phi) ),
                         (0,0),
-                        (N.cos(theta + phi), -N.sin(theta + phi) ),
+                        (np.cos(theta + phi), -np.sin(theta + phi) ),
                         ), float )
         AP *= S
-        shift = (-L*N.cos(theta), L*N.sin(theta) )
+        shift = (-L*np.cos(theta), L*np.sin(theta) )
         AP[1:,:] += shift
         self.ArrowPoints = AP
 
@@ -927,7 +927,7 @@ class ArrowLine(PointsObjectMixin, LineOnlyMixin, DrawObject):
 
         DrawObject.__init__(self, InForeground)
 
-        self.Points = N.asarray(Points,float)
+        self.Points = np.asarray(Points,float)
         self.Points.shape = (-1,2) # Make sure it is a NX2 array, even if there is only one point
         self.ArrowHeadSize = ArrowHeadSize
         self.ArrowHeadAngle = float(ArrowHeadAngle)
@@ -946,17 +946,17 @@ class ArrowLine(PointsObjectMixin, LineOnlyMixin, DrawObject):
     def CalcArrowPoints(self):
         """Calculate the arrow points."""
         S = self.ArrowHeadSize
-        phi = self.ArrowHeadAngle * N.pi / 360
+        phi = self.ArrowHeadAngle * np.pi / 360
         Points = self.Points
         n = Points.shape[0]
-        self.ArrowPoints = N.zeros((n-1, 3, 2), float)
+        self.ArrowPoints = np.zeros((n-1, 3, 2), float)
         for i in range(n-1):
             dx, dy = self.Points[i] - self.Points[i+1]
-            theta = N.arctan2(dy, dx)
-            AP = N.array( (
-                            (N.cos(theta - phi), -N.sin(theta-phi)),
+            theta = np.arctan2(dy, dx)
+            AP = np.array( (
+                            (np.cos(theta - phi), -np.sin(theta-phi)),
                             (0,0),
-                            (N.cos(theta + phi), -N.sin(theta + phi))
+                            (np.cos(theta + phi), -np.sin(theta + phi))
                             ),
                           float )
             self.ArrowPoints[i,:,:] = AP
@@ -964,7 +964,7 @@ class ArrowLine(PointsObjectMixin, LineOnlyMixin, DrawObject):
 
     def _Draw(self, dc , WorldToPixel, ScaleWorldToPixel, HTdc=None):
         Points = WorldToPixel(self.Points)
-        ArrowPoints = Points[1:,N.newaxis,:] + self.ArrowPoints
+        ArrowPoints = Points[1:,np.newaxis,:] + self.ArrowPoints
         dc.SetPen(self.Pen)
         dc.DrawLines(Points)
         for arrow in ArrowPoints:
@@ -1009,7 +1009,7 @@ class PointSet(PointsObjectMixin, ColorOnlyMixin, DrawObject):
         """
         DrawObject.__init__(self, InForeground)
 
-        self.Points = N.array(Points,float)
+        self.Points = np.array(Points,float)
         self.Points.shape = (-1,2) # Make sure it is a NX2 array, even if there is only one point
         self.CalcBoundingBox()
         self.Diameter = Diameter
@@ -1041,7 +1041,7 @@ class PointSet(PointsObjectMixin, ColorOnlyMixin, DrawObject):
 
         """
         d = self.Points - XY
-        return N.argmin(N.hypot(d[:,0],d[:,1]))
+        return np.argmin(np.hypot(d[:,0],d[:,1]))
 
 
     def DrawD2(self, dc, Points):
@@ -1064,7 +1064,7 @@ class PointSet(PointsObjectMixin, ColorOnlyMixin, DrawObject):
             ##fixme: I really should add a DrawCircleList to wxPython
             if len(Points) > 100:
                 xy = Points
-                xywh = N.concatenate((xy-radius, N.ones(xy.shape) * self.Diameter ), 1 )
+                xywh = np.concatenate((xy-radius, np.ones(xy.shape) * self.Diameter ), 1 )
                 dc.DrawEllipseList(xywh)
             else:
                 for xy in Points:
@@ -1079,7 +1079,7 @@ class PointSet(PointsObjectMixin, ColorOnlyMixin, DrawObject):
             else:
                 if len(Points) > 100:
                     xy = Points
-                    xywh = N.concatenate((xy-radius, N.ones(xy.shape) * self.Diameter ), 1 )
+                    xywh = np.concatenate((xy-radius, np.ones(xy.shape) * self.Diameter ), 1 )
                     HTdc.DrawEllipseList(xywh)
                 else:
                     for xy in Points:
@@ -1110,7 +1110,7 @@ class Point(XYObjectMixin, ColorOnlyMixin, DrawObject):
 
         DrawObject.__init__(self, InForeground)
 
-        self.XY = N.array(XY, float)
+        self.XY = np.array(XY, float)
         self.XY.shape = (2,) # Make sure it is a length 2 vector
         self.CalcBoundingBox()
         self.SetColor(Color)
@@ -1167,7 +1167,7 @@ class SquarePoint(XYObjectMixin, ColorOnlyMixin, DrawObject):
         """
         DrawObject.__init__(self, InForeground)
 
-        self.XY = N.array(Point, float)
+        self.XY = np.array(Point, float)
         self.XY.shape = (2,) # Make sure it is a length 2 vector
         self.CalcBoundingBox()
         self.SetColor(Color)
@@ -1255,16 +1255,16 @@ class RectEllipse(XYObjectMixin, LineAndFillMixin, DrawObject):
         :param `WH`: a tuple with the Width and Height for the object
 
         """
-        self.XY = N.array( XY, float)
+        self.XY = np.array( XY, float)
         self.XY.shape = (2,)
-        self.WH = N.array( WH, float)
+        self.WH = np.array( WH, float)
         self.WH.shape = (2,)
         self.CalcBoundingBox()
 
     def CalcBoundingBox(self):
         """Calculate the bounding box."""
         # you need this in case Width or Height are negative
-        corners = N.array((self.XY, (self.XY + self.WH) ), float)
+        corners = np.array((self.XY, (self.XY + self.WH) ), float)
         self.BoundingBox = BBox.fromPoints(corners)
         if self._Canvas:
             self._Canvas.BoundingBoxDirty = True
@@ -1277,8 +1277,8 @@ class Rectangle(RectEllipse):
                                     WorldToPixel,
                                     ScaleWorldToPixel,
                                     HTdc)
-        WH[N.abs(WH) < self.MinSize] = self.MinSize
-        if not( self.DisappearWhenSmall and N.abs(WH).min() <=  self.MinSize) : # don't try to draw it too tiny
+        WH[np.abs(WH) < self.MinSize] = self.MinSize
+        if not( self.DisappearWhenSmall and np.abs(WH).min() <=  self.MinSize) : # don't try to draw it too tiny
             dc.DrawRectangle(XY, WH)
             if HTdc and self.HitAble:
                 HTdc.DrawRectangle(XY, WH)
@@ -1291,8 +1291,8 @@ class Ellipse(RectEllipse):
                                     WorldToPixel,
                                     ScaleWorldToPixel,
                                     HTdc)
-        WH[N.abs(WH) < self.MinSize] = self.MinSize
-        if not( self.DisappearWhenSmall and N.abs(WH).min() <=  self.MinSize) : # don't try to draw it too tiny
+        WH[np.abs(WH) < self.MinSize] = self.MinSize
+        if not( self.DisappearWhenSmall and np.abs(WH).min() <=  self.MinSize) : # don't try to draw it too tiny
             dc.DrawEllipse(XY, WH)
             if HTdc and self.HitAble:
                 HTdc.DrawEllipse(XY, WH)
@@ -1322,8 +1322,8 @@ class Circle(XYObjectMixin, LineAndFillMixin, DrawObject):
         """
         DrawObject.__init__(self, InForeground)
 
-        self.XY = N.array(XY, float)
-        self.WH = N.array((Diameter/2, Diameter/2), float) # just to keep it compatible with others
+        self.XY = np.array(XY, float)
+        self.WH = np.array((Diameter/2, Diameter/2), float) # just to keep it compatible with others
         self.CalcBoundingBox()
 
         self.LineColor = LineColor
@@ -1348,7 +1348,7 @@ class Circle(XYObjectMixin, LineAndFillMixin, DrawObject):
         :param integer `Diameter`: the diameter for the object
 
         """
-        self.WH = N.array((Diameter/2, Diameter/2), float) # just to keep it compatible with others
+        self.WH = np.array((Diameter/2, Diameter/2), float) # just to keep it compatible with others
 
     def CalcBoundingBox(self):
         """Calculate the bounding box of the object."""
@@ -1363,8 +1363,8 @@ class Circle(XYObjectMixin, LineAndFillMixin, DrawObject):
                                     ScaleWorldToPixel,
                                     HTdc)
 
-        WH[N.abs(WH) < self.MinSize] = self.MinSize
-        if not( self.DisappearWhenSmall and N.abs(WH).min() <=  self.MinSize) : # don't try to draw it too tiny
+        WH[np.abs(WH) < self.MinSize] = self.MinSize
+        if not( self.DisappearWhenSmall and np.abs(WH).min() <=  self.MinSize) : # don't try to draw it too tiny
             dc.DrawCircle(XY, WH[0])
             if HTdc and self.HitAble:
                 HTdc.DrawCircle(XY, WH[0])
@@ -1526,7 +1526,7 @@ class Text(TextObjectMixin, DrawObject):
 
         self.BoundingBox = BBox.asBBox((xy, xy))
 
-        self.XY = N.asarray(xy)
+        self.XY = np.asarray(xy)
         self.XY.shape = (2,)
 
         (self.TextWidth, self.TextHeight) = (None, None)
@@ -1626,7 +1626,7 @@ class ScaledText(TextObjectMixin, DrawObject):
         DrawObject.__init__(self,InForeground)
 
         self.String = String
-        self.XY = N.array( XY, float)
+        self.XY = np.array( XY, float)
         self.XY.shape = (2,)
         self.Size = Size
         self.Color = Color
@@ -1803,7 +1803,7 @@ class ScaledTextBox(TextObjectMixin, DrawObject):
         """
         DrawObject.__init__(self,InForeground)
 
-        self.XY = N.array(Point, float)
+        self.XY = np.array(Point, float)
         self.Size = Size
         self.Color = Color
         self.BackgroundColor = BackgroundColor
@@ -1919,7 +1919,7 @@ class ScaledTextBox(TextObjectMixin, DrawObject):
         SpaceWidth = dc.GetTextExtent(" ")[0]
         LineHeight = TextHeight * self.LineSpacing
 
-        LineWidths = N.zeros((len(self.Strings),), float)
+        LineWidths = np.zeros((len(self.Strings),), float)
         y = 0
         Words = []
         AllLinePoints = []
@@ -1927,7 +1927,7 @@ class ScaledTextBox(TextObjectMixin, DrawObject):
         for i, s in enumerate(self.Strings):
             LineWidths[i] = 0
             LineWords = s.split(" ")
-            LinePoints = N.zeros((len(LineWords),2), float)
+            LinePoints = np.zeros((len(LineWords),2), float)
             for j, word in enumerate(LineWords):
                 if j > 0:
                     LineWidths[i] += SpaceWidth
@@ -1937,14 +1937,14 @@ class ScaledTextBox(TextObjectMixin, DrawObject):
                 LineWidths[i] += w
             y -= LineHeight
             AllLinePoints.append(LinePoints)
-        TextWidth = N.maximum.reduce(LineWidths)
+        TextWidth = np.maximum.reduce(LineWidths)
         self.Words = Words
 
         if self.Width is None:
             BoxWidth = TextWidth * ScaleFactor + 2*self.PadSize
         else: # use the defined Width
             BoxWidth = self.Width
-        Points = N.zeros((0,2), float)
+        Points = np.zeros((0,2), float)
 
         for i, LinePoints in enumerate(AllLinePoints):
             ## Scale to World Coords.
@@ -1955,7 +1955,7 @@ class ScaledTextBox(TextObjectMixin, DrawObject):
                 LinePoints[:,0] += (BoxWidth - LineWidths[i]*ScaleFactor)/2.0
             elif self.Alignment == 'right':
                 LinePoints[:,0] += (BoxWidth - LineWidths[i]*ScaleFactor-self.PadSize)
-            Points = N.concatenate((Points, LinePoints))
+            Points = np.concatenate((Points, LinePoints))
 
         BoxHeight = -(Points[-1,1] - (TextHeight * ScaleFactor)) + 2*self.PadSize
         #(x,y) = self.ShiftFun(self.XY[0], self.XY[1], BoxWidth, BoxHeight, world=1)
@@ -2218,15 +2218,15 @@ class ScaledBitmap2(TextObjectMixin, DrawObject, ):
         elif type(Bitmap) == wx.Image:
             self.Image = Bitmap
 
-        self.XY = N.array(XY, float)
+        self.XY = np.array(XY, float)
         self.Height = Height
         (self.bmpWidth, self.bmpHeight) = float(self.Image.GetWidth()), float(self.Image.GetHeight())
-        self.bmpWH = N.array((self.bmpWidth, self.bmpHeight), N.int32)
+        self.bmpWH = np.array((self.bmpWidth, self.bmpHeight), np.int32)
         ## fixme: this should all accommodate different scales for X and Y
         if Width is None:
             self.BmpScale = float(self.bmpHeight) / Height
             self.Width = self.bmpWidth / self.BmpScale
-        self.WH = N.array((self.Width, Height), float)
+        self.WH = np.array((self.Width, Height), float)
         ##fixme: should this have a y = -1 to shift to y-up?
         self.BmpScale = self.bmpWH / self.WH
 
@@ -2251,7 +2251,7 @@ class ScaledBitmap2(TextObjectMixin, DrawObject, ):
         Pb *= (1, -1) ##fixme: this may only works for Yup projection!
                       ##       and may only work for top left position
 
-        return Pb.astype(N.int_)
+        return Pb.astype(np.int_)
 
     def _DrawEntireBitmap(self, dc , WorldToPixel, ScaleWorldToPixel, HTdc):
         """
@@ -2381,7 +2381,7 @@ class DotGrid:
     """
     def __init__(self, Spacing, Size = 2, Color = "Black", Cross=False, CrossThickness = 1):
 
-        self.Spacing = N.array(Spacing, float)
+        self.Spacing = np.array(Spacing, float)
         self.Spacing.shape = (2,)
         self.Size = Size
         self.Color = Color
@@ -2393,13 +2393,13 @@ class DotGrid:
 
         Spacing = self.Spacing
 
-        minx, miny = N.floor(ViewPortBB[0] / Spacing) * Spacing
-        maxx, maxy = N.ceil(ViewPortBB[1] / Spacing) * Spacing
+        minx, miny = np.floor(ViewPortBB[0] / Spacing) * Spacing
+        maxx, maxy = np.ceil(ViewPortBB[1] / Spacing) * Spacing
 
         ##fixme: this could use vstack or something with numpy
-        x = N.arange(minx, maxx+Spacing[0], Spacing[0]) # making sure to get the last point
-        y = N.arange(miny, maxy+Spacing[1], Spacing[1]) # an extra is OK
-        Points = N.zeros((len(y), len(x), 2), float)
+        x = np.arange(minx, maxx+Spacing[0], Spacing[0]) # making sure to get the last point
+        y = np.arange(miny, maxy+Spacing[1], Spacing[1]) # an extra is OK
+        Points = np.zeros((len(y), len(x), 2), float)
         x.shape = (1,-1)
         y.shape = (-1,1)
         Points[:,:,0] += x
@@ -2417,10 +2417,10 @@ class DotGrid:
 
         if self.Cross: # Use cross shaped markers
             #Horizontal lines
-            LinePoints = N.concatenate((Points + (self.Size,0),Points + (-self.Size,0)),1)
+            LinePoints = np.concatenate((Points + (self.Size,0),Points + (-self.Size,0)),1)
             dc.DrawLineList(LinePoints)
             # Vertical Lines
-            LinePoints = N.concatenate((Points + (0,self.Size),Points + (0,-self.Size)),1)
+            LinePoints = np.concatenate((Points + (0,self.Size),Points + (0,-self.Size)),1)
             dc.DrawLineList(LinePoints)
             pass
         else: # use dots
@@ -2438,7 +2438,7 @@ class DotGrid:
                 ##fixme: I really should add a DrawCircleList to wxPython
                 if len(Points) > 100:
                     xy = Points
-                    xywh = N.concatenate((xy-radius, N.ones(xy.shape) * self.Size ), 1 )
+                    xywh = np.concatenate((xy-radius, np.ones(xy.shape) * self.Size ), 1 )
                     dc.DrawEllipseList(xywh)
                 else:
                     for xy in Points:
@@ -2486,7 +2486,7 @@ class Arc(XYObjectMixin, LineAndFillMixin, DrawObject):
         # There is probably a more elegant way to do this next section
         # The bounding box just gets set to the WH of a circle, with center at CenterXY
         # This is suitable for a pie chart as it will be a circle anyway
-        radius = N.sqrt( (StartXY[0]-CenterXY[0])**2 + (StartXY[1]-CenterXY[1])**2 )
+        radius = np.sqrt( (StartXY[0]-CenterXY[0])**2 + (StartXY[1]-CenterXY[1])**2 )
         minX = CenterXY[0]-radius
         minY = CenterXY[1]-radius
         maxX = CenterXY[0]+radius
@@ -2494,12 +2494,12 @@ class Arc(XYObjectMixin, LineAndFillMixin, DrawObject):
         XY = [minX,minY]
         WH = [maxX-minX,maxY-minY]
 
-        self.XY = N.asarray( XY, float).reshape((2,))
-        self.WH = N.asarray( WH, float).reshape((2,))
+        self.XY = np.asarray( XY, float).reshape((2,))
+        self.WH = np.asarray( WH, float).reshape((2,))
 
-        self.StartXY = N.asarray(StartXY, float).reshape((2,))
-        self.CenterXY = N.asarray(CenterXY, float).reshape((2,))
-        self.EndXY = N.asarray(EndXY, float).reshape((2,))
+        self.StartXY = np.asarray(StartXY, float).reshape((2,))
+        self.CenterXY = np.asarray(CenterXY, float).reshape((2,))
+        self.EndXY = np.asarray(EndXY, float).reshape((2,))
 
         #self.BoundingBox = array((self.XY, (self.XY + self.WH)), Float)
         self.CalcBoundingBox()
@@ -2525,7 +2525,7 @@ class Arc(XYObjectMixin, LineAndFillMixin, DrawObject):
 
         """
 
-        Delta = N.asarray(Delta, float)
+        Delta = np.asarray(Delta, float)
         self.XY += Delta
         self.StartXY += Delta
         self.CenterXY += Delta
@@ -2547,7 +2547,7 @@ class Arc(XYObjectMixin, LineAndFillMixin, DrawObject):
 
     def CalcBoundingBox(self):
         """Calculate the bounding box."""
-        self.BoundingBox = BBox.asBBox( N.array((self.XY, (self.XY + self.WH) ),
+        self.BoundingBox = BBox.asBBox( np.array((self.XY, (self.XY + self.WH) ),
                                                 float) )
         if self._Canvas:
             self._Canvas.BoundingBoxDirty = True
@@ -2597,9 +2597,9 @@ class PieChart(XYObjectMixin, LineOnlyMixin, DrawObject):
         """
         DrawObject.__init__(self, InForeground)
 
-        self.XY = N.asarray(XY, float).reshape( (2,) )
+        self.XY = np.asarray(XY, float).reshape( (2,) )
         self.Diameter = Diameter
-        self.Values = N.asarray(Values, dtype=float).reshape((-1,1))
+        self.Values = np.asarray(Values, dtype=float).reshape((-1,1))
         if FillColors is None:
             FillColors = self.DefaultColorList[:len(Values)]
         if FillStyles is None:
@@ -2640,14 +2640,14 @@ class PieChart(XYObjectMixin, LineOnlyMixin, DrawObject):
 
         :param `Values`: sequence of values you want to use for the chart
         """
-        Values = N.asarray(Values, dtype=float).reshape((-1,1))
+        Values = np.asarray(Values, dtype=float).reshape((-1,1))
         self.Values = Values
         self.CalculatePoints()
 
     def CalculatePoints(self):
         """Calculate the points."""
         # add the zero point to start
-        Values = N.vstack( ( (0,), self.Values) )
+        Values = np.vstack( ( (0,), self.Values) )
         self.Angles = 360. * Values.cumsum()/Values.sum()
         self.CalcBoundingBox()
 
@@ -2677,7 +2677,7 @@ class PieChart(XYObjectMixin, LineOnlyMixin, DrawObject):
             Diameter = ScaleWorldToPixel( (self.Diameter,self.Diameter) )[0]
         else:
             Diameter = self.Diameter
-        WH = N.array((Diameter,Diameter), dtype = float)
+        WH = np.array((Diameter,Diameter), dtype = float)
         Corner = CenterXY - (WH / 2)
         dc.SetPen(self.Pen)
         for i, brush in enumerate(self.Brushes):

--- a/wx/lib/floatcanvas/FloatCanvas.py
+++ b/wx/lib/floatcanvas/FloatCanvas.py
@@ -45,7 +45,7 @@ Many samples are available in the `wxPhoenix/samples/floatcanvas` folder.
 import sys
 mac = sys.platform.startswith("darwin")
 
-import numpy as N
+import numpy as np
 try:
     from time import process_time as clock
 except ImportError:
@@ -207,12 +207,12 @@ class FloatCanvas(wx.Panel):
         self.BoundingBoxDirty = False
         self.MinScale = None
         self.MaxScale = None
-        self.ViewPortCenter= N.array( (0,0), float)
+        self.ViewPortCenter= np.array( (0,0), float)
 
         self.SetProjectionFun(None)
 
-        self.MapProjectionVector = N.array( (1,1), float) # No Projection to start!
-        self.TransformVector = N.array( (1,-1), float) # default Transformation
+        self.MapProjectionVector = np.array( (1,1), float) # No Projection to start!
+        self.TransformVector = np.array( (1,-1), float) # default Transformation
 
         self.Scale = 1
         self.ObjectUnderMouse = None
@@ -236,7 +236,7 @@ class FloatCanvas(wx.Panel):
         elif callable(ProjectionFun):
             self.ProjectionFun = ProjectionFun
         elif ProjectionFun is None:
-            self.ProjectionFun = lambda x=None: N.array( (1,1), float)
+            self.ProjectionFun = lambda x=None: np.array( (1,1), float)
         else:
             raise FloatCanvasError('Projectionfun must be either:'
                                    ' "FlatEarth", None, or a callable object '
@@ -259,7 +259,7 @@ class FloatCanvas(wx.Panel):
         MinLatitude = -75
         Lat = min(CenterPoint[1],MaxLatitude)
         Lat = max(Lat,MinLatitude)
-        return N.array((N.cos(N.pi*Lat/180),1),float)
+        return np.array((np.cos(np.pi*Lat/180),1),float)
 
     def SetMode(self, Mode):
         """
@@ -551,8 +551,8 @@ class FloatCanvas(wx.Panel):
 
     def InitializePanel(self):
         """Initialize the panel."""
-        PanelSize  = N.array(self.GetClientSize(),  N.int32)
-        self.PanelSize  = N.maximum(PanelSize, (2,2)) ## OS-X sometimes gives a Size event when the panel is size (0,0)
+        PanelSize  = np.array(self.GetClientSize(),  np.int32)
+        self.PanelSize  = np.maximum(PanelSize, (2,2)) ## OS-X sometimes gives a Size event when the panel is size (0,0)
         self.HalfPanelSize = self.PanelSize / 2 # lrk: added for speed in WorldToPixel
         self.AspectRatio = float(self.PanelSize[0]) / self.PanelSize[1]
 
@@ -598,16 +598,16 @@ class FloatCanvas(wx.Panel):
 
         """
 
-        if N.any(self.PanelSize <= 2 ):
+        if np.any(self.PanelSize <= 2 ):
             # it's possible for this to get called before being properly initialized.
             return
         if self.Debug: start = clock()
         ScreenDC =  wx.ClientDC(self)
-        ViewPortWorld = N.array(( self.PixelToWorld((0,0)),
+        ViewPortWorld = np.array(( self.PixelToWorld((0,0)),
                                   self.PixelToWorld(self.PanelSize) )
                                      )
-        self.ViewPortBB = N.array( ( N.minimum.reduce(ViewPortWorld),
-                              N.maximum.reduce(ViewPortWorld) ) )
+        self.ViewPortBB = np.array( ( np.minimum.reduce(ViewPortWorld),
+                              np.maximum.reduce(ViewPortWorld) ) )
 
         dc = wx.MemoryDC()
         dc.SelectObject(self._Buffer)
@@ -700,9 +700,9 @@ class FloatCanvas(wx.Panel):
          ============== ======================================================
 
         """
-        shift = N.asarray(shift,float)
+        shift = np.asarray(shift,float)
         if CoordType.lower() == 'panel':# convert from panel coordinates
-            shift = shift * N.array((-1,1),float) *self.PanelSize/self.TransformVector
+            shift = shift * np.array((-1,1),float) *self.PanelSize/self.TransformVector
         elif CoordType.lower() == 'pixel': # convert from pixel coordinates
             shift = shift/self.TransformVector
         elif CoordType.lower() == 'world': # No conversion
@@ -712,7 +712,7 @@ class FloatCanvas(wx.Panel):
 
         self.ViewPortCenter = self.ViewPortCenter + shift
         self.MapProjectionVector = self.ProjectionFun(self.ViewPortCenter)
-        self.TransformVector = N.array((self.Scale,-self.Scale),float) * self.MapProjectionVector
+        self.TransformVector = np.array((self.Scale,-self.Scale),float) * self.MapProjectionVector
         self._BackgroundDirty = True
         if ReDraw:
             self.Draw()
@@ -742,7 +742,7 @@ class FloatCanvas(wx.Panel):
         if centerCoords.lower() == "pixel":
             oldpoint = self.PixelToWorld( center )
         elif centerCoords.lower() == 'world':
-            oldpoint = N.array(center, float)
+            oldpoint = np.array(center, float)
         else:
             raise FloatCanvasError('centerCoords must be either "World" or "Pixel"')
 
@@ -753,7 +753,7 @@ class FloatCanvas(wx.Panel):
             if centerCoords.lower() == "pixel":
                 newpoint = self.PixelToWorld( center )
             else:
-                newpoint = N.array(center, float)
+                newpoint = np.array(center, float)
             delta = (newpoint - oldpoint)
             self.MoveImage(-delta, 'World')
         else:
@@ -775,8 +775,8 @@ class FloatCanvas(wx.Panel):
                 self._ResetBoundingBox()
             BoundingBox = self.BoundingBox
         if (BoundingBox is not None) and (not BoundingBox.IsNull()):
-            self.ViewPortCenter = N.array(((BoundingBox[0,0]+BoundingBox[1,0])/2,
-                                         (BoundingBox[0,1]+BoundingBox[1,1])/2 ),N.float64)
+            self.ViewPortCenter = np.array(((BoundingBox[0,0]+BoundingBox[1,0])/2,
+                                         (BoundingBox[0,1]+BoundingBox[1,1])/2 ),np.float64)
             self.MapProjectionVector = self.ProjectionFun(self.ViewPortCenter)
             # Compute the new Scale
             BoundingBox = BoundingBox*self.MapProjectionVector # this does need to make a copy!
@@ -796,7 +796,7 @@ class FloatCanvas(wx.Panel):
                 self._BackgroundDirty = True
         else:
             # Reset the shifting and scaling to defaults when there is no BB
-            self.ViewPortCenter= N.array( (0,0), float)
+            self.ViewPortCenter= np.array( (0,0), float)
             self.Scale= 1
         self.SetToNewScale(DrawFlag=DrawFlag)
 
@@ -813,7 +813,7 @@ class FloatCanvas(wx.Panel):
         if self.MaxScale is not None:
             Scale = min(Scale, self.MaxScale)
         self.MapProjectionVector = self.ProjectionFun(self.ViewPortCenter)
-        self.TransformVector = N.array((Scale,-Scale),float) * self.MapProjectionVector
+        self.TransformVector = np.array((Scale,-Scale),float) * self.MapProjectionVector
         self.Scale = Scale
         self._BackgroundDirty = True
         if DrawFlag:
@@ -886,9 +886,9 @@ class FloatCanvas(wx.Panel):
             SetToNull=True
         if SetToNull:
             self.BoundingBox = BBox.NullBBox()
-            self.ViewPortCenter= N.array( (0,0), float)
-            self.TransformVector = N.array( (1,-1), float)
-            self.MapProjectionVector = N.array( (1,1), float)
+            self.ViewPortCenter= np.array( (0,0), float)
+            self.TransformVector = np.array( (1,-1), float)
+            self.MapProjectionVector = np.array( (1,1), float)
             self.Scale = 1
         self.BoundingBoxDirty = False
 
@@ -900,7 +900,7 @@ class FloatCanvas(wx.Panel):
         or a NX2 Numpy array of x,y coordinates.
 
         """
-        return  (((N.asarray(Points, float) -
+        return  (((np.asarray(Points, float) -
                    (self.PanelSize/2))/self.TransformVector) +
                  self.ViewPortCenter)
 
@@ -912,7 +912,7 @@ class FloatCanvas(wx.Panel):
         a 2-tuple, or sequence of 2-tuples.
         """
         #Note: this can be called by users code for various reasons, so N.asarray is needed.
-        return  (((N.asarray(Coordinates,float) -
+        return  (((np.asarray(Coordinates,float) -
                    self.ViewPortCenter)*self.TransformVector)+
                  (self.HalfPanelSize)).astype('i')
 
@@ -924,7 +924,7 @@ class FloatCanvas(wx.Panel):
         Lengths should be a NX2 array of (x,y) coordinates, or
         a 2-tuple, or sequence of 2-tuples.
         """
-        return  ( (N.asarray(Lengths, float)*self.TransformVector) ).astype('i')
+        return  ( (np.asarray(Lengths, float)*self.TransformVector) ).astype('i')
 
     def ScalePixelToWorld(self,Lengths):
         """
@@ -934,7 +934,7 @@ class FloatCanvas(wx.Panel):
         Lengths should be a NX2 array of (x,y) coordinates, or
         a 2-tuple, or sequence of 2-tuples.
         """
-        return  (N.asarray(Lengths,float) / self.TransformVector)
+        return  (np.asarray(Lengths,float) / self.TransformVector)
 
     def AddObject(self, obj):
         """

--- a/wx/lib/floatcanvas/GUIMode.py
+++ b/wx/lib/floatcanvas/GUIMode.py
@@ -22,7 +22,7 @@ version of the code.
 """
 
 import wx
-import numpy as N
+import numpy as np
 
 from . import FCEvents, Resources
 from .Utilities import BBox
@@ -222,14 +222,14 @@ class GUIMove(ZoomWithMouseWheel, GUIBase):
     def OnLeftDown(self, event):
         self.Canvas.SetCursor(self.GrabCursor)
         self.Canvas.CaptureMouse()
-        self.StartMove = N.array( event.GetPosition() )
+        self.StartMove = np.array( event.GetPosition() )
         self.MidMove = self.StartMove
         self.PrevMoveXY = (0,0)
 
     def OnLeftUp(self, event):
         self.Canvas.SetCursor(self.Cursor)
         if self.StartMove is not None:
-            self.EndMove = N.array(event.GetPosition())
+            self.EndMove = np.array(event.GetPosition())
             DiffMove = self.MidMove-self.EndMove
             self.Canvas.MoveImage(DiffMove, 'Pixel', ReDraw=True)
 
@@ -237,7 +237,7 @@ class GUIMove(ZoomWithMouseWheel, GUIBase):
         # Always raise the Move event.
         self.Canvas._RaiseMouseEvent(event, FCEvents.EVT_FC_MOTION)
         if event.Dragging() and event.LeftIsDown() and not self.StartMove is None:
-            self.EndMove = N.array(event.GetPosition())
+            self.EndMove = np.array(event.GetPosition())
             self.MoveImage(event)
             DiffMove = self.MidMove-self.EndMove
             self.Canvas.MoveImage(DiffMove, 'Pixel', ReDraw=False)# reset the canvas without re-drawing
@@ -321,7 +321,7 @@ class GUIZoomIn(ZoomWithMouseWheel, GUIBase):
         self.Cursor = self.Cursors.MagPlusCursor
 
     def OnLeftDown(self, event):
-        self.StartRBBox = N.array( event.GetPosition() )
+        self.StartRBBox = np.array( event.GetPosition() )
         self.PrevRBBox = None
         self.Canvas.CaptureMouse()
 
@@ -335,7 +335,7 @@ class GUIZoomIn(ZoomWithMouseWheel, GUIBase):
                     and abs(StartRBBox[1] - EndRBBox[1]) > 10 ):
                 EndRBBox = self.Canvas.PixelToWorld(EndRBBox)
                 StartRBBox = self.Canvas.PixelToWorld(StartRBBox)
-                self.Canvas.ZoomToBB( BBox.fromPoints(N.r_[EndRBBox,StartRBBox]) )
+                self.Canvas.ZoomToBB( BBox.fromPoints(np.r_[EndRBBox,StartRBBox]) )
             else:
                 Center = self.Canvas.PixelToWorld(StartRBBox)
                 self.Canvas.Zoom(1.5,Center)
@@ -346,7 +346,7 @@ class GUIZoomIn(ZoomWithMouseWheel, GUIBase):
         self.Canvas._RaiseMouseEvent(event,FCEvents.EVT_FC_MOTION)
         if event.Dragging() and event.LeftIsDown() and not (self.StartRBBox is None):
             xy0 = self.StartRBBox
-            xy1 = N.array( event.GetPosition() )
+            xy1 = np.array( event.GetPosition() )
             wh  = abs(xy1 - xy0)
             wh[0] = max(wh[0], int(wh[1]*self.Canvas.AspectRatio))
             wh[1] = int(wh[0] / self.Canvas.AspectRatio)

--- a/wx/lib/floatcanvas/Utilities/BBox.py
+++ b/wx/lib/floatcanvas/Utilities/BBox.py
@@ -15,9 +15,9 @@ A Bounding Box object and assorted utilities , subclassed from a numpy array
 
 """
 
-import numpy as N
+import numpy as np
 
-class BBox(N.ndarray):
+class BBox(np.ndarray):
     """
     A Bounding Box object:
 
@@ -61,12 +61,12 @@ class BBox(N.ndarray):
         fromPoints
 
         """
-        arr = N.array(data, float)
+        arr = np.array(data, float)
         arr.shape = (2,2)
         if arr[0,0] > arr[1,0] or arr[0,1] > arr[1,1]:
             # note: zero sized BB OK.
             raise ValueError("BBox values not aligned: \n minimum values must be less that maximum values")
-        return N.ndarray.__new__(subtype, shape=arr.shape, dtype=arr.dtype, buffer=arr)
+        return np.ndarray.__new__(subtype, shape=arr.shape, dtype=arr.dtype, buffer=arr)
 
     def Overlaps(self, BB):
         """
@@ -77,7 +77,7 @@ class BBox(N.ndarray):
         If they are just touching, returns True
         """
 
-        if N.isinf(self).all() or N.isinf(BB).all():
+        if np.isinf(self).all() or np.isinf(BB).all():
             return True
         if ( (self[1,0] >= BB[0,0]) and (self[0,0] <= BB[1,0]) and
              (self[1,1] >= BB[0,1]) and (self[0,1] <= BB[1,1]) ):
@@ -130,7 +130,7 @@ class BBox(N.ndarray):
         """
         if self.IsNull():
             self[:] = BB
-        elif N.isnan(BB).all(): ## BB may be a regular array, so I can't use IsNull
+        elif np.isnan(BB).all(): ## BB may be a regular array, so I can't use IsNull
             pass
         else:
             if BB[0,0] < self[0,0]: self[0,0] = BB[0,0]
@@ -141,7 +141,7 @@ class BBox(N.ndarray):
         return None
 
     def IsNull(self):
-        return N.isnan(self).all()
+        return np.isnan(self).all()
 
     ## fixme: it would be nice to add setter, too.
     def _getLeft(self):
@@ -179,7 +179,7 @@ class BBox(N.ndarray):
 
 
     ## Save the ndarray __eq__ for internal use.
-    Array__eq__ = N.ndarray.__eq__
+    Array__eq__ = np.ndarray.__eq__
     def __eq__(self, BB):
         """
         __eq__(BB) The equality operator
@@ -187,7 +187,7 @@ class BBox(N.ndarray):
         A == B if and only if all the entries are the same
 
         """
-        if self.IsNull() and N.isnan(BB).all(): ## BB may be a regular array, so I can't use IsNull
+        if self.IsNull() and np.isnan(BB).all(): ## BB may be a regular array, so I can't use IsNull
             return True
         else:
             return self.Array__eq__(BB).all()
@@ -212,8 +212,8 @@ def asBBox(data):
 
     if isinstance(data, BBox):
         return data
-    arr = N.asarray(data, float)
-    return N.ndarray.__new__(BBox, shape=arr.shape, dtype=arr.dtype, buffer=arr)
+    arr = np.asarray(data, float)
+    return np.ndarray.__new__(BBox, shape=arr.shape, dtype=arr.dtype, buffer=arr)
 
 def fromPoints(Points):
     """
@@ -225,10 +225,10 @@ def fromPoints(Points):
     If a single point is passed in, a zero-size Bounding Box is returned.
 
     """
-    Points = N.asarray(Points, float).reshape(-1,2)
+    Points = np.asarray(Points, float).reshape(-1,2)
 
-    arr = N.vstack( (Points.min(0), Points.max(0)) )
-    return N.ndarray.__new__(BBox, shape=arr.shape, dtype=arr.dtype, buffer=arr)
+    arr = np.vstack( (Points.min(0), Points.max(0)) )
+    return np.ndarray.__new__(BBox, shape=arr.shape, dtype=arr.dtype, buffer=arr)
 
 def fromBBArray(BBarray):
     """
@@ -243,8 +243,8 @@ def fromBBArray(BBarray):
 
  #   BBarray = N.asarray(BBarray, float).reshape(-1,2)
  #   arr = N.vstack( (BBarray.min(0), BBarray.max(0)) )
-    BBarray = N.asarray(BBarray, float).reshape(-1,2,2)
-    arr = N.vstack( (BBarray[:,0,:].min(0), BBarray[:,1,:].max(0)) )
+    BBarray = np.asarray(BBarray, float).reshape(-1,2,2)
+    arr = np.vstack( (BBarray[:,0,:].min(0), BBarray[:,1,:].max(0)) )
     return asBBox(arr)
     #return asBBox( (upperleft, lowerright) ) * 2
 
@@ -260,8 +260,8 @@ def NullBBox():
 
     """
 
-    arr = N.array(((N.nan, N.nan),(N.nan, N.nan)), float)
-    return N.ndarray.__new__(BBox, shape=arr.shape, dtype=arr.dtype, buffer=arr)
+    arr = np.array(((np.nan, np.nan),(np.nan, np.nan)), float)
+    return np.ndarray.__new__(BBox, shape=arr.shape, dtype=arr.dtype, buffer=arr)
 
 def InfBBox():
     """
@@ -269,8 +269,8 @@ def InfBBox():
 
     """
 
-    arr = N.array(((-N.inf, -N.inf),(N.inf, N.inf)), float)
-    return N.ndarray.__new__(BBox, shape=arr.shape, dtype=arr.dtype, buffer=arr)
+    arr = np.array(((-np.inf, -np.inf),(np.inf, np.inf)), float)
+    return np.ndarray.__new__(BBox, shape=arr.shape, dtype=arr.dtype, buffer=arr)
 
 class RectBBox(BBox):
     """


### PR DESCRIPTION
The convention when importing NumPy is to use `import numpy as np`. This PR makes it uniform across the project, especially in samples.

Fixes: unconventional-import-alias (ICN001)
Ruff rule: https://docs.astral.sh/ruff/rules/unconventional-import-alias/

