### PR TITLE
Handle deduplicated property-grid callback typedef

### DIFF
--- a/etg/propgriddefs.py
+++ b/etg/propgriddefs.py
@@ -30,7 +30,10 @@ def run():
     #-----------------------------------------------------------------
     # Tweak the parsed meta objects in the module object as needed for
     # customizing the generated code and docstrings.
-    module.find('wxPGSortCallback').ignore()
+    # Newer Doxygen versions only emit this duplicate typedef in propgrid.h.
+    callback = module.findItem('wxPGSortCallback')
+    if callback is not None:
+        callback.ignore()
 
     module.addPyCode(
         code="""\


### PR DESCRIPTION
Doxygen 1.18 emits `wxPGSortCallback` in `interface_2wx_2propgrid_2propgrid_8h.xml` but omits the duplicate from `propgriddefs_8h.xml`. The unconditional lookup in `etg/propgriddefs.py` then raises `ExtractorError` and stops binding generation.

Ignore the typedef when present, allowing the definitions module to omit it. `etg/propgrid.py` continues to ignore the actual callback declaration and its unsupported accessors.

Verified the generator against Doxygen 1.18 XML and a copy with the duplicate typedef restored; both layouts pass. This fixes the failure reproduced by Homebrew/homebrew-core#303131 on Linux and macOS.
