### PR TITLE
style: Normalise ElementTree imports with `import xml.etree.ElementTree as ET`

### DIFF
--- a/etgtools/__init__.py
+++ b/etgtools/__init__.py
@@ -85,7 +85,7 @@ def parseDoxyXML(module, class_or_filename_list):
             print("Loading %s..." % pathname)
         _filesparsed.add(pathname)
 
-        root = et.parse(pathname).getroot()
+        root = ET.parse(pathname).getroot()
         for element in root:
             # extract and add top-level elements from the XML document
             item = module.addElement(element)

--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -15,7 +15,7 @@ wxWidgets API info which we need from them.
 import sys
 import os
 import pprint
-import xml.etree.ElementTree as et
+import xml.etree.ElementTree as ET
 import copy
 
 from .tweaker_tools import FixWxPrefix, magicMethods, \
@@ -666,7 +666,7 @@ class ParamDef(BaseDef):
                 self.default = flattenNode(element.find('defval'))
         except:
             print("error when parsing element:")
-            et.dump(element)
+            ET.dump(element)
             raise
 #---------------------------------------------------------------------------
 
@@ -740,7 +740,7 @@ class ClassDef(BaseDef):
                 return all_classes, specials
 
             fname = os.path.join(XMLSRC, refid+'.xml')
-            root = et.parse(fname).getroot()
+            root = ET.parse(fname).getroot()
             compounds = findDescendants(root, 'basecompoundref')
         else:
             compounds = element.findall('basecompoundref')
@@ -783,7 +783,7 @@ class ClassDef(BaseDef):
             from etgtools import XMLSRC
             ref = node.get('refid')
             fname = os.path.join(XMLSRC, ref+'.xml')
-            root = et.parse(fname).getroot()
+            root = ET.parse(fname).getroot()
             innerclass = root[0]
             kind = innerclass.get('kind')
             assert kind in ['class', 'struct']
@@ -1603,7 +1603,7 @@ class ModuleDef(BaseDef):
         from etgtools import XMLSRC
         refid = node.get('refid')
         fname = os.path.join(XMLSRC, refid.rsplit('_', 1)[0]) + '.xml'
-        root = et.parse(fname).getroot()
+        root = ET.parse(fname).getroot()
         return root.find(".//memberdef[@id='{}']".format(refid))
 
 
@@ -1749,7 +1749,7 @@ def prependText(node, text):
 
 
 def makeTextElement(text):
-    element = et.Element('para')
+    element = ET.Element('para')
     element.text = text
     return element
 

--- a/etgtools/sphinx_generator.py
+++ b/etgtools/sphinx_generator.py
@@ -22,7 +22,7 @@ import textwrap
 
 from io import StringIO
 
-import xml.etree.ElementTree as et
+import xml.etree.ElementTree as ET
 
 # Phoenix-specific stuff
 import etgtools.extractors as extractors
@@ -783,7 +783,7 @@ class Paragraph(Node):
 
                 first = line.index('Availability:')
 
-                element = et.Element('available', kind='available')
+                element = ET.Element('available', kind='available')
                 element.text = line[first+13:]
 
                 section = Section(element, None, self.kind)
@@ -2002,7 +2002,7 @@ class XMLDocString(object):
         # non-empty string. In such cases, this branch will insert a deprecated section into the xml tree
         # so that the Node Tree (see classes above) will generate the deprecated  tag on their own in self.RecurseXML
         if hasattr(xml_item, 'deprecated') and xml_item.deprecated and isinstance(xml_item.deprecated, str):
-            element = et.Element('deprecated', kind='deprecated')
+            element = ET.Element('deprecated', kind='deprecated')
             element.text = xml_item.deprecated
 
             deprecated_section = Section(element, None, self.kind, self.is_overload, self.share_docstrings)
@@ -2227,7 +2227,7 @@ class XMLDocString(object):
             rest_class = ULink(element, parent)
 
         elif tag == 'onlyfor':
-            onlyfor = et.Element('available', kind='available')
+            onlyfor = ET.Element('available', kind='available')
             onlyfor.text = text
             onlyfor.tail = tail
 
@@ -2586,7 +2586,7 @@ class XMLDocString(object):
                     else:
                         new_section.append('`%s`' % stripped)
 
-            element = et.Element('return', kind='return')
+            element = ET.Element('return', kind='return')
             element.text = '( %s )'%(', '.join(new_section))
 
             return_section = Section(element, None, self.kind, self.is_overload, self.share_docstrings)
@@ -3571,7 +3571,7 @@ class SphinxGenerator(generators.DocsGeneratorBase):
                     else:
                         new_section.append('`%s`'%stripped)
 
-            element = et.Element('return', kind='return')
+            element = ET.Element('return', kind='return')
             element.text = '( %s )'%(', '.join(new_section))
 
             rtype2 = Section(element, None, 'method')


### PR DESCRIPTION
Similar to #2693 
The convention is that `xml.etree.ElementTree` should be imported as `ET`. This PR makes it uniform across the project. It is limited to etgtools.

Fixes: unconventional-import-alias (ICN001)

Ruff rule: https://docs.astral.sh/ruff/rules/unconventional-import-alias/
