### PR TITLE
wx.lib.inspection dark mode issues [Issue #2917]

### DIFF
--- a/wx/lib/inspection.py
+++ b/wx/lib/inspection.py
@@ -595,7 +595,7 @@ class InspectionInfoPanel(wx.stc.StyledTextCtrl):
     def __init__(self, *args, **kw):
         wx.stc.StyledTextCtrl.__init__(self, *args, **kw)
 
-        from wx.py.editwindow import FACES
+        FACES = wx.py.editwindow.get_faces()
         self.StyleSetSpec(wx.stc.STC_STYLE_DEFAULT,
                           "face:%(mono)s,size:%(size)d,back:%(backcol)s" % FACES)
         self.StyleClearAll()

--- a/wx/py/editwindow.py
+++ b/wx/py/editwindow.py
@@ -14,10 +14,6 @@ from . import dispatcher
 from .version import VERSION
 
 
-import wx
-
-FACES = None
-
 def get_faces():
     if 'wxMSW' in wx.PlatformInfo:
         # Safely evaluate IsDark() inside a try-except fallback block

--- a/wx/py/editwindow.py
+++ b/wx/py/editwindow.py
@@ -15,13 +15,14 @@ from .version import VERSION
 
 
 def get_faces():
+    
+    try:
+        is_dark = wx.SystemSettings.GetAppearance().IsDark()
+    except wx.PyNoAppError:
+        is_dark = False
+        
     if 'wxMSW' in wx.PlatformInfo:
         # Safely evaluate IsDark() inside a try-except fallback block
-        try:
-            is_dark = wx.SystemSettings.GetAppearance().IsDark()
-        except wx.PyNoAppError:
-            is_dark = False
-
         return { 
             'times'     : 'Times New Roman',
             'mono'      : 'Courier New',

--- a/wx/py/editwindow.py
+++ b/wx/py/editwindow.py
@@ -14,7 +14,11 @@ from . import dispatcher
 from .version import VERSION
 
 
+import wx
+
 if 'wxMSW' in wx.PlatformInfo:
+    is_dark = wx.SystemSettings.GetAppearance().IsDark()
+
     FACES = { 'times'     : 'Times New Roman',
               'mono'      : 'Courier New',
               'helv'      : 'Arial',
@@ -22,9 +26,10 @@ if 'wxMSW' in wx.PlatformInfo:
               'other'     : 'Comic Sans MS',
               'size'      : 10,
               'lnsize'    : 8,
-              'backcol'   : '#FFFFFF',
-              'calltipbg' : '#FFFFB8',
-              'calltipfg' : '#404040',
+              # Conditional formatting for theme states
+              'backcol'   : '#202020' if is_dark else '#FFFFFF',
+              'calltipbg' : '#2D2D2D' if is_dark else '#FFFFB8',
+              'calltipfg' : '#E0E0E0' if is_dark else '#404040',
             }
 
 elif 'wxGTK' in wx.PlatformInfo and ('gtk2' in wx.PlatformInfo or

--- a/wx/py/editwindow.py
+++ b/wx/py/editwindow.py
@@ -18,7 +18,7 @@ def get_faces():
     
     try:
         is_dark = wx.SystemSettings.GetAppearance().IsDark()
-    except wx.PyNoAppError:
+    except:
         is_dark = False
         
     if 'wxMSW' in wx.PlatformInfo:

--- a/wx/py/editwindow.py
+++ b/wx/py/editwindow.py
@@ -34,7 +34,6 @@ def get_faces():
             'other'     : 'Comic Sans MS',
             'size'      : 10,
             'lnsize'    : 8,
-            # Conditional formatting safely evaluated at runtime
             'backcol'   : '#202020' if is_dark else '#FFFFFF',
             'calltipbg' : '#2D2D2D' if is_dark else '#FFFFB8',
             'calltipfg' : '#E0E0E0' if is_dark else '#404040',
@@ -48,9 +47,9 @@ def get_faces():
             'other'     : 'new century schoolbook',
             'size'      : 10,
             'lnsize'    : 9,
-            'backcol'   : '#FFFFFF',
-            'calltipbg' : '#FFFFB8',
-            'calltipfg' : '#404040',
+            'backcol'   : '#202020' if is_dark else '#FFFFFF',
+            'calltipbg' : '#2D2D2D' if is_dark else '#FFFFB8',
+            'calltipfg' : '#E0E0E0' if is_dark else '#404040',
         }
 
     elif 'wxMac' in wx.PlatformInfo:
@@ -61,9 +60,9 @@ def get_faces():
             'other'     : 'new century schoolbook',
             'size'      : 12,
             'lnsize'    : 10,
-            'backcol'   : '#FFFFFF',
-            'calltipbg' : '#FFFFB8',
-            'calltipfg' : '#404040',
+            'backcol'   : '#202020' if is_dark else '#FFFFFF',
+            'calltipbg' : '#2D2D2D' if is_dark else '#FFFFB8',
+            'calltipfg' : '#E0E0E0' if is_dark else '#404040',
         }
 
     else: # GTK1, etc.
@@ -87,8 +86,7 @@ class EditWindow(stc.StyledTextCtrl):
     def __init__(self, parent, id=-1, pos=wx.DefaultPosition,
                  size=wx.DefaultSize, style=wx.CLIP_CHILDREN | wx.SUNKEN_BORDER):
         """Create EditWindow instance."""
-        global FACES
-        FACES = get_faces()
+        self.FACES = get_faces()
         stc.StyledTextCtrl.__init__(self, parent, id, pos, size, style)
         self.__config()
         self.Bind(stc.EVT_STC_UPDATEUI, self.OnUpdateUI)
@@ -119,7 +117,7 @@ class EditWindow(stc.StyledTextCtrl):
         self.SetLexer(stc.STC_LEX_PYTHON)
         self.SetKeyWords(0, ' '.join(keyword.kwlist))
 
-        self.setStyles(FACES)
+        self.setStyles(self.FACES)
         self.SetViewWhiteSpace(False)
         self.SetTabWidth(4)
         self.SetUseTabs(False)
@@ -136,8 +134,8 @@ class EditWindow(stc.StyledTextCtrl):
         # Do we want to automatically pop up command argument help?
         self.autoCallTip = True
         self.callTipInsert = True
-        self.CallTipSetBackground(FACES['calltipbg'])
-        self.CallTipSetForeground(FACES['calltipfg'])
+        self.CallTipSetBackground(self.FACES['calltipbg'])
+        self.CallTipSetForeground(self.FACES['calltipfg'])
         self.SetWrapMode(False)
         try:
             self.SetEndAtLastLine(False)
@@ -168,7 +166,7 @@ class EditWindow(stc.StyledTextCtrl):
 
         # Built in styles
         self.StyleSetSpec(stc.STC_STYLE_LINENUMBER,
-                          "back:#C0C0C0,face:%(mono)s,size:%(lnsize)d" % FACES)
+                          "back:#C0C0C0,face:%(mono)s,size:%(lnsize)d" % faces)
         self.StyleSetSpec(stc.STC_STYLE_CONTROLCHAR,
                           "face:%(mono)s" % faces)
         self.StyleSetSpec(stc.STC_STYLE_BRACELIGHT,

--- a/wx/py/editwindow.py
+++ b/wx/py/editwindow.py
@@ -16,58 +16,68 @@ from .version import VERSION
 
 import wx
 
-if 'wxMSW' in wx.PlatformInfo:
-    is_dark = wx.SystemSettings.GetAppearance().IsDark()
+FACES = None
 
-    FACES = { 'times'     : 'Times New Roman',
-              'mono'      : 'Courier New',
-              'helv'      : 'Arial',
-              'lucida'    : 'Lucida Console',
-              'other'     : 'Comic Sans MS',
-              'size'      : 10,
-              'lnsize'    : 8,
-              # Conditional formatting for theme states
-              'backcol'   : '#202020' if is_dark else '#FFFFFF',
-              'calltipbg' : '#2D2D2D' if is_dark else '#FFFFB8',
-              'calltipfg' : '#E0E0E0' if is_dark else '#404040',
-            }
+def get_faces():
+    if 'wxMSW' in wx.PlatformInfo:
+        # Safely evaluate IsDark() inside a try-except fallback block
+        try:
+            is_dark = wx.SystemSettings.GetAppearance().IsDark()
+        except wx.PyNoAppError:
+            is_dark = False
 
-elif 'wxGTK' in wx.PlatformInfo and ('gtk2' in wx.PlatformInfo or
-                                     'gtk3' in wx.PlatformInfo):
-    FACES = { 'times'     : 'Serif',
-              'mono'      : 'Monospace',
-              'helv'      : 'Sans',
-              'other'     : 'new century schoolbook',
-              'size'      : 10,
-              'lnsize'    : 9,
-              'backcol'   : '#FFFFFF',
-              'calltipbg' : '#FFFFB8',
-              'calltipfg' : '#404040',
-            }
+        return { 
+            'times'     : 'Times New Roman',
+            'mono'      : 'Courier New',
+            'helv'      : 'Arial',
+            'lucida'    : 'Lucida Console',
+            'other'     : 'Comic Sans MS',
+            'size'      : 10,
+            'lnsize'    : 8,
+            # Conditional formatting safely evaluated at runtime
+            'backcol'   : '#202020' if is_dark else '#FFFFFF',
+            'calltipbg' : '#2D2D2D' if is_dark else '#FFFFB8',
+            'calltipfg' : '#E0E0E0' if is_dark else '#404040',
+        }
 
-elif 'wxMac' in wx.PlatformInfo:
-    FACES = { 'times'     : 'Lucida Grande',
-              'mono'      : 'Monaco',
-              'helv'      : 'Geneva',
-              'other'     : 'new century schoolbook',
-              'size'      : 12,
-              'lnsize'    : 10,
-              'backcol'   : '#FFFFFF',
-              'calltipbg' : '#FFFFB8',
-              'calltipfg' : '#404040',
-            }
+    elif 'wxGTK' in wx.PlatformInfo and ('gtk2' in wx.PlatformInfo or 'gtk3' in wx.PlatformInfo):
+        return { 
+            'times'     : 'Serif',
+            'mono'      : 'Monospace',
+            'helv'      : 'Sans',
+            'other'     : 'new century schoolbook',
+            'size'      : 10,
+            'lnsize'    : 9,
+            'backcol'   : '#FFFFFF',
+            'calltipbg' : '#FFFFB8',
+            'calltipfg' : '#404040',
+        }
 
-else: # GTK1, etc.
-    FACES = { 'times'     : 'Times',
-              'mono'      : 'Courier',
-              'helv'      : 'Helvetica',
-              'other'     : 'new century schoolbook',
-              'size'      : 12,
-              'lnsize'    : 10,
-              'backcol'   : '#FFFFFF',
-              'calltipbg' : '#FFFFB8',
-              'calltipfg' : '#404040',
-            }
+    elif 'wxMac' in wx.PlatformInfo:
+        return { 
+            'times'     : 'Lucida Grande',
+            'mono'      : 'Monaco',
+            'helv'      : 'Geneva',
+            'other'     : 'new century schoolbook',
+            'size'      : 12,
+            'lnsize'    : 10,
+            'backcol'   : '#FFFFFF',
+            'calltipbg' : '#FFFFB8',
+            'calltipfg' : '#404040',
+        }
+
+    else: # GTK1, etc.
+        return { 
+            'times'     : 'Times',
+            'mono'      : 'Courier',
+            'helv'      : 'Helvetica',
+            'other'     : 'new century schoolbook',
+            'size'      : 12,
+            'lnsize'    : 10,
+            'backcol'   : '#FFFFFF',
+            'calltipbg' : '#FFFFB8',
+            'calltipfg' : '#404040',
+        }
 
 
 class EditWindow(stc.StyledTextCtrl):
@@ -77,6 +87,8 @@ class EditWindow(stc.StyledTextCtrl):
     def __init__(self, parent, id=-1, pos=wx.DefaultPosition,
                  size=wx.DefaultSize, style=wx.CLIP_CHILDREN | wx.SUNKEN_BORDER):
         """Create EditWindow instance."""
+        global FACES
+        FACES = get_faces()
         stc.StyledTextCtrl.__init__(self, parent, id, pos, size, style)
         self.__config()
         self.Bind(stc.EVT_STC_UPDATEUI, self.OnUpdateUI)


### PR DESCRIPTION
this commit partially fixes the dark mode issues in wx.lib.inspection 
by making the editor window readable when in dark mode

<!-- Be sure to set the issue number that this PR fixes or implements below, and give
     a good description. If this PR is for a new feature or enhancement, then it's
     okay to remove the "Fixes #..." below, but be sure to give an even better
     description of the PR in that case.

     See also https://wxpython.org/pages/contributor-guide/  -->

Fixes #2917

