### PR TITLE
Handle nullptr when creating a Python argstring

### DIFF
--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -485,6 +485,7 @@ class FunctionDef(BaseDef, FixWxPrefix):
         defValueMap = { 'true':  'True',
                         'false': 'False',
                         'NULL':  'None',
+                        'nullptr': 'None',
                         'wxString()': '""',
                         'wxArrayString()' : '[]',
                         'wxArrayInt()' : '[]',


### PR DESCRIPTION
Fixes: https://github.com/wxWidgets/Phoenix/issues/2934
