### PR TITLE
Fix for #2239

### DIFF
--- a/wx/lib/agw/ultimatelistctrl.py
+++ b/wx/lib/agw/ultimatelistctrl.py
@@ -13609,6 +13609,7 @@ class UltimateListCtrl(wx.Control):
             raise Exception("Invalid height passed to SetHeaderHeight: %s"%repr(height))
 
         self._headerWin._headerHeight = height
+        self._headerWin.InvalidateBestSize()
         self.DoLayout()
 
 


### PR DESCRIPTION
This is a possible simple fix for #2239 (SetHeaderHeight does not work in UltimateListCtrl). 

Only tested on Windows.

Fixes #2239

