### PR TITLE
Fix using `setuptools.build_meta` backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,7 @@ requires = [
     "requests >= 2.26.0",
     "sip == 6.10.0",
 ]
-# Using "setuptools.build_meta:__legacy__" instead of "setuptools.build_meta" for now.
-# Allows to have access to the folder on the search path when building, like before.
-build-backend = "setuptools.build_meta:__legacy__"
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]
 exclude = ["src", "buildtools*", "etgtools", "sphinxtools", "src", "unittests"]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ from setuptools.command.bdist_egg   import bdist_egg as orig_bdist_egg
 from setuptools.command.sdist       import sdist as orig_sdist
 from setuptools.command.bdist_wheel import bdist_wheel as orig_bdist_wheel
 
+# Alter the path so that buildtools can be imported from the current directory.
+sys.path.insert(0, os.path.dirname(__file__))
+
 from buildtools.config import Config, msg, opj, runcmd, canGetSOName, getSOName
 import buildtools.version as version
 


### PR DESCRIPTION
Add the current directory path to `sys.path` explicitly, in order to fix using the correct `setuptools.build_meta` backend.  The legacy backend is only meant to be used implicitly for packages that have not been ported to PEP 517 builds yet, and using it explicitly is invalid. The correct solution here is to set the import path correctly.
