### PR TITLE
Rewrite test_pi_import.py to validate generated .pyi stub syntax

### DIFF
--- a/unittests/test_pi_import.py
+++ b/unittests/test_pi_import.py
@@ -1,95 +1,45 @@
 import unittest
-import sys, os, subprocess
+import ast
+import os
 import wx
 
 #---------------------------------------------------------------------------
 
-# TODO: We have a bunch of chicken/egg problems in the generated .pyi files, but
-# ensuring the stubs are executable Python seems to be less important than it
-# used to be so we'll just skip these for now.
+PI_MODULES = [
+    'adv', 'aui', 'core', 'dataview', 'glcanvas', 'grid', 'html', 'html2',
+    'media', 'propgrid', 'ribbon', 'richtext', 'stc', 'xml', 'xrc',
+]
 
-@unittest.skip("Skipping .pyi tests for now...")
+if 'wxMSW' in wx.PlatformInfo:
+    PI_MODULES.append('msw')
+
+
 class PIImportTest(unittest.TestCase):
     """
     The *.pyi files generated are used with some IDE's to create things like
-    autocomplete lists and call tips. They are essentially just Python code
-    with stubs for all the classes and other things that are in the extension
-    modules and that are not easily introspected.
-
-    This test case ensures that the code in the pi files is valid by trying
-    to run the file with a new instance of Python.
+    autocomplete lists and call tips. They are PEP 484 stub files: code meant
+    to be read by static analysis tools such as mypy or pyright, not to be
+    executed. Stub syntax intentionally allows things that aren't valid at
+    runtime (e.g. a class referring to itself in a default argument value),
+    so this test just checks that each expected .pyi file was generated and
+    is parseable as Python, which is all that's required for it to be usable
+    by IDEs and type checkers.
     """
 
-    def runPI(self, filename):
-        cwd = os.getcwd()
-        dirname = os.path.dirname(wx.__file__)
-        os.chdir(dirname)
+    def test_pi_files(self):
+        wx_dir = os.path.dirname(wx.__file__)
 
-        sp = subprocess.Popen('%s %s' % (sys.executable, filename),
-                              shell=True,
-                              stdout=subprocess.PIPE,
-                              stderr=subprocess.STDOUT)
-        stdout, stderr = sp.communicate()
-        os.chdir(cwd)
-
-        # stdout will likely contain a traceback or some other indication of
-        # the failure, so use it as the assert message for the unittest.
-        self.assertEqual(sp.returncode, 0, stdout)
-
-
-    def test_core_pi(self):
-        self.runPI('core.pyi')
-
-    def test_adv_pi(self):
-        self.runPI('adv.pyi')
-
-    def test_stc_pi(self):
-        self.runPI('stc.pyi')
-
-    def test_html_pi(self):
-        self.runPI('html.pyi')
-
-    def test_html2_pi(self):
-        self.runPI('html2.pyi')
-
-    def test_dataview_pi(self):
-        self.runPI('dataview.pyi')
-
-    def test_xml_pi(self):
-        self.runPI('xml.pyi')
-
-    def test_xrc_pi(self):
-        self.runPI('xrc.pyi')
-
-    def test_richtext_pi(self):
-        self.runPI('richtext.pyi')
-
-    def test_glcanvas_pi(self):
-        self.runPI('glcanvas.pyi')
-
-    def test_grid_pi(self):
-        self.runPI('grid.pyi')
-
-    def test_media_pi(self):
-        self.runPI('media.pyi')
-
-    def test_propgrid_pi(self):
-        self.runPI('propgrid.pyi')
-
-    def test_ribbon_pi(self):
-        self.runPI('ribbon.pyi')
-
-
-    @unittest.skipIf('wxMSW' not in wx.PlatformInfo,
-                     'wx.msw only relevant on Windows')
-    def test_msw_pi(self):
-        self.runPI('msw.pyi')
-
-
-    @unittest.skipIf('wxOSX' not in wx.PlatformInfo,
-                     'wx.webkit only relevant on Macs')
-    def test_webkit_pi(self):
-        self.runPI('webkit.pyi')
+        for modname in PI_MODULES:
+            filename = os.path.join(wx_dir, modname + '.pyi')
+            with self.subTest(filename=modname + '.pyi'):
+                self.assertTrue(os.path.isfile(filename),
+                                 '%s was not generated' % filename)
+                with open(filename, encoding='utf-8') as f:
+                    source = f.read()
+                try:
+                    ast.parse(source, filename=filename)
+                except SyntaxError as e:
+                    self.fail('%s: %s' % (filename, e))
 
 
 #---------------------------------------------------------------------------
@@ -97,4 +47,3 @@ class PIImportTest(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
-


### PR DESCRIPTION
The previous test tried to execute each .pyi file as a real Python script via subprocess, but .pyi files are PEP 484 stub files meant to be statically read by tools like mypy/pyright, not executed -- stub syntax allows things (e.g. a class referencing itself in a default argument value) that are valid for a type checker but not at runtime. That made the test fundamentally unable to pass, so it had been disabled.

Replace it with a test that parses each expected .pyi file with ast.parse() to catch invalid syntax (the actual bug from #2932), checking against an explicit list of modules so a module that fails to generate its stub at all also fails the test instead of being silently skipped.

Fixes: https://github.com/wxWidgets/Phoenix/issues/2932

