### PR TITLE
Declare the minimum SIP ABI for generated bindings

### DIFF
--- a/build.py
+++ b/build.py
@@ -1427,7 +1427,7 @@ def _buildSipModule(cfg, options, src_name):
     # Write out a pyproject.toml to configure sip
     pyproject_toml = textwrap.dedent("""\
         [build-system]
-        requires = ["sip >=6.6.2, <7"]
+        requires = ["sip >=6.10, <7"]
         build-backend = "sipbuild.api"
 
         [project]

--- a/etgtools/sip_generator.py
+++ b/etgtools/sip_generator.py
@@ -82,6 +82,9 @@ class SipWrapperGenerator(generators.WrapperGeneratorBase):
 
 """ % (module.package, module.name))
 
+            if module.name == "_core":
+                stream.write('%MinimumABIVersion "{}"\n\n'.format(cfg.SIP_ABI))
+
             if module.name.startswith('_'):
                 doc = ''
                 if module.docstring:


### PR DESCRIPTION
Emit `%MinimumABIVersion` only in `_core`, which the other modules import, using the existing `Config.SIP_ABI` value, and require SIP 6.10 or newer in the generated build configuration because that version introduced the directive. The development requirements already pin SIP 6.15.1.

This avoids the SIP 6.16.1 failure `ABI v12 is being targeted but the wx._core module doesn't support it` and the deprecation warning for omitting the directive. The bundled ABI remains 12.14.

Verified SIP generation for all modules with SIP 6.16.1 while investigating Homebrew/homebrew-core#303131. Related SIP regression: Python-SIP/sip#114.
