### PR TITLE
Use build module instead of pip to build wheels

### DIFF
--- a/.github/workflows/build-linux-wheels.yml
+++ b/.github/workflows/build-linux-wheels.yml
@@ -121,8 +121,12 @@ jobs:
         env:
           WXPYTHON_BUILD_ARGS: ${{ steps.init.outputs.build_opts }}
         run: |
+          mkdir dist/wxpython-src
+          tar xzf dist/wxpython-${{ env.VERSION }}.tar.gz -C dist/wxpython-src --strip-components=1
+
+          pip install build
           cd dist
-          pip wheel -v wxpython-${{ env.VERSION }}.tar.gz
+          python -m build --wheel --verbose --outdir . ./wxpython-src
 
       - name: Tag wheel filename with OS to avoid collisions across the OS matrix
         run: |

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -262,12 +262,13 @@ jobs:
           mkdir dist/wxpython-src
           tar xzf dist/wxpython-${{ env.VERSION }}.tar.gz -C dist/wxpython-src --strip-components=1
 
+          cd dist
           if [ -z "$CIBW_BUILD" ]; then
-              cd dist
-              pip wheel -v ./wxpython-src
+              pip install build
+              python -m build --wheel --verbose --outdir . ./wxpython-src
           else
               pip install cibuildwheel
-              cibuildwheel dist/wxpython-src --output-dir dist
+              cibuildwheel ./wxpython-src --output-dir .
           fi
 
       - name: Tag Linux wheel filename with OS to avoid collisions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ requires = [
     "setuptools>=70.1",
     "cython >= 3.0.10",
     "requests >= 2.26.0",
-    "sip == 6.12.0",
+    "sip == 6.15.1",
     "typing-extensions; python_version < '3.11'",
 ]
 build-backend = "setuptools.build_meta"
@@ -113,7 +113,7 @@ exclude = ["src", "buildtools*", "etgtools", "sphinxtools", "src", "unittests"]
 namespaces = false
 
 [tool.cibuildwheel]
-build-frontend = "pip"
+build-frontend = "build"
 build-verbosity = 1
 enable = ["cpython-prerelease"]
 


### PR DESCRIPTION
This seems to be the more modern/preferred approach.  Note that it has to be done carefully to avoid our build.py.
