### PR TITLE
CI: Add Ubuntu 26.04 to matrix

### DIFF
--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-22.04, ubuntu-24.04 ]
+        os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-26.04 ]
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         architecture: [ 'x64' ]
 

--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -63,6 +63,10 @@ jobs:
         exclude:
           - os: ubuntu-26.04
             python-version: 3.10
+          - os: ubuntu-26.04
+            python-version: 3.11
+          - os: ubuntu-26.04
+            python-version: 3.12
 
     env:
       VERSION: ${{ needs.build-source-dist.outputs.VERSION }}

--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -60,6 +60,9 @@ jobs:
         os: [ ubuntu-22.04, ubuntu-24.04, ubuntu-26.04 ]
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         architecture: [ 'x64' ]
+        exclude:
+          - os: ubuntu-26.04
+            python-version: 3.10
 
     env:
       VERSION: ${{ needs.build-source-dist.outputs.VERSION }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -142,6 +142,12 @@ jobs:
           # Python interpreter < 3.11 doesn't exist for Windows 11 ARM
           - os: windows-11-arm
             python-version: '3.10'
+          - os: ubuntu-26.04
+            python-version: '3.10'
+        include:
+          - os: ubuntu-26.04
+            python-version: ${{ github.event_name == 'pull_request' && '3.11' }}
+            architecture: 'x64'
 
     env:
       VERSION: ${{ needs.build-source-dist.outputs.VERSION }}

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -104,7 +104,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-24.04, windows-2025, macos-15-intel, macos-15, windows-11-arm ]
+        os: [ ubuntu-24.04, ubuntu-26.04, windows-2025, macos-15-intel, macos-15, windows-11-arm ]
         python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         architecture: [ 'x86', 'x64', 'arm64' ]
         # Exclude x86 configs on non-Windows OSs
@@ -112,6 +112,10 @@ jobs:
           - os: ubuntu-24.04
             architecture: x86
           - os: ubuntu-24.04
+            architecture: arm64
+          - os: ubuntu-26.04
+            architecture: x86
+          - os: ubuntu-26.04
             architecture: arm64
           - os: macos-15-intel
             architecture: x86

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -146,7 +146,7 @@ jobs:
             python-version: '3.10'
         include:
           - os: ubuntu-26.04
-            python-version: ${{ github.event_name == 'pull_request' && '3.11' }}
+            python-version: ${{ github.event_name == 'pull_request' && '3.13' }}
             architecture: 'x64'
 
     env:


### PR DESCRIPTION
<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

I wanted to set up a new dev environment, and found out that there were no prebuilt wheels for Ubuntu 26.04. This is an attempt to see what else breaks when naively adding ubuntu 26.04 runner images to the os matrix. These runner images are in preview, so they are available.
