### PR TITLE
Mark wx.SystemSettings.GetAppearance() as requiring wx.App

### DIFF
--- a/etg/settings.py
+++ b/etg/settings.py
@@ -40,6 +40,7 @@ def run():
     c.find('GetMetric').mustHaveApp()
     c.find('HasFeature').mustHaveApp()
     c.find('GetScreenType').mustHaveApp()
+    c.find('GetAppearance').mustHaveApp()
 
 
     c = module.find('wxSystemAppearance')


### PR DESCRIPTION
This avoids crashing when calling this method without a wx.App instance.

Fixes: https://github.com/wxWidgets/Phoenix/issues/2771
