### PR TITLE
Implement dependency-groups in pyproject.toml

### DIFF
--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -30,11 +30,12 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
           sudo apt-get install -y gettext
-          python -m pip install --upgrade -r requirements.txt
+          python -m pip install --upgrade --group codegen
 
       - name: Generate wrapper code
         id: generate
@@ -110,10 +111,7 @@ jobs:
           python-version: '${{ matrix.python-version }}'
           architecture: '${{ matrix.architecture }}'
           cache: 'pip'
-
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade -r requirements.txt
+          cache-dependency-path: pyproject.toml
 
       - name: Install Ubuntu dependencies
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -64,11 +64,12 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
 
       - name: Install dependencies
         run: |
           sudo apt-get install -y gettext
-          python -m pip install --upgrade -r requirements.txt
+          python -m pip install --upgrade --group codegen
 
       - name: Generate wrapper code
         id: generate
@@ -214,11 +215,12 @@ jobs:
           python-version: '${{ matrix.python-version }}'
           architecture: '${{ matrix.architecture }}'
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
           allow-prereleases: true
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade -r requirements.txt
+          python -m pip install --upgrade --group test
 
       - name: Install Ubuntu dependencies
         if: runner.os == 'Linux'
@@ -328,10 +330,11 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
+          cache-dependency-path: pyproject.toml
 
       - name: Install Python dependencies
         run: |
-          python -m pip install --upgrade -r requirements.txt
+          python -m pip install --upgrade --group build --group docs
           python -m pip install --upgrade pillow numpy comtypes pywin32 cairocffi PyMuPDF
 
       - name: Setup MSVC

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,35 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[dependency-groups]
+codegen = [
+    "setuptools>=70.1",
+    "sip==6.15.1",
+    "requests>=2.26.0",
+]
+build = [
+    {include-group = "codegen"},
+    "cython>=3.0.10",
+]
+test = [
+    "setuptools>=70.1",
+    "pytest",
+    "pytest-xdist",
+    "pytest-timeout",
+    "pytest-rerunfailures",
+]
+docs = [
+    "sphinx",
+    "python-docs-theme",
+    "doc2dash",
+    "beautifulsoup4",
+]
+devel = [
+    {include-group = "build"},
+    {include-group = "test"},
+    {include-group = "docs"},
+]
+
 [tool.setuptools.packages.find]
 exclude = ["src", "buildtools*", "etgtools", "sphinxtools", "src", "unittests"]
 namespaces = false

--- a/requirements/devel.txt
+++ b/requirements/devel.txt
@@ -1,4 +1,8 @@
 # Python packages needed for building and testing wxPython Phoenix
+#
+# Legacy: GitHub Actions CI now installs from pyproject.toml's
+# [dependency-groups] instead. Keep this file's codegen/build/test/docs
+# packages in sync with those groups.
 -r install.txt
 appdirs
 setuptools


### PR DESCRIPTION
This will allow installing reduced dependencies for individual build steps and is more modern than requirements.txt.
