### PR TITLE
Add missing transfer attributes for SetArtProvider

### DIFF
--- a/etg/auibar.py
+++ b/etg/auibar.py
@@ -38,6 +38,7 @@ def run():
     c = module.find('wxAuiToolBar')
     assert isinstance(c, etgtools.ClassDef)
     tools.fixWindowClass(c)
+    c.find('SetArtProvider.art').transfer = True
 
 
     c = module.find('wxAuiToolBarEvent')

--- a/etg/auibook.py
+++ b/etg/auibook.py
@@ -57,6 +57,7 @@ def run():
     c = module.find('wxAuiTabContainer')
     tools.ignoreConstOverloads(c)
     c.find('GetPages').ignore()
+    c.find('SetArtProvider.art').transfer = True
 
     notebook_page_equality_code = """
 #include <wx/aui/auibook.h>

--- a/etg/auiframemanager.py
+++ b/etg/auiframemanager.py
@@ -43,6 +43,7 @@ def run():
     c.find('CalculateHintRect').find('offset').default="wxPoint(0,0)"
     c.find('DrawHintRect').find('offset').default="wxPoint(0,0)"
     c.find('GetAllPanes').findOverload('', isConst=True).ignore()
+    c.find('SetArtProvider.art_provider').transfer = True
 
     c = module.find('wxAuiPaneInfo')
     module.addItem(


### PR DESCRIPTION
This avoids triggering segmentation faults when setting custom art providers