### PR TITLE
Generate placeholder names for unnamed C++ parameters

### DIFF
--- a/etgtools/extractors.py
+++ b/etgtools/extractors.py
@@ -316,8 +316,13 @@ class FunctionDef(BaseDef, FixWxPrefix):
         self.definition = element.find('definition').text
         self.argsString = element.find('argsstring').text
         self.checkDeprecated()
-        for node in element.findall('param'):
+        for idx, node in enumerate(element.findall('param')):
             p = ParamDef(node)
+            if not p.name and p.type != '...':
+                # wxWidgets gave no name for this param; make one up so the
+                # generated Python signature is syntactically valid.
+                p.name = '_param_%d' % idx
+                p.isNameFake = True
             self.items.append(p)
             # TODO: Look at self.detailedDoc and pull out any matching
             # parameter description items and assign that value as the
@@ -533,7 +538,7 @@ class FunctionDef(BaseDef, FixWxPrefix):
                         default = param.default
                         default = defValueMap.get(default, default)
                         default = '|'.join([self.cleanName(x, True) for x in default.split('|')])
-                    params.append(P(s, param_type, default))
+                    params.append(P(s, param_type, default, is_fake=param.isNameFake))
                     if default == 'None':
                         params[-1].make_optional()
         if getattr(self, 'isCtor', False):
@@ -655,6 +660,7 @@ class ParamDef(BaseDef):
         self.transferThis = False     # ownership of 'this' pointer transferred to this arg
         self.keepReference = False    # an extra reference to the arg is held
         self.constrained = False      # limit auto-conversion of similar types (like float -> int)
+        self.isNameFake = False       # name was made up because wxWidgets didn't provide one
         self.__dict__.update(kw)
         if element is not None:
             self.extract(element)

--- a/etgtools/sphinx_generator.py
+++ b/etgtools/sphinx_generator.py
@@ -604,6 +604,9 @@ class ParameterList(Node):
                   'This may be a documentation bug in wxWidgets or a side-effect of removing the `wx` prefix from signatures.\n\n'
 
         for arg in arguments:
+            if arg.is_fake:
+                # Made-up name; nothing in the docs XML to match it against.
+                continue
             arg_name = arg.name
             if arg.position_type in (ParameterType.VAR_ARGS, ParameterType.KWARGS):
                 continue

--- a/etgtools/tweaker_tools.py
+++ b/etgtools/tweaker_tools.py
@@ -66,13 +66,14 @@ class Signature:
     """
 
     class Parameter:
-        __slots__ = ('name', 'type_hint', 'default', 'position_type', )
+        __slots__ = ('name', 'type_hint', 'default', 'position_type', 'is_fake', )
         name: str
         type_hint: Optional[str]
         default: Optional[str]
         position_type: ParameterType
+        is_fake: bool
 
-        def __init__(self, name: str, type_hint: Optional[str] = None, default: Optional[str] = None, position_type: ParameterType = ParameterType.DEFAULT) -> None:
+        def __init__(self, name: str, type_hint: Optional[str] = None, default: Optional[str] = None, position_type: ParameterType = ParameterType.DEFAULT, is_fake: bool = False) -> None:
             if name.startswith('**'):
                 name = name[2:]
                 position_type = ParameterType.KWARGS
@@ -85,6 +86,7 @@ class Signature:
             self.type_hint = type_hint
             self.default = default
             self.position_type = position_type
+            self.is_fake = is_fake
 
         @property
         def _position_marking(self) -> str:


### PR DESCRIPTION
wxWidgets sometimes omits parameter names in its Doxygen interface headers (e.g. wxAuiTabArt::GetBestTabCtrlSize), which produced invalid Python in generated .pyi stubs and docstrings, such as def SetCornerLabelValue(self, : str) -> None:

Make up a name (param0, param1, ...) for any such parameter so the generated signature is valid Python, and flag it as fake so the sphinx doc generator's signature/docs mismatch check skips it, since there's nothing in the wxWidgets docs to match a made-up name against.

Fixes: https://github.com/wxWidgets/Phoenix/issues/2801
