### PR TITLE
Fix eol style.

### DIFF
--- a/wx/py/editwindow.py
+++ b/wx/py/editwindow.py
@@ -187,7 +187,7 @@ class EditWindow(stc.StyledTextCtrl):
         self.StyleSetSpec(stc.STC_P_COMMENTBLOCK,
                           "fore:#7F7F7F")
         self.StyleSetSpec(stc.STC_P_STRINGEOL,
-                          "fore:#000000,face:%(mono)s,back:#E0C0E0,eolfilled" % faces)
+                          "fore:#000000,face:%(mono)s,back:#E0C0E0,eol" % faces)
 
     def OnUpdateUI(self, event):
         """Check for matching braces."""


### PR DESCRIPTION
This PR fixes an unclosed string literal, allowing it to display as intended.
![image](https://github.com/user-attachments/assets/5fb9b689-5e03-42f8-bfa9-18743d6fc5fb)
