### PR TITLE
Add typing-extensions to build system requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ requires = [
     "cython >= 3.0.10",
     "requests >= 2.26.0",
     "sip == 6.12.0",
-    "typing-extensions",
+    "typing-extensions; python_version < '3.11'",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
This should fix CI jobs using Python 3.10 where this module is needed.