### PR TITLE
Qt support for wxPython in Linux

### DIFF
--- a/etg/listctrl.py
+++ b/etg/listctrl.py
@@ -325,7 +325,7 @@ def run():
 
     c.addCppMethod('wxWindow*', 'GetMainWindow', '()',
         body="""\
-        #if defined(__WXMSW__) || defined(__WXMAC__)
+        #if defined(__WXMSW__) || defined(__WXMAC__) || defined(__WXQT__)
             return self;
         #else
             return (wxWindow*)self->m_mainWin;

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -11,6 +11,16 @@
 import wx.__version__
 __version__ = wx.__version__.VERSION_STRING
 
+import os
+
+
+# Select platform backend
+__plat__ = '@DEFAULT@'
+if 'WX_API' in os.environ:
+    __plat__ = os.environ['WX_API']
+    if __plat__ not in ['@PLATS@']:
+        raise ImportError(f'invalid WX_API {__plat__}')
+
 
 # Import all items from the core wxPython module so they appear in the wx
 # package namespace.

--- a/src/core_ex.cpp
+++ b/src/core_ex.cpp
@@ -120,6 +120,10 @@ void wxPyCoreModuleInject(PyObject* moduleDict)
 #define wxPort "__WXGTK__"
 #define wxPortName "wxGTK"
 #endif
+#ifdef __WXQT__
+#define wxPort "__WXQT__"
+#define wxPortName "wxQT"
+#endif
 #ifdef __WXMSW__
 #define wxPort "__WXMSW__"
 #define wxPortName "wxMSW"
@@ -187,6 +191,9 @@ void wxPyCoreModuleInject(PyObject* moduleDict)
 #else
     _AddInfoString("gtk1");
 #endif
+#endif
+#ifdef __WXQT__
+    _AddInfoString("qt");
 #endif
 #ifdef __WXDEBUG__
     _AddInfoString("wx-assertions-on");

--- a/src/multi.py
+++ b/src/multi.py
@@ -1,0 +1,16 @@
+import importlib
+import sys
+
+root = importlib.import_module(__package__)
+
+_@NAME@ = importlib.import_module(f'.@NAME@_{root.__plat__}', __package__)
+
+if hasattr(_@NAME@, '__all__'):
+    __all__ = _@NAME@.__all__
+else:
+    __all__ = [name for name in dir(_@NAME@) if name != "__name__"]
+
+globals().update({name: getattr(_@NAME@, name) for name in __all__})
+
+del root
+del _@NAME@


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

This PR adds support for wxQt in wxPython. The reasoning behind this is that wxQt has been around for quite a while since wxWidgets `3.2.0` released 2 years ago, Qt has support for many platforms outside of Linux/BSDs X11 and Wayland and that Qt will remain with X11 alongside Wayland. Besides this, here is also brought to you the option to select your preferred wxWidgets backend via the `WX_API` env var, similar to spyder-ide/qtpy.

As of now the PR will remain as WIP because there are a few issues with the wxQt Python modules. Worth mentioning is that this also fixes a few compilation errors with wxQt.
