### PR TITLE
Restore deprecated wx.propgrid.PG_ACTION constants

### DIFF
--- a/etg/propgrid.py
+++ b/etg/propgrid.py
@@ -108,6 +108,34 @@ def run():
         EVT_PG_COL_END_DRAG = wx.PyEventBinder( wxEVT_PG_COL_END_DRAG, 1 )
         """)
 
+    # wxPG_ACTION_XXX compat aliases are stripped by our Doxygen run (see
+    # #2941), so restore them via module __getattr__ with a DeprecationWarning.
+    module.addPyCode("""\
+        _PG_ACTION_deprecated_aliases = {
+            "PG_ACTION_INVALID"           : PGKeyboardAction.Invalid,
+            "PG_ACTION_NEXT_PROPERTY"     : PGKeyboardAction.NextProperty,
+            "PG_ACTION_PREV_PROPERTY"     : PGKeyboardAction.PrevProperty,
+            "PG_ACTION_EXPAND_PROPERTY"   : PGKeyboardAction.ExpandProperty,
+            "PG_ACTION_COLLAPSE_PROPERTY" : PGKeyboardAction.CollapseProperty,
+            "PG_ACTION_CANCEL_EDIT"       : PGKeyboardAction.CancelEdit,
+            "PG_ACTION_EDIT"              : PGKeyboardAction.Edit,
+            "PG_ACTION_PRESS_BUTTON"      : PGKeyboardAction.PressButton,
+            "PG_ACTION_MAX"               : PGKeyboardAction.PressButton + 1,
+        }
+
+        def __getattr__(name):
+            try:
+                value = _PG_ACTION_deprecated_aliases[name]
+            except KeyError:
+                raise AttributeError(
+                    "module {!r} has no attribute {!r}".format(__name__, name))
+            import warnings
+            warnings.warn(
+                "wx.propgrid.{} is deprecated, use wx.propgrid.PGKeyboardAction instead"
+                .format(name), wx.wxPyDeprecationWarning, stacklevel=2)
+            return value
+        """)
+
 
     # Switch all wxVariant types to wxPGVariant, so the propgrid-specific
     # version of the MappedType will be used for converting to/from Python

--- a/unittests/test_propgrid.py
+++ b/unittests/test_propgrid.py
@@ -1,6 +1,8 @@
 import unittest
+import pytest
 from unittests import wtc
 
+import wx
 import wx.propgrid as pg
 
 #---------------------------------------------------------------------------
@@ -47,6 +49,28 @@ class propgrid_Tests(wtc.WidgetTestCase):
         pgrid = pg.PropertyGrid(self.frame)
 
 
+    def test_propgrid04_deprecatedPGActionConstants(self):
+        # These wxPG_ACTION_XXX constants were dropped when wxWidgets moved
+        # to the PGKeyboardAction enum, see issue #2941. They should still
+        # be accessible, but raise a DeprecationWarning and return the
+        # equivalent PGKeyboardAction value.
+        expected = {
+            'PG_ACTION_INVALID'           : pg.PGKeyboardAction.Invalid,
+            'PG_ACTION_NEXT_PROPERTY'     : pg.PGKeyboardAction.NextProperty,
+            'PG_ACTION_PREV_PROPERTY'     : pg.PGKeyboardAction.PrevProperty,
+            'PG_ACTION_EXPAND_PROPERTY'   : pg.PGKeyboardAction.ExpandProperty,
+            'PG_ACTION_COLLAPSE_PROPERTY' : pg.PGKeyboardAction.CollapseProperty,
+            'PG_ACTION_CANCEL_EDIT'       : pg.PGKeyboardAction.CancelEdit,
+            'PG_ACTION_EDIT'              : pg.PGKeyboardAction.Edit,
+            'PG_ACTION_PRESS_BUTTON'      : pg.PGKeyboardAction.PressButton,
+            'PG_ACTION_MAX'               : pg.PGKeyboardAction.PressButton + 1,
+        }
+        for name, value in expected.items():
+            with pytest.warns(wx.wxPyDeprecationWarning):
+                self.assertEqual(getattr(pg, name), value)
+
+        with self.assertRaises(AttributeError):
+            pg.PG_ACTION_THIS_DOES_NOT_EXIST
 
 
 


### PR DESCRIPTION
They will now issue a DeprecationWarning.
Fixes: https://github.com/wxWidgets/Phoenix/issues/2941