### PR TITLE
Handle deprecated NumPy type aliases in samples

### DIFF
--- a/samples/floatcanvas/BNAEditor.py
+++ b/samples/floatcanvas/BNAEditor.py
@@ -75,7 +75,7 @@ class BNAData:
                 num_points = int(line)
                 self.Types.append(Type)
                 self.Names.append(Name)
-                polygon = np.zeros((num_points,2),np.float)
+                polygon = np.zeros((num_points,2),float)
                 for i in range(num_points):
                     polygon[i,:] = map(float, file_.readline().split(','))
                 self.PointsData.append(polygon)
@@ -208,7 +208,7 @@ class DrawFrame(wx.Frame):
             dc.SetPen(wx.Pen('WHITE', 2, wx.SHORT_DASH))
             dc.SetLogicalFunction(wx.XOR)
             if self.SelectedPointNeighbors is None:
-                self.SelectedPointNeighbors = np.zeros((3,2), np.float)
+                self.SelectedPointNeighbors = np.zeros((3,2), float)
                 #fixme: This feels very inelegant!
                 if Index == 0:
                     self.SelectedPointNeighbors[0] = self.SelectedPoly.Points[-1]

--- a/samples/floatcanvas/BarPlot.py
+++ b/samples/floatcanvas/BarPlot.py
@@ -27,7 +27,7 @@ def YScaleFun(center):
     """
 
     # center gets ignored in this case
-    return np.array((1, float(NumChannels)/MaxValue), np.float)
+    return np.array((1, float(NumChannels)/MaxValue), float)
 
 def ScaleWorldToPixel(self, Lengths):
     """
@@ -41,7 +41,7 @@ def ScaleWorldToPixel(self, Lengths):
         Lengths should be a NX2 array of (x,y) coordinates, or
         a 2-tuple, or sequence of 2-tuples.
     """
-    return  np.ceil(( (np.asarray(Lengths, np.float)*self.TransformVector) )).astype('i')
+    return  np.ceil(( (np.asarray(Lengths, float)*self.TransformVector) )).astype('i')
 
 
 class DrawFrame(wx.Frame):

--- a/samples/floatcanvas/MovingElements.py
+++ b/samples/floatcanvas/MovingElements.py
@@ -192,7 +192,7 @@ class DrawFrame(wx.Frame):
         Points = np.array(((0,0),
                           (1,0),
                           (0.5, 1)),
-                         np.float)
+                         float)
 
         data  = (( (0,0),  1),
                  ( (3,3),  2),

--- a/samples/floatcanvas/ProcessDiagram.py
+++ b/samples/floatcanvas/ProcessDiagram.py
@@ -100,8 +100,8 @@ class NodeObject(FC.Group, MovingObjectMixin, ConnectorObjectMixin):
                  TextColor = "Black",
                  InForeground  = False,
                  IsVisible = True):
-        XY = np.asarray(XY, np.float).reshape(2,)
-        WH = np.asarray(WH, np.float).reshape(2,)
+        XY = np.asarray(XY, float).reshape(2,)
+        WH = np.asarray(WH, float).reshape(2,)
         Label = FC.ScaledText(Label,
                         XY,
                         Size = WH[1] / 2.0,

--- a/samples/floatcanvas/ScaleDemo.py
+++ b/samples/floatcanvas/ScaleDemo.py
@@ -30,7 +30,7 @@ def YScaleFun(center):
 
     """
     # center gets ignored in this case
-    return np.array((5e7, 1), np.float)
+    return np.array((5e7, 1), float)
 
 class DrawFrame(wx.Frame):
 

--- a/samples/floatcanvas/TextBox2.py
+++ b/samples/floatcanvas/TextBox2.py
@@ -62,7 +62,7 @@ class DrawFrame(wx.Frame):
         self.Canvas.Bind(FloatCanvas.EVT_LEFT_UP, self.OnLeftUp )
         self.Canvas.Bind(FloatCanvas.EVT_LEFT_DOWN, self.OnLeftDown)
 
-        Point = np.array((0,0), np.float)
+        Point = np.array((0,0), float)
 
 
 

--- a/samples/floatcanvas/Tree.py
+++ b/samples/floatcanvas/Tree.py
@@ -100,8 +100,8 @@ class NodeObject(FC.Group, MovingObjectMixin, ConnectorObjectMixin):
                  TextColor = "Black",
                  InForeground  = False,
                  IsVisible = True):
-        XY = np.asarray(XY, np.float).reshape(2,)
-        WH = np.asarray(WH, np.float).reshape(2,)
+        XY = np.asarray(XY, float).reshape(2,)
+        WH = np.asarray(WH, float).reshape(2,)
         Label = FC.ScaledText(Label,
                         XY,
                         Size = WH[1] / 2.0,


### PR DESCRIPTION
These aliases were deprecated in NumPy 1.20.0 (January 2021), and removed in 1.24.0 (December 2022) This helps with NumPy 2 support (June 2024).

Fixes: numpy-deprecated-type-alias (NPY001)
Ruff rule to help transition: https://docs.astral.sh/ruff/rules/numpy-deprecated-type-alias/, as recommended in their migration guide: https://numpy.org/devdocs/numpy_2_0_migration_guide.html

Follow up from #2693 