### PR TITLE
Improve type stubs

### DIFF
--- a/build.py
+++ b/build.py
@@ -1149,6 +1149,11 @@ def cmd_etg(options, args):
     # 2. Actually create the sip files
     # This is needed because each etg file is run in its own python invocation, so
     # the data is lost between them.
+
+    # First delete the old cache if found
+    cacheFile = opj(cfg.ROOT_DIR, 'sip', 'gen', '__auto_conversion_cache__.json')
+    if os.path.isfile(cacheFile):
+        os.remove(cacheFile)
     is_newer = {}
     for script in etgfiles:
         sipfile = etg2sip(script)
@@ -1170,6 +1175,9 @@ def cmd_etg(options, args):
     for script in etgfiles:
         if is_newer[script]:
             runcmd('"%s" %s %s' % (PYTHON, script, flags))
+    # Delete the cache
+    if os.path.isfile(cacheFile):
+        os.remove(cacheFile)
 
 
 def cmd_sphinx(options, args):

--- a/build.py
+++ b/build.py
@@ -1144,6 +1144,12 @@ def cmd_etg(options, args):
         etgfiles.remove(core_file)
         etgfiles.insert(0, core_file)
 
+    # We need two loops:
+    # 1. Cache all type auto conversion rules which get created in etgtools/tweaker_tools.FixWxPrefix
+    # 2. Actually create the sip files
+    # This is needed because each etg file is run in its own python invocation, so
+    # the data is lost between them.
+    is_newer = {}
     for script in etgfiles:
         sipfile = etg2sip(script)
         deps = [script]
@@ -1157,6 +1163,12 @@ def cmd_etg(options, args):
 
         # run the script only if any dependencies are newer
         if newer_group(deps, sipfile):
+            is_newer[script] = True
+            runcmd('"%s" %s %s' % (PYTHON, script, flags + " --only-cache-auto-conversions"))
+        else:
+            is_newer[script] = False
+    for script in etgfiles:
+        if is_newer[script]:
             runcmd('"%s" %s %s' % (PYTHON, script, flags))
 
 

--- a/etgtools/pi_generator.py
+++ b/etgtools/pi_generator.py
@@ -591,8 +591,8 @@ class PiWrapperGenerator(generators.WrapperGeneratorBase, FixWxPrefix):
                     value_types.append(setter.signature[0].type_hint)
                 if setter.hasOverloads():
                     for overload in setter.overloads:
-                        if overload.signature and len(overload.signature._parameters) == 1:
-                            value_types.append( overload.signature[0].type_hint)
+                        if not overload.ignored and overload.signature and len(overload.signature._parameters) == 1:
+                            value_types.append(overload.signature[0].type_hint)
                 if len(value_types) == 1:
                     value_type = value_types[0]
                 elif value_types:

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -401,7 +401,7 @@ class FixWxPrefix(object):
             'time_t': 'int',
             'size_t': 'int',
             'Int32': 'int',
-            'UInt32': 'int',
+            'Uint32': 'int',
             'long': long_type,
             'unsignedlong': long_type,
             'ulong': long_type,

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -250,7 +250,7 @@ def removeWxPrefix(name):
 _AUTO_CONVERSION_CACHE_FILE: Final = '__auto_conversion_cache__.json'
 
 
-def load_auto_conversions(destFile: str | None = None) -> dict[str, Tuple[str, ...]]:
+def load_auto_conversions(destFile: Optional[str] = None) -> dict[str, Tuple[str, ...]]:
     """Load FixWxPrefix auto conversions from cache file if it exists."""
     import json
     if not destFile:
@@ -275,7 +275,7 @@ class FixWxPrefix(object):
     _auto_conversions: dict[str, Tuple[str, ...]] = load_auto_conversions()
 
     @classmethod
