### PR TITLE
Configuration Support for building universal2 binaries on newer macOS versions

### DIFF
--- a/buildtools/build_wxwidgets.py
+++ b/buildtools/build_wxwidgets.py
@@ -287,7 +287,7 @@ def main(wxDir, args):
             # find the newest SDK available on this system
             SDK = 'none found'
             for xcodePath in getXcodePaths():
-                possibles = [(major, minor) for major in [10, 11, 12] for minor in range(16)]
+                possibles = [(major, minor) for major in [10, 11, 12, 13, 14, 15, 26, 27] for minor in range(16)]
                 for major, minor in reversed(possibles):
                     sdk = os.path.join(xcodePath, "SDKs/MacOSX{}.{}.sdk".format(major, minor))
                     if os.path.exists(sdk):


### PR DESCRIPTION
"build.py --mac_arch=arm64,x86_64 build" properly sets universalCapable=True in build_wxwidgts.py when building on macs with only newer SDKs installed

Building universal2 wxPython required MacOS SDK  11 or newer, but only checked for SDKs up to version 12.  This patch expands to all modern SDKs which then enables proper universal2 builds.

Optionally, 1766336e555aef3b1af700f780b659e80543e2a3 can be reverted to re-enable default universal builds. [buildtools/build_wxwidgets.py#311](https://github.com/wxWidgets/Phoenix/blob/f2ef00cf13d5681ac1e06bfa9d8e7a54ecd6c644/buildtools/build_wxwidgets.py#L311) was defaulting to x86_64 when the building system had only SDKs newer than 12.0