### PR TITLE
Enable whole-word search in the Shell

### DIFF
--- a/wx/py/frame.py
+++ b/wx/py/frame.py
@@ -536,11 +536,10 @@ class Frame(wx.Frame):
             return
         win = wx.Window.FindFocus()
         if self.shellName == 'PyCrust':
-            self.findDlg = wx.FindReplaceDialog(win, self.findData,
-                                               "Find",wx.FR_NOWHOLEWORD)
+            self.findDlg = wx.FindReplaceDialog(win, self.findData, "Find")
         else:
-            self.findDlg = wx.FindReplaceDialog(win, self.findData,
-                "Find & Replace", wx.FR_NOWHOLEWORD|wx.FR_REPLACEDIALOG)
+            self.findDlg = wx.FindReplaceDialog(win, self.findData, "Find & Replace",
+                                                wx.FR_REPLACEDIALOG)
         self.findDlg.Show()
 
     def OnFindNext(self, event, backward=False):


### PR DESCRIPTION
Add whole-word search functionality to DoFindNext
* Use stc's SearchInTarget instead of str.find/rfind.

This enhancement affects all modules that use editwindow, such as PyCrust and PyShell.
![image](https://github.com/user-attachments/assets/70cab1dd-08d0-415b-a561-14101eed3f52)

