### PR TITLE
Fixes Ogl when resizing and dragging shapes

### DIFF
--- a/wx/lib/ogl/basic.py
+++ b/wx/lib/ogl/basic.py
@@ -324,8 +324,8 @@ class Shape(ShapeEvtHandler):
         self._id = 0
         self._formatted = False
         self._canvas = canvas
-        self._xpos = 0.0
-        self._ypos = 0.0
+        self._xpos = 0
+        self._ypos = 0
         self._pen = BlackForegroundPen
         self._brush = wx.WHITE_BRUSH
         self._font = NormalFont
@@ -353,7 +353,7 @@ class Shape(ShapeEvtHandler):
         self._centreResize = True
         self._maintainAspectRatio = False
         self._highlighted = False
-        self._rotation = 0.0
+        self._rotation = 0
         self._branchNeckLength = 10
         self._branchStemLength = 10
         self._branchSpacing = 10
@@ -3612,15 +3612,15 @@ class ShapeRegion(object):
         else:
             self._regionText = ""
             self._font = NormalFont
-            self._minHeight = 5.0
-            self._minWidth = 5.0
-            self._width = 0.0
-            self._height = 0.0
-            self._x = 0.0
-            self._y = 0.0
+            self._minHeight = 5
+            self._minWidth = 5
+            self._width = 0
+            self._height = 0
+            self._x = 0
+            self._y = 0
 
-            self._regionProportionX = -1.0
-            self._regionProportionY = -1.0
+            self._regionProportionX = -1
+            self._regionProportionY = -1
             self._formatMode = FORMAT_CENTRE_HORIZ | FORMAT_CENTRE_VERT
             self._regionName = ""
             self._textColour = "BLACK"

--- a/wx/lib/ogl/basic.py
+++ b/wx/lib/ogl/basic.py
@@ -2518,22 +2518,22 @@ class Shape(ShapeEvtHandler):
 
         if self.GetCentreResize():
             # Maintain the same centre point
-            new_width = 2.0 * abs(x - self.GetX())
-            new_height = 2.0 * abs(y - self.GetY())
+            new_width = 2 * abs(x - self.GetX())
+            new_height = 2 * abs(y - self.GetY())
 
             # Constrain sizing according to what control point you're dragging
             if pt._type == CONTROL_POINT_HORIZONTAL:
                 if self.GetMaintainAspectRatio():
