### PR TITLE
Update hyperlink.py, fixes #2686

### DIFF
--- a/wx/lib/agw/hyperlink.py
+++ b/wx/lib/agw/hyperlink.py
@@ -122,7 +122,7 @@ Version 0.7
 """
 
 import wx
-from wx.lib.stattext import GenStaticText as StaticText
+from wx import StaticText
 
 # Import the useful webbrowser module for platform-independent results
 import webbrowser


### PR DESCRIPTION
Uses StaticText instead of GenStaticText

Tested in linux (fedora, ubuntu), windows 11, MacOS sequoia

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #NNNN

