### PR TITLE
Restore removed wx.propgrid defines

### DIFF
--- a/etg/propgriddefs.py
+++ b/etg/propgriddefs.py
@@ -32,6 +32,15 @@ def run():
     # customizing the generated code and docstrings.
     module.find('wxPGSortCallback').ignore()
 
+    module.addPyCode(
+        code="""\
+        PG_LABEL = "@!"
+        PG_LABEL_STRING = PG_LABEL
+        PG_NULL_BITMAP = wx.NullBitmap
+        PG_COLOUR_BLACK = wx.BLACK
+        PG_DEFAULT_IMAGE_SIZE = wx.Size(-1, -1)
+        """,
+        order=15)
 
     #-----------------------------------------------------------------
     tools.doCommonTweaks(module)


### PR DESCRIPTION
Most of these were deprecated in wxWidgets 3.3, but restore them for now since people are using them.
