### PR TITLE
Remove no-op code from aui LoadPerspectives for deleting panes referring to inexistent windows

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -5353,9 +5353,8 @@ class AuiManager(wx.EvtHandler):
             if isinstance(pane.window, auibar.AuiToolBar) and (pane.IsFloatable() or pane.IsDockable()):
                 pane.window.SetGripperVisible(True)
 
-        inexistentPaneIndexes = []
         for paneIndex, p in enumerate(self._panes):
-            if p.window:
+            if not p.IsNotebookControl():
                 if p.IsMinimized():
                     self.MinimizePane(p, False)
                 elif p.minimize_mode & AUI_MINIMIZE_POS_MASK == AUI_MINIMIZE_POS_TOOLBAR:
@@ -5367,15 +5366,7 @@ class AuiManager(wx.EvtHandler):
                     item = minimizeToolbar.FindToolByUserData((ID_RESTORE_FRAME, p.window))
                     if item: # Delete the icon if it was there
                         minimizeToolbar.DeleteTool(item)
-            else:
-                # The perspective is referencing a non-existing pane that was added nonetheless. This will
-                # happen with a notebook that ends up containing no pages
-                inexistentPaneIndexes.append(paneIndex)
-                
-        for paneIndex in reversed(inexistentPaneIndexes): # reverse is required when deleting elements by index
-            del self._panes[index]
-                
-            
+              
         if update:
             self.Update()
 


### PR DESCRIPTION
This PR removes no-op code from aui for deleting panes created referring to inexistent windows that were created in the process of loading a perspective. 

Rationale: All panes referring to inexistent windows created when loading a perspective that is otherwise valid are already removed during update. 

Fixes #2865

Supersedes #2880

---------------
#### Analysis of why this code is not neccesary for removing panes referring to inexistent windows:

When loading a perspective, panes referenced in the perspective layout that don't refer to a valid window and are not notebooks are ignored. See [LoadPerspective](https://github.com/wxWidgets/Phoenix/blob/master/wx/lib/agw/aui/framemanager.py#L5336-L5344)

WRT to notebooks in a perspective containing pages that don't exist -- removal of which was the goal of the code removed in this PR: Remark that notebooks that end up containing no pages are removed later, during the next update, see [DoUpdate](https://github.com/wxWidgets/Phoenix/blob/master/wx/lib/agw/aui/framemanager.py#L6514-L6517), so removing them in `LoadPerspective` is unnecessary.

I have validated this behavior experimentally by manually modifying the perspective given in https://github.com/wxWidgets/Phoenix/issues/2865#issuecomment-4258275336 by adding new panes to it both notebook and non-notebook and confirm that no panes referring to inexistent windows or empty notebooks are retained by the aui framemanager after update.

--------------

#### Rationale of why this fixes #2865 (and thus makes #2880 unnecessary

Remark that the removed code was incorrectly deleting all aui notebooks, not just those with empty pages, because that code was flagging panes not pointing to any window as not containing pages, but _all_ notebooks, not only those with no pages, don't refer to any window. See: [NotebookCtrl](https://github.com/wxWidgets/Phoenix/blob/master/wx/lib/agw/aui/framemanager.py#L1306).

Thus removing this code Fixes #2865, which makes #2880 intended to fix it, unnecessary.

--------------

#### Note on loading _invalid_ perspectives

In the experiments described above I have observed that loading a perspective that contains multiple panes referring to the same notebook id may produce strange results. But a perspective containing multiple panes referring to the same notebook id  is an invalid perspective and thus not relevant to this PR or #2880 