-                    new_height = bound_y * (new_width / bound_x)
+                    new_height = bound_y * (new_width // bound_x)
                 else:
                     new_height = bound_y
             elif pt._type == CONTROL_POINT_VERTICAL:
                 if self.GetMaintainAspectRatio():
-                    new_width = bound_x * (new_height / bound_y)
+                    new_width = bound_x * (new_height // bound_y)
                 else:
                     new_width = bound_x
             elif pt._type == CONTROL_POINT_DIAGONAL and (keys & KEY_SHIFT):
-                new_height = bound_y * (new_width / bound_x)
+                new_height = bound_y * (new_width // bound_x)
 
             if self.GetFixedWidth():
                 new_width = bound_x
@@ -2558,23 +2558,23 @@ class Shape(ShapeEvtHandler):
                 newX1 = pt._controlPointDragStartX
                 newX2 = newX1 + pt._controlPointDragStartWidth
             elif pt._type == CONTROL_POINT_DIAGONAL and (keys & KEY_SHIFT or self.GetMaintainAspectRatio()):
-                newH = (newX2 - newX1) * (float(pt._controlPointDragStartHeight) / pt._controlPointDragStartWidth)
+                newH = (newX2 - newX1) * (float(pt._controlPointDragStartHeight) // pt._controlPointDragStartWidth)
                 if self.GetY() > pt._controlPointDragStartY:
                     newY2 = newY1 + newH
                 else:
                     newY1 = newY2 - newH
 
-            newWidth = float(newX2 - newX1)
-            newHeight = float(newY2 - newY1)
+            newWidth = round(newX2 - newX1)
+            newHeight = round(newY2 - newY1)
 
             if pt._type == CONTROL_POINT_VERTICAL and self.GetMaintainAspectRatio():
-                newWidth = bound_x * (newHeight / bound_y)
+                newWidth = bound_x * (newHeight // bound_y)
 
             if pt._type == CONTROL_POINT_HORIZONTAL and self.GetMaintainAspectRatio():
-                newHeight = bound_y * (newWidth / bound_x)
+                newHeight = bound_y * (newWidth // bound_x)
 
-            pt._controlPointDragPosX = newX1 + newWidth / 2.0
-            pt._controlPointDragPosY = newY1 + newHeight / 2.0
+            pt._controlPointDragPosX = newX1 + newWidth // 2
+            pt._controlPointDragPosY = newY1 + newHeight // 2
             if self.GetFixedWidth():
                 newWidth = bound_x
 
@@ -2600,19 +2600,19 @@ class Shape(ShapeEvtHandler):
         # Choose the 'opposite corner' of the object as the stationary
         # point in case this is non-centring resizing.
         if pt.GetX() < self.GetX():
-            pt._controlPointDragStartX = self.GetX() + bound_x / 2.0
+            pt._controlPointDragStartX = self.GetX() + bound_x // 2
         else:
-            pt._controlPointDragStartX = self.GetX() - bound_x / 2.0
+            pt._controlPointDragStartX = self.GetX() - bound_x // 2
 
         if pt.GetY() < self.GetY():
-            pt._controlPointDragStartY = self.GetY() + bound_y / 2.0
+            pt._controlPointDragStartY = self.GetY() + bound_y // 2
         else:
-            pt._controlPointDragStartY = self.GetY() - bound_y / 2.0
+            pt._controlPointDragStartY = self.GetY() - bound_y // 2
 
         if pt._type == CONTROL_POINT_HORIZONTAL:
-            pt._controlPointDragStartY = self.GetY() - bound_y / 2.0
+            pt._controlPointDragStartY = self.GetY() - bound_y // 2
         elif pt._type == CONTROL_POINT_VERTICAL:
-            pt._controlPointDragStartX = self.GetX() - bound_x / 2.0
+            pt._controlPointDragStartX = self.GetX() - bound_x // 2
 
         # We may require the old width and height
         pt._controlPointDragStartWidth = bound_x
@@ -2623,22 +2623,22 @@ class Shape(ShapeEvtHandler):
         dc.SetBrush(wx.TRANSPARENT_BRUSH)
 
         if self.GetCentreResize():
-            new_width = 2.0 * abs(x - self.GetX())
-            new_height = 2.0 * abs(y - self.GetY())
+            new_width = 2 * abs(x - self.GetX())
+            new_height = 2 * abs(y - self.GetY())
 
             # Constrain sizing according to what control point you're dragging
             if pt._type == CONTROL_POINT_HORIZONTAL:
                 if self.GetMaintainAspectRatio():
-                    new_height = bound_y * (new_width / bound_x)
+                    new_height = bound_y * (new_width // bound_x)
                 else:
                     new_height = bound_y
             elif pt._type == CONTROL_POINT_VERTICAL:
                 if self.GetMaintainAspectRatio():
-                    new_width = bound_x * (new_height / bound_y)
+                    new_width = bound_x * (new_height // bound_y)
                 else:
                     new_width = bound_x
             elif pt._type == CONTROL_POINT_DIAGONAL and (keys & KEY_SHIFT):
-                new_height = bound_y * (new_width / bound_x)
+                new_height = bound_y * (new_width // bound_x)
 
             if self.GetFixedWidth():
                 new_width = bound_x
@@ -2662,23 +2662,23 @@ class Shape(ShapeEvtHandler):
                 newX1 = pt._controlPointDragStartX
                 newX2 = newX1 + pt._controlPointDragStartWidth
             elif pt._type == CONTROL_POINT_DIAGONAL and (keys & KEY_SHIFT or self.GetMaintainAspectRatio()):
-                newH = (newX2 - newX1) * (float(pt._controlPointDragStartHeight) / pt._controlPointDragStartWidth)
+                newH = (newX2 - newX1) * (round(pt._controlPointDragStartHeight) // pt._controlPointDragStartWidth)
                 if pt.GetY() > pt._controlPointDragStartY:
                     newY2 = newY1 + newH
                 else:
                     newY1 = newY2 - newH
 
-            newWidth = float(newX2 - newX1)
-            newHeight = float(newY2 - newY1)
+            newWidth = round(newX2 - newX1)
+            newHeight = round(newY2 - newY1)
 
             if pt._type == CONTROL_POINT_VERTICAL and self.GetMaintainAspectRatio():
-                newWidth = bound_x * (newHeight / bound_y)
+                newWidth = bound_x * (newHeight // bound_y)
 
             if pt._type == CONTROL_POINT_HORIZONTAL and self.GetMaintainAspectRatio():
-                newHeight = bound_y * (newWidth / bound_x)
+                newHeight = bound_y * (newWidth // bound_x)
 
-            pt._controlPointDragPosX = newX1 + newWidth / 2.0
-            pt._controlPointDragPosY = newY1 + newHeight / 2.0
+            pt._controlPointDragPosX = newX1 + newWidth // 2
+            pt._controlPointDragPosY = newY1 + newHeight // 2
             if self.GetFixedWidth():
                 newWidth = bound_x
 

--- a/wx/lib/ogl/diagram.py
+++ b/wx/lib/ogl/diagram.py
@@ -31,7 +31,7 @@ class Diagram(object):
         self._diagramCanvas = None
         self._quickEditMode = False
         self._snapToGrid = True
-        self._gridSpacing = 5.0
+        self._gridSpacing = 5
         self._shapeList = []
         self._mouseTolerance = DEFAULT_MOUSE_TOLERANCE
 
@@ -162,7 +162,7 @@ class Diagram(object):
 
         """
         if self._snapToGrid:
-            return self._gridSpacing * int(x / self._gridSpacing + 0.5), self._gridSpacing * int(y / self._gridSpacing + 0.5)
+            return self._gridSpacing * round(x / self._gridSpacing + 0.5), self._gridSpacing * round(y / self._gridSpacing + 0.5)
         return x, y
 
     def SetGridSpacing(self, spacing):

--- a/wx/lib/ogl/drawn.py
+++ b/wx/lib/ogl/drawn.py
@@ -414,7 +414,7 @@ class PseudoMetaFile(object):
         self._currentRotation = theta
 
     def LoadFromMetaFile(self, filename, rwidth, rheight):
-        if not os.path.exist(filename):
+        if not os.path.exists(filename):
             return False
 
         print("LoadFromMetaFile not implemented yet.")

--- a/wx/lib/ogl/drawn.py
+++ b/wx/lib/ogl/drawn.py
@@ -755,10 +755,10 @@ class DrawnShape(RectangleShape):
 
         return RectangleShape.GetPerimeterPoint(self, x1, y1, x2, y2)
 
-    def LoadFromMetaFile(self, filename):
+    def LoadFromMetaFile(self, filename, rwidth, rheight):
         """Load a (very simple) Windows metafile, created for example by
         Top Draw, the Windows shareware graphics package."""
-        return self._metafiles[0].LoadFromMetaFile(filename)
+        return self._metafiles[0].LoadFromMetaFile(filename, rwidth, rheight)
 
     # Set of functions for drawing into a pseudo metafile.
     # They use integers, but doubles are used internally for accuracy

--- a/wx/lib/ogl/lines.py
+++ b/wx/lib/ogl/lines.py
@@ -433,10 +433,10 @@ class LineShape(Shape):
             last_point = self._lineControlPoints[-1]
             second_last_point = self._lineControlPoints[-2]
 
-            line_x = (last_point[0] + second_last_point[0]) / 2.0
-            line_y = (last_point[1] + second_last_point[1]) / 2.0
+            line_x = (last_point[0] + second_last_point[0]) // 2
+            line_y = (last_point[1] + second_last_point[1]) // 2
 
-        point = wx.RealPoint(line_x, line_y)
+        point = wx.Point(line_x, line_y)
         self._lineControlPoints.insert(len(self._lineControlPoints)-1, point)
 
     def DeleteLineControlPoint(self):
@@ -473,7 +473,7 @@ class LineShape(Shape):
                     else:
                         y2 = first_point[1]
                         y1 = last_point[1]
-                    self._lineControlPoints[i] = wx.RealPoint((x2 - x1) // 2 + x1, (y2 - y1) // 2 + y1)
+                    self._lineControlPoints[i] = wx.Point((x2 - x1) // 2 + x1, (y2 - y1) // 2 + y1)
             self._initialised = True
 
     def FormatText(self, dc, s, i):
@@ -600,7 +600,7 @@ class LineShape(Shape):
         """
         if position == 0:
             # Want to take the middle section for the label
-            half_way = int(len(self._lineControlPoints) / 2.0)
+            half_way = int(len(self._lineControlPoints) // 2)
 
             # Find middle of this line
             point = self._lineControlPoints[half_way - 1]
@@ -609,7 +609,7 @@ class LineShape(Shape):
             dx = next_point[0] - point[0]
             dy = next_point[1] - point[1]
 
-            return point[0] + dx / 2.0, point[1] + dy / 2.0
+            return point[0] + dx // 2, point[1] + dy // 2
         elif position == 1:
             return self._lineControlPoints[0][0], self._lineControlPoints[0][1]
         elif position == 2:
@@ -1420,7 +1420,7 @@ class LineShape(Shape):
         if pt._type == CONTROL_POINT_LINE:
             x, y = self._canvas.Snap(x, y)
 
-            rpt = wx.RealPoint(x, y)
+            rpt = wx.Point(x, y)
 
             # Move the control point back to where it was;
             # MoveControlPoint will move it to the new position
@@ -1461,7 +1461,7 @@ class LineShape(Shape):
 
         return True
 
-    def AddArrow(self, type, end = ARROW_POSITION_END, size = 10.0, xOffset = 0.0, name = "", mf = None, arrowId = -1):
+    def AddArrow(self, type, end = ARROW_POSITION_END, size = 10, xOffset = 0, name = "", mf = None, arrowId = -1):
         """
         Add an arrow (or annotation) to the line.
 

--- a/wx/lib/ogl/lines.py
+++ b/wx/lib/ogl/lines.py
@@ -409,7 +409,7 @@ class LineShape(Shape):
         self._lineControlPoints = []
 
         for _ in range(n):
-            point = wx.RealPoint(-999, -999)
+            point = wx.Point(-999, -999)
             self._lineControlPoints.append(point)
 
         # pi: added _initialised to keep track of when we have set
@@ -473,7 +473,7 @@ class LineShape(Shape):
                     else:
                         y2 = first_point[1]
                         y1 = last_point[1]
-                    self._lineControlPoints[i] = wx.RealPoint((x2 - x1) / 2.0 + x1, (y2 - y1) / 2.0 + y1)
+                    self._lineControlPoints[i] = wx.RealPoint((x2 - x1) // 2 + x1, (y2 - y1) // 2 + y1)
             self._initialised = True
 
     def FormatText(self, dc, s, i):
@@ -666,12 +666,12 @@ class LineShape(Shape):
 
 
         """
-        self._lineControlPoints[0] = wx.RealPoint(x1, y1)
-        self._lineControlPoints[-1] = wx.RealPoint(x2, y2)
+        self._lineControlPoints[0] = wx.Point(x1, y1)
+        self._lineControlPoints[-1] = wx.Point(x2, y2)
 
-        # Find centre point
-        self._xpos = (x1 + x2) / 2.0
-        self._ypos = (y1 + y2) / 2.0
+        # Find center point
+        self._xpos = (x1 + x2) // 2
+        self._ypos = (y1 + y2) // 2
 
     # Get absolute positions of ends
     def GetEnds(self):

--- a/wx/lib/ogl/lines.py
+++ b/wx/lib/ogl/lines.py
@@ -666,8 +666,8 @@ class LineShape(Shape):
 
 
         """
-        self._lineControlPoints[0] = wx.Point(x1, y1)
-        self._lineControlPoints[-1] = wx.Point(x2, y2)
+        self._lineControlPoints[0] = wx.Point(round(x1), round(y1))
+        self._lineControlPoints[-1] = wx.Point(round(x2), round(y2))
 
         # Find center point
         self._xpos = (x1 + x2) // 2
@@ -896,7 +896,7 @@ class LineShape(Shape):
             else:
                 dc.SetBrush(self._brush)
 
-            dc.DrawEllipse(x1, y1, diameter, diameter)
+            dc.DrawEllipse(round(x1), round(y1), diameter, diameter)
         elif at == ARROW_SINGLE_OBLIQUE:
             pass
         elif at == ARROW_METAFILE:

--- a/wx/lib/ogl/oglmisc.py
+++ b/wx/lib/ogl/oglmisc.py
@@ -337,8 +337,8 @@ def FindEndForBox(width, height, x1, y1, x2, y2):
     :returns: the end position
 
     """
-    xvec = [x1 - width / 2.0, x1 - width / 2.0, x1 + width / 2.0, x1 + width / 2.0, x1 - width / 2.0]
-    yvec = [y1 - height / 2.0, y1 + height / 2.0, y1 + height / 2.0, y1 - height / 2.0, y1 - height / 2.0]
+    xvec = [x1 - width // 2, x1 - width // 2, x1 + width // 2, x1 + width // 2, x1 - width // 2]
+    yvec = [y1 - height // 2, y1 + height // 2, y1 + height // 2, y1 - height // 2, y1 - height // 2]
 
     return FindEndForPolyline(xvec, yvec, x2, y2, x1, y1)
 
@@ -419,7 +419,9 @@ def FindEndForPolyline(xvec, yvec, x1, y1, x2, y2):
         if line_ratio < min_ratio:
             min_ratio = line_ratio
 
-    return x1 + (x2 - x1) * min_ratio, y1 + (y2 - y1) * min_ratio
+    x: int = round(x1 + (x2 - x1) * min_ratio)
+    y: int = round(y1 + (y2 - y1) * min_ratio)
+    return x, y
 
 
 def PolylineHitTest(xvec, yvec, x1, y1, x2, y2):


### PR DESCRIPTION
[
Many of the computations when resizing or moving OGL shapes result in float values.  The result is that the `wx.DC` primitive calls fail because they expect integer values.  This PR changes the computations results to become integer values,  thus  method calls on the wx device contexts do not fail

Most of the changes involve
* using the integer divide operator '`//`' instead of the float operator '`/`'
* In some instances I massage the results via the 'round' operator
* Additonally, I change the use of `wx.RealPoint` to just `wx.Point`
* Finally, I changed some of the `float` constants to integer constants
]


Fixes #2739

