### PR TITLE
Sync floating AuiNotebook caption bar when the active tab changes

### DIFF
--- a/wx/lib/agw/aui/framemanager.py
+++ b/wx/lib/agw/aui/framemanager.py
@@ -7282,6 +7282,18 @@ class AuiManager(wx.EvtHandler):
                 if notebookRoot:
                     notebookRoot.Caption(paneInfo.caption)
                     self.RefreshCaptions()
+                    if notebookRoot.IsFloating() and notebookRoot.frame:
+                        # When the notebook is floating, its visible caption bar is drawn by
+                        # the AuiFloatingFrame's own internal AuiManager, from a *copy* of this
+                        # pane's info made when the frame was created (see SetPaneWindow). That
+                        # copy is never told about caption changes, so update it directly and
+                        # refresh/re-sync that inner manager too.
+                        innerMgr = notebookRoot.frame._mgr
+                        innerPane = innerMgr.GetPane(notebook)
+                        if innerPane.IsOk():
+                            innerPane.Caption(paneInfo.caption)
+                            innerMgr.RefreshCaptions()
+                        notebookRoot.frame.SetTitle(paneInfo.caption)
 
         event.Skip()
 


### PR DESCRIPTION
## Bug

When an `AuiNotebook` (an automatic "tabbed" pane container created by docking two panes together) is floating, switching the active tab does not update the floating window's caption/title bar. It keeps showing the caption of whichever tab was active when the notebook was floated.

For a **docked** tabbed pane this works correctly: `AuiManager.OnTabSelected` updates the notebook-control pane's caption and calls `RefreshCaptions()`, which repaints the docked caption UI part.

For a **floating** notebook this has no visible effect, because on non-native-miniframe platforms (the default everywhere except Mac), the floating frame's caption bar is not drawn by the outer manager at all — it's drawn by the `AuiFloatingFrame`'s own internal `AuiManager`, from an `AuiPaneInfo` *copy* made once when the frame was created (`AuiFloatingFrame.SetPaneWindow` → `CopyAttributes`). That copy's caption is never kept in sync afterwards, so `RefreshCaptions()`/`Update()` on the outer manager touch the wrong `AuiPaneInfo` object entirely.

## Fix

In `AuiManager.OnTabSelected`, when the notebook root pane is floating, also update the caption on the floating frame's own internal manager's pane copy and refresh it, in addition to setting the frame's native title (relevant on native-miniframe platforms, e.g. Mac).

## Repro script

Save as `repro.py` and run with `python3 repro.py`:

```python
#!/usr/bin/env python3
"""
Two panes, "Pane A" and "Pane B", are docked together as tabs. Click
"Float notebook" to detach them into a floating window, then click the
"Pane B" tab: the floating window's caption should update to "Pane B"
but does not.
"""
import wx
import wx.lib.agw.aui as aui


class ReproFrame(wx.Frame):
    def __init__(self):
        super().__init__(None, title="AUI floating notebook caption repro", size=(700, 500))

        self._mgr = aui.AuiManager(self)

        panelA = wx.Panel(self)
        panelA.SetBackgroundColour(wx.Colour(220, 235, 250))
        wx.StaticText(panelA, label="Content of Pane A", pos=(10, 10))
        panelA.SetMinSize((500, 400))

        panelB = wx.Panel(self)
        panelB.SetBackgroundColour(wx.Colour(250, 230, 220))
        wx.StaticText(panelB, label="Content of Pane B", pos=(10, 10))
        panelB.SetMinSize((500, 400))

        centerPanel = wx.Panel(self)
        centerPanel.SetBackgroundColour(wx.Colour(240, 240, 240))
        wx.StaticText(centerPanel, label=(
            "1. Click 'Float notebook'.\n"
            "2. In the floating window, click the 'Pane B' tab.\n"
            "3. Check whether the floating window's TITLE BAR\n"
            "   updates from 'Pane A' to 'Pane B'."
        ), pos=(10, 10))

        floatBtn = wx.Button(centerPanel, label="Float notebook", pos=(10, 100))
        floatBtn.Bind(wx.EVT_BUTTON, self._on_float)

        self._mgr.AddPane(centerPanel, aui.AuiPaneInfo().CenterPane())

        paneA = aui.AuiPaneInfo().Caption("Pane A").Right().Layer(1).Position(0) \
            .BestSize((500, 400)).MinSize((500, 400))
        paneB = aui.AuiPaneInfo().Caption("Pane B").Right().Layer(1).Position(0) \
            .BestSize((500, 400)).MinSize((500, 400))

        self._mgr.AddPane(panelA, paneA)
        # Adding panelB with target=paneA docks it into the same automatic
        # notebook as panelA.
        self._mgr.AddPane(panelB, paneB, target=self._mgr.GetPane(panelA))

        self._panelA = panelA
        self._panelB = panelB

        self._mgr.Update()

        self.Bind(wx.EVT_CLOSE, self._on_close)

    def _on_float(self, event):
        notebooks = self._mgr.GetNotebooks()
        if not notebooks:
            print("No automatic notebook found (panes may not have tabbed).")
            return
        notebook = notebooks[0]
        notebookPane = self._mgr.GetPane(notebook)
        notebookPane.Float().FloatingPosition(self.GetScreenPosition() + (750, 50))
        notebookPane.FloatingSize((500, 400))
        self._mgr.Update()
        print("Notebook floated. Current tab caption:", notebookPane.caption)

    def _on_close(self, event):
        self._mgr.UnInit()
        event.Skip()


if __name__ == "__main__":
    app = wx.App()
    frame = ReproFrame()
    frame.Show()
    app.MainLoop()
```

## Test plan

- [x] Ran the repro script against unpatched `wx.lib.agw.aui`: confirmed the floating window's caption stays stuck on the tab that was active when it was floated.
- [x] Ran the repro script against this branch: confirmed the floating window's caption now updates correctly when switching tabs.