### PR TITLE
Fix unbalanced Freeze/Thaw in ButtonPanel

### DIFF
--- a/wx/lib/agw/buttonpanel.py
+++ b/wx/lib/agw/buttonpanel.py
@@ -1865,6 +1865,7 @@ class ButtonPanel(wx.Panel):
                 self._mainsizer.Insert(lenChildren-1, self._text, 0, wx.ALIGN_CENTER,
                                        userData=self._text, realIndex=lenChildren)
 
+            self.Thaw()
             return
 
         # We have text, so insert the text and an expandable spacer
@@ -1878,6 +1879,8 @@ class ButtonPanel(wx.Panel):
             self._mainsizer.Insert(lenChildren-1, self._text, 0, wx.ALIGN_CENTER,
                                    userData=self._text, realIndex=lenChildren)
             self._mainsizer.Insert(lenChildren-1, (0, 0), 1, wx.EXPAND)
+
+        self.Thaw()
 
 
     def RemoveText(self):
@@ -2024,6 +2027,8 @@ class ButtonPanel(wx.Panel):
         self._mainsizer.Clear()
         self.ReCreateSizer(bartext)
 
+        self.Thaw()
+
 
     def GetAlignment(self):
         """
@@ -2072,6 +2077,8 @@ class ButtonPanel(wx.Panel):
         # Recreate the sizer accordingly to the new alignment
         self.ReCreateSizer(text)
 
+        self.Thaw()
+
 
     def IsVertical(self):
         """
@@ -2115,9 +2122,6 @@ class ButtonPanel(wx.Panel):
         size = self.GetSize()
         self.SetSize((size.x+1, size.y+1))
         self.SetSize((size.x, size.y))
-
-        if self.IsFrozen():
-            self.Thaw()
 
 
     def ReCreateSizer(self, text=None):
@@ -2171,8 +2175,6 @@ class ButtonPanel(wx.Panel):
             self.SetBarText(text)
 
         self.DoLayout()
-
-        self.Thaw()
 
 
     def DoGetBestSize(self):

--- a/wx/lib/agw/buttonpanel.py
+++ b/wx/lib/agw/buttonpanel.py
@@ -263,11 +263,6 @@ BP_USE_GRADIENT = 2
 _DELAY = 3000
 
 
-# Check for the new method in 2.7 (not present in 2.6.3.3)
-if wx.VERSION_STRING < "2.7":
-    wx.Rect.Contains = lambda self, point: wx.Rect.Inside(self, point)
-
-
 def BrightenColour(colour, factor):
     """
     Brighten the input colour by a factor.
@@ -2724,39 +2719,6 @@ class ButtonPanel(wx.Panel):
 
         self._art = art
         self.Refresh()
-
-
-    if wx.VERSION < (2,7,1,1):
-        def Freeze(self):
-            """
-            Freezes the window or, in other words, prevents any updates from taking place
-            on screen, the window is not redrawn at all. :meth:`~ButtonPanel.Thaw` must be called to re-enable
-            window redrawing. Calls to these two functions may be nested.
-
-            :note: This method is useful for visual appearance optimization.
-            """
-
-            self._freezeCount = self._freezeCount + 1
-            wx.Panel.Freeze(self)
-
-
-        def Thaw(self):
-            """
-            Reenables window updating after a previous call to :meth:`~ButtonPanel.Freeze`. To really thaw the
-            control, it must be called exactly the same number of times as :meth:`~ButtonPanel.Freeze`.
-            """
-
-            if self._freezeCount == 0:
-                raise Exception("\nERROR: Thawing Unfrozen ButtonPanel?")
-
-            self._freezeCount = self._freezeCount - 1
-            wx.Panel.Thaw(self)
-
-
-        def IsFrozen(self):
-            """ Returns ``True`` if the window is currently frozen by a call to :meth:`~ButtonPanel.Freeze`. """
-
-            return self._freezeCount != 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

`ButtonPanel.DoLayout()` called `self.Thaw()` whenever `self.IsFrozen()`
was true, and `ReCreateSizer()` called `self.Thaw()` unconditionally -
even though neither method calls `Freeze()` itself. This is unsound
because `wx.Window.Freeze()`/`Thaw()` propagate recursively to child
windows, so a `ButtonPanel` can appear frozen (or get thawed) simply
because an ancestor froze itself for unrelated reasons. In that case
these calls steal one of the ancestor's thaws, and the ancestor's own
later `Thaw()` finds the count already off by one - an assert in debug
wx builds.

`SetBarText()` had the mirror problem: it calls `self.Freeze()` but never
called a matching `self.Thaw()` itself, relying on `DoLayout()`'s stray
thaw (called right after, by every caller) to bail it out.

## Fix

`Freeze()`/`Thaw()` are now owned entirely by the methods that actually
freeze: `Clear()`, `SetAlignment()`, and `SetBarText()` each call their
own matching `Thaw()` on every exit path. `DoLayout()`/`ReCreateSizer()`,
which never freeze, no longer touch freeze state at all. I traced every
execution path through the affected methods to confirm each `Freeze()`
is matched by exactly one `Thaw()`.

## Repro

Fails on the code before this fix (`wxAssertionError: Thaw() without
matching Freeze()`) ,and completes cleanly after it:


```python
import wx
import wx.lib.agw.buttonpanel as BP
app = wx.App()
frame = wx.Frame(None)
panel = wx.Panel(frame)
titleBar = BP.ButtonPanel(panel, -1, "Repro")
btn = BP.ButtonInfo(titleBar, wx.ID_ANY, wx.ArtProvider.GetBitmap(wx.ART_INFORMATION))
titleBar.AddButton(btn)
titleBar.DoLayout()
sizer = wx.BoxSizer(wx.VERTICAL)
sizer.Add(titleBar, 0, wx.EXPAND)
panel.SetSizer(sizer)
panel.Freeze()
titleBar.DoLayout() # ordinary standalone call, e.g. after changing a metric
panel.Thaw() # raises before the fix; clean after it
print("OK")
```

## Separate question

While looking at this code I noticed `wx/lib/agw/buttonpanel.py` still has a `if wx.VERSION < (2,7,1,1):` guarded block (around line 2726) that defines a legacy, manually-counted `Freeze`/`Thaw`/`IsFrozen` override for `ButtonPanel`, for wxWidgets versions older than 2.7.1.1. Is that version range still supported? If not, this dead code and the similar `wx.VERSION_STRING < "2.7"` guard near the top of the file could be removed as a follow-up cleanup. Happy to submit that separately if desired.