### PR TITLE
Added a check to not remove control panes that don't have a window yet

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -5369,8 +5369,11 @@ class AuiManager(wx.EvtHandler):
                         minimizeToolbar.DeleteTool(item)
             else:
                 # The perspective is referencing a non-existing pane that was added nonetheless. This will
-                # happen with a notebook that ends up containing no pages
-                inexistentPaneIndexes.append(paneIndex)
+                # happen with a notebook that ends up containing no pages.
+                # Notebook control panes (for example "__notebook_0") are expected to not have windows 
+                # at this point because they will be created later by Update(), so we don't delete them.
+                if not p.IsNotebookControl():
+                    inexistentPaneIndexes.append(paneIndex)
                 
         for paneIndex in reversed(inexistentPaneIndexes): # reverse is required when deleting elements by index
             del self._panes[index]


### PR DESCRIPTION

This issue broke retrocompatibility with old saved perspectives, this PR fixes it

Fixes #2865

