### PR TITLE
Fix assert_ to assertTrue

### DIFF
--- a/wx/py/tests/test_interpreter.py
+++ b/wx/py/tests/test_interpreter.py
@@ -10,7 +10,7 @@ from wx.py import interpreter
 """
 These unittest methods are preferred:
 -------------------------------------
-self.assert_(expr, msg=None)
+self.assertTrue(expr, msg=None)
 self.assertEqual(first, second, msg=None)
 self.assertRaises(excClass, callableObj, *args, **kwargs)
 self.fail(msg=None)
@@ -22,13 +22,13 @@ class ModuleTestCase(unittest.TestCase):
 
     def test_module(self):
         module = interpreter
-        self.assert_(module.__author__)
-        self.assert_(module.Interpreter)
-        self.assert_(module.Interpreter.push)
-        self.assert_(module.Interpreter.runsource)
-        self.assert_(module.Interpreter.getAutoCompleteList)
-        self.assert_(module.Interpreter.getCallTip)
-        self.assert_(module.InterpreterAlaCarte)
+        self.assertTrue(module.__author__)
+        self.assertTrue(module.Interpreter)
+        self.assertTrue(module.Interpreter.push)
+        self.assertTrue(module.Interpreter.runsource)
+        self.assertTrue(module.Interpreter.getAutoCompleteList)
+        self.assertTrue(module.Interpreter.getCallTip)
+        self.assertTrue(module.InterpreterAlaCarte)
 
 
 class InterpreterTestCase(unittest.TestCase):

--- a/wx/py/tests/test_introspect.py
+++ b/wx/py/tests/test_introspect.py
@@ -11,7 +11,7 @@ from wx.py import introspect
 """
 These unittest methods are preferred:
 -------------------------------------
-self.assert_(expr, msg=None)
+self.assertTrue(expr, msg=None)
 self.assertEqual(first, second, msg=None)
 self.assertRaises(excClass, callableObj, *args, **kwargs)
 self.fail(msg=None)
@@ -23,15 +23,15 @@ class ModuleTestCase(unittest.TestCase):
 
     def test_module(self):
         module = introspect
-        self.assert_(module.__author__)
-        self.assert_(module.getAllAttributeNames)
-        self.assert_(module.getAttributeNames)
-        self.assert_(module.getAutoCompleteList)
-        self.assert_(module.getBaseObject)
-        self.assert_(module.getCallTip)
-        self.assert_(module.getConstructor)
-        self.assert_(module.getRoot)
-        self.assert_(module.rtrimTerminus)
+        self.assertTrue(module.__author__)
+        self.assertTrue(module.getAllAttributeNames)
+        self.assertTrue(module.getAttributeNames)
+        self.assertTrue(module.getAutoCompleteList)
+        self.assertTrue(module.getBaseObject)
+        self.assertTrue(module.getCallTip)
+        self.assertTrue(module.getConstructor)
+        self.assertTrue(module.getRoot)
+        self.assertTrue(module.rtrimTerminus)
 
 
 class RtrimTerminusTestCase(unittest.TestCase):
@@ -665,7 +665,7 @@ class GetAttributeNamesTestCase(GetAttributeTestCase):
     def test_getAttributeNames(self):
         for item in self.items:
             self._checkAttributeNames(item)
-        if 'object' in __builtins__:
+        if 'object' in __builtins__ if isinstance(__builtins__, dict) else vars(__builtins__):
             self._checkAttributeNames(object)
 
     def test_getAttributeNames_NoSingle(self):
@@ -698,8 +698,8 @@ class GetAttributeNamesTestCase(GetAttributeTestCase):
         attributes = [attribute for attribute in self.values \
                       if hasattr(item, attribute)]
         for attribute in attributes:
-            self.assert_(attribute in result,
-                         ':item: %r :attribute: %r' % (item, attribute))
+            self.assertTrue(attribute in result,
+                            ':item: %r :attribute: %r' % (item, attribute))
 
 
 class GetAutoCompleteListTestCase(GetAttributeTestCase):