-    def cache_auto_conversions(cls, destFile: str | None = None) -> None:
+    def cache_auto_conversions(cls, destFile: Optional[str] = None) -> None:
         """Save current auto conversions to a cache file."""
         import json
 

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -20,7 +20,7 @@ import re
 import sys, os
 import copy
 import textwrap
-from typing import NamedTuple, Optional, Tuple, Union
+from typing import Final, NamedTuple, Optional, Tuple, Union
 
 
 isWindows = sys.platform.startswith('win')
@@ -246,20 +246,24 @@ def removeWxPrefix(name):
     return name
 
 
-def load_auto_conversions(destFile=None):
+# Filename for type auto conversion cache file 
+_AUTO_CONVERSION_CACHE_FILE: Final = '__auto_conversion_cache__.json'
+
+
+def load_auto_conversions(destFile: str | None = None) -> dict[str, Tuple[str, ...]]:
     """Load FixWxPrefix auto conversions from cache file if it exists."""
     import json
     if not destFile:
         from buildtools.config import Config
 
         cfg = Config(noWxConfig=True)
-        phoenixRoot = cfg.ROOT_DIR
-        destFile = os.path.join(phoenixRoot, 'sip/gen', '__auto_conversion_cache__.json')
+        destFile = os.path.join(cfg.ROOT_DIR, 'sip', 'gen', _AUTO_CONVERSION_CACHE_FILE)
     # Need to merge existing data with current data
     if os.path.isfile(destFile):
         with open(destFile, 'r', encoding='utf-8') as f:
             return json.load(f)
     return {}
+
 
 class FixWxPrefix(object):
     """
@@ -271,16 +275,15 @@ class FixWxPrefix(object):
     _auto_conversions: dict[str, Tuple[str, ...]] = load_auto_conversions()
 
     @classmethod
-    def cache_auto_conversions(cls, destFile=None):
-        """Save current auto conversions to a cache."""
+    def cache_auto_conversions(cls, destFile: str | None = None) -> None:
+        """Save current auto conversions to a cache file."""
         import json
 
         if not destFile:
             from buildtools.config import Config
 
             cfg = Config(noWxConfig=True)
-            phoenixRoot = cfg.ROOT_DIR
-            destFile = os.path.join(phoenixRoot, 'sip/gen', '__auto_conversion_cache__.json')
+            destFile = os.path.join(cfg.ROOT_DIR, 'sip', 'gen', _AUTO_CONVERSION_CACHE_FILE)
         # We overwrite the cache file, as we should have loaded the existing values when
         # initializing the class.
         with textfile_open(destFile, 'wt') as f:

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -246,6 +246,20 @@ def removeWxPrefix(name):
     return name
 
 
+def load_auto_conversions(destFile=None):
+    """Load FixWxPrefix auto conversions from cache file if it exists."""
+    import json
+    if not destFile:
+        from buildtools.config import Config
+
+        cfg = Config(noWxConfig=True)
+        phoenixRoot = cfg.ROOT_DIR
+        destFile = os.path.join(phoenixRoot, 'sip/gen', '__auto_conversion_cache__.json')
+    # Need to merge existing data with current data
+    if os.path.isfile(destFile):
+        with open(destFile, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {}
 
 class FixWxPrefix(object):
     """
