### PR TITLE
Set rpath in link arguments rather than LD_RUN_PATH

### DIFF
--- a/build.py
+++ b/build.py
@@ -1770,15 +1770,10 @@ def cmd_build_py(options, args):
             build_options.append('--gtk3')
             wafBuildDir = posixjoin(wafBuildBase, 'gtk3')
 
+    if options.no_magic:
+        build_options.append('--no_magic')
     build_options.append('--python="%s"' % PYTHON)
     build_options.append('--out=%s' % wafBuildDir) # this needs to be the last option
-
-    if not isWindows and not isDarwin and not options.no_magic and not options.use_syswx:
-        # Using $ORIGIN in the rpath will cause the dynamic linker to look
-        # for shared libraries in a folder relative to the loading binary's
-        # location. Here we'll use just $ORIGIN so it should look in the same
-        # folder as the wxPython extension modules.
-        os.environ['LD_RUN_PATH'] = '$ORIGIN'
 
     # Regenerate the _sysconfigdata module?
     if options.regenerate_sysconfig:

--- a/wscript
+++ b/wscript
@@ -193,7 +193,7 @@ def configure(conf):
         conf.env.CXXFLAGS_WXPY = list()
 
         # Check wx-config exists and fetch some values from it
-        rpath = ' --no-rpath' if not conf.options.no_magic else ''
+        rpath = ' --no-rpath'
         conf.check_cfg(path=conf.options.wx_config, package='',
                        args='--cxxflags --libs core,net' + rpath,
                        uselib_store='WX', mandatory=True,
@@ -325,6 +325,13 @@ def configure(conf):
         conf.env.LIBPATH_PYEXT = []
         conf.env.LIB_PYEXT = []
 
+        # Use an explicit -Wl,-rpath,$ORIGIN linker flag rather than relying on
+        # LD_RUN_PATH. GNU ld silently ignores LD_RUN_PATH whenever any explicit
+        # -rpath flag appears on the command line (e.g. one injected by pyenv
+        # Python via sysconfig LDFLAGS). Explicit -rpath entries accumulate, so
+        # both the pyenv path and $ORIGIN will be present in the final binary.
+        if not isDarwin and not conf.options.no_magic:
+            conf.env.append_value('LINKFLAGS_WXPY', ['-Wl,-rpath,$ORIGIN'])
 
         # Use the same compilers that wxWidgets used
         if cfg.CC:


### PR DESCRIPTION
This should fix wxPython wheel installs when using pyenv as pyenv sets an rpath link argument, which was overriding LD_RUN_PATH.  Instead, set rpath to $ORIGIN in a link argument, which should be additive with the pyenv one(s).
