### PR TITLE
CI: skip building Windows 32-bit on Pull Requests

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -134,6 +134,8 @@ jobs:
           - python-version: ${{ github.event_name == 'pull_request' && '3.10' }}
           - python-version: ${{ github.event_name == 'pull_request' && '3.11' }}
           - python-version: ${{ github.event_name == 'pull_request' && '3.12' }}
+          # Skip Windows x86 builds on PRs
+          - architecture: ${{ github.event_name == 'pull_request' && 'x86' }}
           # Only build windows-11-arm on pushes
           - os: ${{ github.event_name != 'push' && 'windows-11-arm' }}
           # Python interpreter < 3.11 doesn't exist for Windows 11 ARM


### PR DESCRIPTION
We'll still keep building wheels for now, but save some resources on pull requests for this lesser-used architecture.

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #NNNN

