### PR TITLE
Avoid fetching all git history when checking out source

### DIFF
--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           submodules: 'recursive'
           fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -84,6 +86,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: 'recursive'
+          filter: blob:none
+          persist-credentials: false
 
       - name: download CI source artifact
         uses: actions/download-artifact@v8

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -52,6 +52,8 @@ jobs:
         with:
           submodules: 'recursive'
           fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -179,6 +181,8 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: 'recursive'
+          filter: blob:none
+          persist-credentials: false
 
       - name: download CI source artifact
         uses: actions/download-artifact@v8
@@ -248,6 +252,8 @@ jobs:
         with:
           submodules: 'recursive'
           fetch-depth: 0
+          filter: blob:none
+          persist-credentials: false
 
       - name: Set up Python 3.13
         uses: actions/setup-python@v6


### PR DESCRIPTION
Not sure why this was done initially but it shouldn't be necessary and should speed up builds.