@@ -726,8 +726,8 @@ class GetAutoCompleteListTestCase(GetAttributeTestCase):
             attributes = [attribute for attribute in self.values \
                           if hasattr(object, attribute)]
             for attribute in attributes:
-                self.assert_(attribute in result,
-                             ':item: %r :attribute: %r' % (item, attribute))
+                self.assertTrue(attribute in result,
+                                ':item: %r :attribute: %r' % (item, attribute))
 
     def test_getAutoCompleteList_NoSingle(self):
         for item in self.items:
@@ -771,7 +771,7 @@ class C1(A1):
 class D1(C1, B1):
     pass
 
-if 'object' in __builtins__:
+if 'object' in __builtins__ if isinstance(__builtins__, dict) else vars(__builtins__):
     class A2(object):
         def __init__(self, a):
             self.a = a
@@ -809,4 +809,5 @@ class GetConstructorTestCase(unittest.TestCase):
 
 
 if __name__ == '__main__':
+    sys.ps2 = '... '
     unittest.main()

--- a/wx/py/tests/test_pseudo.py
+++ b/wx/py/tests/test_pseudo.py
@@ -10,7 +10,7 @@ from wx.py import pseudo
 """
 These unittest methods are preferred:
 -------------------------------------
-self.assert_(expr, msg=None)
+self.assertTrue(expr, msg=None)
 self.assertEqual(first, second, msg=None)
 self.assertRaises(excClass, callableObj, *args, **kwargs)
 self.fail(msg=None)
@@ -22,12 +22,12 @@ class ModuleTestCase(unittest.TestCase):
 
     def test_module(self):
         module = pseudo
-        self.assert_(module.__author__)
-        self.assert_(module.PseudoFile)
-        self.assert_(module.PseudoFileErr)
-        self.assert_(module.PseudoFileIn)
-        self.assert_(module.PseudoFileOut)
-        self.assert_(module.PseudoKeyword)
+        self.assertTrue(module.__author__)
+        self.assertTrue(module.PseudoFile)
+        self.assertTrue(module.PseudoFileErr)
+        self.assertTrue(module.PseudoFileIn)
+        self.assertTrue(module.PseudoFileOut)
+        self.assertTrue(module.PseudoKeyword)
 
 
 class PseudoTestCase(unittest.TestCase):
@@ -60,7 +60,7 @@ class PseudoFileOutTestCase(unittest.TestCase):
         pass
 
     def test_PseudoFileOut_goodInit(self):
-        self.assert_(pseudo.PseudoFileOut(write=self._write))
+        self.assertTrue(pseudo.PseudoFileOut(write=self._write))
 
     def test_PseudoFileOut_badInit(self):
         self.assertRaises(ValueError, pseudo.PseudoFileOut, write='bad')

--- a/wx/py/tests/test_version.py
+++ b/wx/py/tests/test_version.py
@@ -10,7 +10,7 @@ from wx.py import version
 """
 These unittest methods are preferred:
 -------------------------------------
-self.assert_(expr, msg=None)
+self.assertTrue(expr, msg=None)
 self.assertEqual(first, second, msg=None)
 self.assertRaises(excClass, callableObj, *args, **kwargs)
 self.fail(msg=None)
@@ -22,14 +22,14 @@ class ModuleTestCase(unittest.TestCase):
 
     def test_module(self):
         module = version
-        self.assert_(module.__author__)
-        self.assert_(module.VERSION)
+        self.assertTrue(module.__author__)
+        self.assertTrue(module.VERSION)
 
 
 class VersionTestCase(unittest.TestCase):
 
     def test_VERSION(self):
-        self.assert_(isinstance(version.VERSION, str))
+        self.assertTrue(isinstance(version.VERSION, str))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #NNNN

This PR fixes the wx.py.tests modules so they run without errors.
Note that this does not mean that the tests pass. There are still some test failures due to recent Python updates.

Fix the test for both cases where `__builtins__` is a dict or a module.
Fix AttributeError: `sys.ps2` which exists only in interactive mode and does not exist when running a script.
