### PR TITLE
Add non-zero width and height to default tab size to avoid wxWidgets warning

### DIFF
--- a/wx/lib/agw/aui/auibook.py
+++ b/wx/lib/agw/aui/auibook.py
@@ -926,7 +926,7 @@ class AuiTabContainer(object):
         self._tab_close_buttons = []
         self._click_tab = None
 
-        self._rect = wx.Rect()
+        self._rect = wx.Rect(0, 0, 1, 1)
         self._auiNotebook = auiNotebook
 
         self.AddButton(AUI_BUTTON_LEFT, wx.LEFT, name="Scroll Left")


### PR DESCRIPTION
This PR fixes a warning about zero sizes reported at https://github.com/wxWidgets/Phoenix/pull/2501#issuecomment-3248054002

