### PR TITLE
Fix SuperToolTip window too small when footerBmp is used

### DIFF
--- a/wx/lib/agw/supertooltip.py
+++ b/wx/lib/agw/supertooltip.py
@@ -423,7 +423,7 @@ class ToolTipWindowBase(object):
             dc.DrawText(footer, bmpXPos + bmpWidth + self._spacing, yPos + toAdd)
             maxWidth = max(bmpXPos + bmpWidth + (self._spacing*2) + textWidth, maxWidth)
         if footerBmp and footerBmp.IsOk():
-            toAdd = (height - bmpHeight + self._spacing) / 2
+            toAdd = (height - bmpHeight + self._spacing) // 2
             dc.DrawBitmap(footerBmp, bmpXPos, int(yPos + toAdd), True)
             maxWidth = max(footerBmp.GetSize().GetWidth() + bmpXPos, maxWidth)
 
@@ -678,7 +678,7 @@ class ToolTipWindowBase(object):
         """ Calculates the :class:`SuperToolTip` window best size. """
 
         maxWidth, maxHeight = self.OnPaint(None)
-        self.SetSize((maxWidth, maxHeight))
+        self.SetSize((int(maxWidth), int(maxHeight)))
 
 
     def CalculateBestPosition(self,widget):


### PR DESCRIPTION
When only a footer bitmap is set (no footer text), the toAdd variable is computed with true division (/), producing a float. In newer wx SetSize() silently ignores a float height, leaving the tooltip at its default 20px height and hiding all content.

Fix: use integer division (//) for the footer bitmap toAdd path, consistent with the footer text path. Also add int() casts in CalculateBestSize() as a defensive guard.

Fixes #2884 

