### PR TITLE
Add Fedora-41 docker configuration with Python 3.13 and 3.14

### DIFF
--- a/docker/build/fedora-41/Dockerfile
+++ b/docker/build/fedora-41/Dockerfile
@@ -1,0 +1,64 @@
+# The base image
+FROM fedora:41
+
+# Set environment variables
+ENV DIST_NAME=fedora-41
+ENV USER=wxpy
+ENV HOME=/home/$USER
+ENV PYTHONUNBUFFERED=1
+ENV PATH=$HOME/bin:$PATH
+ENV GTK2_OK=no
+
+# Update and install basic OS packages
+RUN \
+        dnf -y update; \
+        dnf -y group install "Development Tools"; \
+        dnf -y install gcc-c++ sudo nano which; \
+# Set up a user, and etc.
+        mkdir -p /dist; \
+        adduser -m ${USER}; \
+        echo "${USER} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers; \
+# Install development packages needed for building wxPython
+        dnf install -y \
+                freeglut-devel \
+                gstreamer1-devel \
+                gstreamer1-plugins-base-devel \
+                gtk3-devel \
+                libjpeg-turbo-devel \
+                libnotify-devel \
+                libpng-devel \
+                libSM-devel \
+                libtiff-devel \
+                libXtst-devel \
+                SDL-devel \
+                webkit2gtk3-devel;
+
+RUN \
+# Install all available Python packages and their dev packages
+        dnf -y install python3 python3-devel; \
+        dnf -y install python3.14 python3.14-devel;
+
+RUN \
+# Clean up dnf caches
+        dnf clean all;
+
+
+# Set the user and group to use for the rest of the commands
+USER ${USER}:${USER}
+
+# Set the working directory
+WORKDIR ${HOME}
+
+# Create virtual environments for each Python
+RUN \
+        cd ${HOME}; \
+        mkdir -p ${HOME}/venvs; \
+        python3.13 -m venv venvs/Py313; \
+        python3.14 -m venv venvs/Py314;
+
+# Add files from host into the container
+COPY scripts ${HOME}/bin
+
+# Define default command
+CMD ["/bin/bash", "-l"]
+


### PR DESCRIPTION
Add Fedora-41 docker configuration with Python 3.13 and 3.14

Did not had success in building due to error in build Wx (see this [post](https://discuss.wxpython.org/t/building-wxpython-in-fedora-41-fails-with-sdl-sethint-not-declared/40205?u=helio_guilherme)).

