### PR TITLE
Permit building against system wxWidgets built without WebView support

### DIFF
--- a/etg/webview.py
+++ b/etg/webview.py
@@ -44,10 +44,12 @@ def run():
     # customizing the generated code and docstrings.
 
     module.addHeaderCode("""\
+        #if wxUSE_WEBVIEW
         #include <wx/webview.h>
         #if wxUSE_WEBVIEW_IE && defined(__WXMSW__)
             #include <wx/msw/webview_ie.h>
             #include <wx/msw/webview_edge.h>
+        #endif
         #endif
         """)
     module.addHeaderCode('#include <wx/filesys.h>')
@@ -213,7 +215,7 @@ def run():
     # these methods with a new implementation that does the RightThing using
     # sys.executable.
     c.addCppCode(r"""
-        #if wxUSE_WEBVIEW_IE && defined(__WXMSW__)
+        #if wxUSE_WEBVIEW && wxUSE_WEBVIEW_IE && defined(__WXMSW__)
         #include <wx/msw/webview_ie.h>
         #include <wx/msw/registry.h>
 

--- a/etgtools/sip_generator.py
+++ b/etgtools/sip_generator.py
@@ -443,6 +443,9 @@ from .%s import *
         if klass.ignored:
             return
 
+        # For any header filename starting with these prefixes, protect the #include with an #if wxUSE_ guard
+        optional_wx_modules = [ "webview" ]
+
         # Propagate preMethodCode setting to the ctors
         if klass.preMethodCode:
             for item in klass.allItems():
@@ -466,7 +469,15 @@ from .%s import *
         if klass.includes:
             stream.write('%s%%TypeHeaderCode\n' % indent2)
             for inc in klass.includes:
+                header_basename = inc.split('/')[-1].split('.')[0]
+                need_endif = False
+                for module_name in optional_wx_modules:
+                    if header_basename.startswith(module_name):
+                        stream.write('%s  #if wxUSE_%s\n' % (indent2, module_name.upper()))
+                        need_endif = True
                 stream.write('%s    #include <%s>\n' % (indent2, inc))
+                if need_endif:
+                    stream.write('%s  #endif\n' % indent2)
             stream.write('%s%%End\n\n' % indent2)
 
         # C++ code to be written to the Type's header


### PR DESCRIPTION
Addresses #2825.  `etg/webview.py` and the `sip/gen/webview.sip` that it generates both go to a lot of trouble to provide dummy stubs for the WebView API, but the generated headers still assume that `<wx/webview*.h>` are present, which won't be the case if wxWidgets was indeed built without WebView support.

Since WebView depends on WebKit, which has large number of known and suspected security issues and no longer receives maintenance updates, requiring WebKit support in wxWidgets in order to build wxPython unnecessarily increases the attack surface of the host system.

The `optional_wx_modules = [...]` definition in `etgtools/sip_generator.py` can be expanded to allow wxPython to be built on systems without other nonessential wxWidgets modules, if desired.
