### PR TITLE
Build macOS architectures separately for CI and wheels

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -104,15 +104,25 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, windows-2022, macos-13 ]
+        os: [ ubuntu-22.04, windows-2022, macos-13, macos-14 ]
         python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
-        architecture: [ 'x86', 'x64' ]
+        architecture: [ 'x86', 'x64', 'arm64' ]
         # Exclude x86 configs on non-Windows OSs
         exclude:
           - os: ubuntu-22.04
             architecture: x86
+          - os: ubuntu-22.04
+            architecture: arm64
           - os: macos-13
             architecture: x86
+          - os: macos-13
+            architecture: arm64
+          - os: macos-14
+            architecture: x86
+          - os: macos-14
+            architecture: x64
+          - os: windows-2022
+            architecture: arm64
           # Only build oldest and newest Pythons on PRs
           - python-version: ${{ github.event_name == 'pull_request' && '3.10' }}
           - python-version: ${{ github.event_name == 'pull_request' && '3.11' }}
@@ -136,7 +146,14 @@ jobs:
               short_name=linux
           elif [ ${{ matrix.os }} == macos-13 ]; then
               short_name=macos
-              build_opts="$build_opts --mac_arch=arm64,x86_64"
+              echo "CIBW_BUILD=cp$(echo ${{ matrix.python-version }} | sed 's/\.//')-macosx_$(uname -m)" >> "$GITHUB_ENV"
+              echo "CIBW_BUILD_VERBOSITY=1" >> "$GITHUB_ENV"
+              echo "MACOSX_DEPLOYMENT_TARGET=10.10" >> "$GITHUB_ENV"
+          elif [ ${{ matrix.os }} == macos-14 ]; then
+              short_name=macos
+              echo "CIBW_BUILD=cp$(echo ${{ matrix.python-version }} | sed 's/\.//')-macosx_$(uname -m)" >> "$GITHUB_ENV"
+              echo "CIBW_BUILD_VERBOSITY=1" >> "$GITHUB_ENV"
+              echo "MACOSX_DEPLOYMENT_TARGET=11.0" >> "$GITHUB_ENV"
           elif [ ${{ matrix.os }} == windows-2022 ]; then
               if [ ${{ matrix.architecture }} == x64 ]; then
                   short_name=win64
@@ -201,8 +218,13 @@ jobs:
         env:
           WXPYTHON_BUILD_ARGS: ${{ steps.init.outputs.build_opts }}
         run: |
-          cd dist
-          pip wheel -v wxPython-${{ env.VERSION }}.tar.gz
+          if [ -z "$CIBW_BUILD" ]; then
+              cd dist
+              pip wheel -v wxPython-${{ env.VERSION }}.tar.gz
+          else
+              pip install cibuildwheel
+              cibuildwheel dist/wxPython-${{ env.VERSION }}.tar.gz --output-dir dist
+          fi
 
       - name: Simple smoke test
         run: |

--- a/build.py
+++ b/build.py
@@ -1504,8 +1504,6 @@ def cmd_build_wx(options, args):
 
             if options.mac_arch:
                 build_options.append("--mac_universal_binary=%s" % options.mac_arch)
-            else:
-                build_options.append("--mac_universal_binary=default")
 
         if options.no_config:
             build_options.append('--no_config')

--- a/buildtools/build_wxwidgets.py
+++ b/buildtools/build_wxwidgets.py
@@ -194,7 +194,7 @@ def main(wxDir, args):
         "gtk3"          : (True,  "On Linux build for gtk3"),
         "mac_distdir"   : (None, "If set on Mac, will create an installer package in the specified dir."),
         "mac_universal_binary"
-                        : ("default", "Comma separated list of architectures to include in the Mac universal binary"),
+                        : ("", "Comma separated list of architectures to include in the Mac universal binary"),
         "mac_framework" : (False, "Install the Mac build as a framework"),
         "mac_framework_prefix"
                         : (defFwPrefix, "Prefix where the framework should be installed. Default: %s" % defFwPrefix),

--- a/buildtools/config.py
+++ b/buildtools/config.py
@@ -280,6 +280,14 @@ class Configuration(object):
                         del LDSHARED[index:index+2]
                     except ValueError:
                         break
+                # also remove any -arch flags and their arg
+                while True:
+                    try:
+                        index = LDSHARED.index('-arch')
+                        # Strip this argument and the next one:
+                        del LDSHARED[index:index+2]
+                    except ValueError:
+                        break
                 LDSHARED = ' '.join(LDSHARED)
                 # Combine with wx's ld command and stash it in the env
                 # where distutils will get it later.


### PR DESCRIPTION
Building the architectures separately allows them to be built in parallel, which will speed up CI but also result in smaller wheels which should be more efficient instead of universal wheels.
