### PR TITLE
Drop recursive checkout during build-wheels CI step

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -196,7 +196,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
         with:
-          submodules: 'recursive'
           filter: blob:none
           persist-credentials: false
 


### PR DESCRIPTION
This should not be needed and should be a slight performance tweak.

