### PR TITLE
Update SIP ABI version to 12.11

### DIFF
--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -88,7 +88,7 @@ class Configuration(object):
     PKGDIR = 'wx'
     # The name of the top-level package
 
-    SIP_ABI = '12.11'
+    SIP_ABI = '12.14'
     SIP_TRACE = False
 
     # ---------------------------------------------------------------

--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -88,7 +88,7 @@ class Configuration(object):
     PKGDIR = 'wx'
     # The name of the top-level package
 
-    SIP_ABI = '12.9'
+    SIP_ABI = '12.11'
     SIP_TRACE = False
 
     # ---------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ requires = [
     "setuptools>=70.1",
     "cython == 3.0.10",
     "requests >= 2.26.0",
-    "sip == 6.9.1",
+    "sip == 6.10.0",
 ]
 # Using "setuptools.build_meta:__legacy__" instead of "setuptools.build_meta" for now.
 # Allows to have access to the folder on the search path when building, like before.

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -2,7 +2,7 @@
 -r install.txt
 appdirs
 setuptools
-sip == 6.9.1
+sip == 6.10.0
 
 twine
 requests >= 2.26.0


### PR DESCRIPTION
We haven't supported 12.8 since before we upgraded to SIP 6.6+. However, SIP has not been correctly generating the correct module version until very recently, so generating 12.8 doesn't actually compile with current wxPython.