@@ -254,7 +268,23 @@ class FixWxPrefix(object):
     """
 
     _coreTopLevelNames = None
-    _auto_conversions: dict[str, Tuple[str, ...]] = {}
+    _auto_conversions: dict[str, Tuple[str, ...]] = load_auto_conversions()
+
+    @classmethod
+    def cache_auto_conversions(cls, destFile=None):
+        """Save current auto conversions to a cache."""
+        import json
+
+        if not destFile:
+            from buildtools.config import Config
+
+            cfg = Config(noWxConfig=True)
+            phoenixRoot = cfg.ROOT_DIR
+            destFile = os.path.join(phoenixRoot, 'sip/gen', '__auto_conversion_cache__.json')
+        # We overwrite the cache file, as we should have loaded the existing values when
+        # initializing the class.
+        with textfile_open(destFile, 'wt') as f:
+            json.dump(FixWxPrefix._auto_conversions, f)
 
     @classmethod
     def register_autoconversion(cls, class_name: str, convertables: Tuple[str, ...]) -> None:
@@ -371,6 +401,7 @@ class FixWxPrefix(object):
             'time_t': 'int',
             'size_t': 'int',
             'Int32': 'int',
+            'UInt32': 'int',
             'long': long_type,
             'unsignedlong': long_type,
             'ulong': long_type,
@@ -950,6 +981,9 @@ def runGenerators(module):
     checkForUnitTestModule(module)
 
     generators = list()
+    if '--only-cache-auto-conversions' in sys.argv:
+        FixWxPrefix.cache_auto_conversions()
+        return
 
     # Create the code generator selected from command line args
     generators.append(getWrapperGenerator())


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

- Implements the 2 stage etg execution described in https://github.com/wxWidgets/Phoenix/pull/2668#issuecomment-2722983250
<details>

<summary>The cache file contents look like this for one of my runs (don't know if they depend on platform/python version/...)</summary>

```json
{"DateTime": ["datetime", "date"], "Point": ["_TwoInts"], "Size": ["_TwoInts"], "Rect": ["_FourInts"], "RealPoint": ["_TwoFloats"], "Point2D": ["_TwoFloats"], "Rect2D": ["_FourFloats"], "Position": ["_TwoInts"], "Colour": ["wx.Colour", "_ThreeInts", "_FourInts", "str", "None"], "InputStream": [], "OutputStream": [], "BitmapBundle": ["wx.Bitmap", "wx.Icon"], "GBPosition": ["_TwoInts"], "GBSpan": ["_TwoInts"], "GridCellCoords": ["_TwoInts"], "PGPropArgCls": ["str", "None"], "RichTextRange": ["_TwoInts"]}
```
</details>

- Adds missing conversion of `Uint32` to python `int`
- Improves types for properties in multiple ways:
  - Considers only setter functions which take exactly one argument (fixes wrong hints)
  - Tracks different types for getter return type and setter value type (supported in e.g. [mypy Version 1.16](https://github.com/python/mypy/blob/master/CHANGELOG.md#different-property-getter-and-setter-types))

Example changes for illustration:
```python
class FooBar:
  def GetFoo(self) -> Size:
  @overload
  def SetFoo(self, width: int, height: int) -> None: ...
  @overload
  def SetFoo(self, rect: Rect) -> None: ...
  @overload
  def SetFoo(self, size: Union[Size, Tuple[int, int]]) -> None: ...

  @property
  def Foo(self) -> Size: ... # Old: -> int (First argument was chosen even if setter function takes more than one)
  @Foo.setter
  def Foo(self, value: Union[Rect, Union[Size, Tuple[int, int]]]) -> None: ... # Old: value: int
  # Note: Unions are not flattened, which should be okay (tested mypy)

  def GetBar(self) -> Size: ...
  def SetBar(self, size: Union[Size, Tuple[int, int]]) -> None: ...
  @property
  def Bar(self) -> Size: ... # Old: -> Union[Size, Tuple[int, int]] (Less helpfull and always Size at runtime)
  @Bar.setter
  def Bar(self, value: Union[Size, Tuple[int, int]]) -> None: ...

```

Open Questions/Todos:
- [ ] The cache file is created in `sip/gen` as json file. Is there a better location?
- [x] ~~The cache file is currently never cleaned. It should probably be deleted by build.py after the etg stage finished.~~
   - [ ] Deleting the cache file as implemented now breaks the caching of the etg scripts output (would always need to run all etg files to rebuild the cache instead of only effected ones)
- [ ] The implementation of the first (the caching) stage via a magic argument in `sys.argv` when executing the etg module scripts feels kind of hacky. Is this okay, or are there better solutions?


Fixes #2775
Fixes #2733 

